### PR TITLE
#14: Allow response supporting crossing site requests. Peng & Jinwen

### DIFF
--- a/pact-jvm-consumer/src/test/scala/au/com/dius/pact/consumer/Fixtures.scala
+++ b/pact-jvm-consumer/src/test/scala/au/com/dius/pact/consumer/Fixtures.scala
@@ -20,7 +20,7 @@ object Fixtures {
     "test" -> true)
 
   val response = Response(200,
-    Map("testreqheader" -> "testreqheaderval"),
+    Map("testreqheader" -> "testreqheaderval", "Access-Control-Allow-Origin" -> "*"),
     "responsetest" -> true)
 
   val interaction = Interaction(

--- a/pact-jvm-consumer/src/test/scala/au/com/dius/pact/consumer/MockServiceProviderSpec.scala
+++ b/pact-jvm-consumer/src/test/scala/au/com/dius/pact/consumer/MockServiceProviderSpec.scala
@@ -71,7 +71,8 @@ class MockServiceProviderSpec extends Specification {
         actual.response.copy(body = None) must beEqualTo(response.copy(body = None))
       }
       
-      compare(interactions.head, invalidRequest, Response(500, None, Some(JObject(JField("error", JString("unexpected request"))))))
+      compare(interactions.head, invalidRequest, Response(500, Map("Access-Control-Allow-Origin" -> "*"),
+        Some(JObject(JField("error", JString("unexpected request"))))))
       compare(interactions.tail.head, validRequest, response)
     }
   }

--- a/pact-jvm-model/src/main/scala/au/com/dius/pact/model/Pact.scala
+++ b/pact-jvm-model/src/main/scala/au/com/dius/pact/model/Pact.scala
@@ -145,6 +145,9 @@ case class Response(status: Int,
 }
 
 object Response extends Optionals {
+
+  val CrossSiteHeaders = Map[String, String]("Access-Control-Allow-Origin" -> "*")
+
   def apply(status: Int, headers: Map[String, String], body: String): Response = {
     Response(status, optional(headers), optional(body))
   }
@@ -158,7 +161,7 @@ object Response extends Optionals {
   }
 
   def invalidRequest(request: Request, pact: Pact) = {
-    Response(500, Map[String, String](), "error"-> s"unexpected request : $request \nnot in : $pact")
+    Response(500, CrossSiteHeaders, "error"-> s"unexpected request : $request \nnot in : $pact")
   }
 }
 

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Server.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Server.scala
@@ -48,7 +48,7 @@ object Complete {
       msp =>
         val verification = verify(msp.pact, msp.interactions)
         val result = PactGeneration(msp.pact, verification) match {
-          case PactVerified => pactWritten(Response(200, crossSiteHeaders, None), msp.config.port)
+          case PactVerified => pactWritten(Response(200, Response.CrossSiteHeaders, None), msp.config.port)
           case error => pactWritten(Response(400, Map[String, String](), toJson(error)), msp.config.port)
         }
         msp.stop
@@ -66,7 +66,7 @@ object Create {
     val server = stopped.start
     val entry = config.port -> server
     val body: JValue = "port" -> config.port
-    Result(Response(201, crossSiteHeaders, body), oldState + entry)
+    Result(Response(201, Response.CrossSiteHeaders, body), oldState + entry)
   }
 
   def apply(request: Request, oldState: ServerState): Result = {
@@ -82,7 +82,7 @@ object Create {
 
     (maybeState, maybeJsonPact) match {
       case (Some(state), Some(body)) => create(state, body, oldState)
-      case _ => Result(Response(400, noHeaders, errorJson), oldState)
+      case _ => Result(Response(400, Response.CrossSiteHeaders, errorJson), oldState)
     }
   }
 }

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
@@ -4,8 +4,4 @@ import au.com.dius.pact.consumer.MockServiceProvider.StartedMockServiceProvider
 
 package object server {
   type ServerState = Map[Int, StartedMockServiceProvider]
-
-  val noHeaders = Map[String, String]()
-
-  val crossSiteHeaders = Map[String, String]("Access-Control-Allow-Origin" -> "*")
 }


### PR DESCRIPTION
Now all response have  `"Access-Control-Allow-Origin" -> "*"` to support cross domain request
