### PR TITLE
Made the Java Interaction DSL public

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/ConsumerInteractionJavaDsl.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/ConsumerInteractionJavaDsl.java
@@ -8,19 +8,19 @@ import java.util.Map;
 public class ConsumerInteractionJavaDsl {
     public static PactVerification.VerificationResult pactVerified = PactVerification.PactVerified$.MODULE$;
 
-
-
-    static ConsumerInteractionJavaDsl given(String providerState) {
-        return new ConsumerInteractionJavaDsl(providerState);
-    }
-
     private String providerState;
+    private String description;
+    private Request request;
+    private Response response;
+
     ConsumerInteractionJavaDsl(String providerState) {
         this.providerState = providerState;
     }
 
-    private String description;
-    private Request request;
+    public static ConsumerInteractionJavaDsl given(String providerState) {
+        return new ConsumerInteractionJavaDsl(providerState);
+    }
+
     public ConsumerInteractionJavaDsl uponReceiving(
         String description,
         String path,
@@ -33,7 +33,6 @@ public class ConsumerInteractionJavaDsl {
         return this;
     }
 
-    private Response response;
     public ConsumerInteractionJavaDsl willRespondWith(
         int status,
         Map<String, String> headers,


### PR DESCRIPTION
The Java DSL was inaccessible, the entry point being package private.   At risk of outstaying my welcome, I also rearranged the members in the class to be grouped together a little more logically.
