### PR TITLE
create headers for cross site request

### DIFF
--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Server.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Server.scala
@@ -48,7 +48,7 @@ object Complete {
       msp =>
         val verification = verify(msp.pact, msp.interactions)
         val result = PactGeneration(msp.pact, verification) match {
-          case PactVerified => pactWritten(Response(200, None, None), msp.config.port)
+          case PactVerified => pactWritten(Response(200, crossSiteHeaders, None), msp.config.port)
           case error => pactWritten(Response(400, Map[String, String](), toJson(error)), msp.config.port)
         }
         msp.stop
@@ -66,7 +66,7 @@ object Create {
     val server = stopped.start
     val entry = config.port -> server
     val body: JValue = "port" -> config.port
-    Result(Response(201, noHeaders, body), oldState + entry)
+    Result(Response(201, crossSiteHeaders, body), oldState + entry)
   }
 
   def apply(request: Request, oldState: ServerState): Result = {

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
@@ -6,4 +6,6 @@ package object server {
   type ServerState = Map[Int, StartedMockServiceProvider]
 
   val noHeaders = Map[String, String]()
+
+  val crossSiteHeaders = Map[String, String]("Access-Control-Allow-Origin" -> "*")
 }


### PR DESCRIPTION
Hi, Travis, this is Jinwen, we are writing javascript pact test now, and when we try to use jquery to send POST request http://localhost:29999/create?state=blah to create mock server, the client side couldn't receive the response. (the body is picked from test example which is good)
The strange thing is when I use postman(chrome) to send the POST request, we can receive the response, and we check to find that no head set in response.So we assumed that is caused by cross site issue.

You can give it a go and reproduce this issue at your localhost to see if this pull request will fix this issue.
