### PR TITLE
Making the stateChangeUrl optional in the provider config

### DIFF
--- a/pact-jvm-provider/src/main/scala/au/com/dius/pact/provider/PactConfiguration.scala
+++ b/pact-jvm-provider/src/main/scala/au/com/dius/pact/provider/PactConfiguration.scala
@@ -6,4 +6,4 @@ case class Address(protocol: String, host: String, port: Int = 80, path: String 
 
 case class PactConfiguration(
   providerRoot: Address,
-  stateChangeUrl: Address)
+  stateChangeUrl: Option[Address])

--- a/pact-jvm-provider/src/main/scala/au/com/dius/pact/provider/PactSpec.scala
+++ b/pact-jvm-provider/src/main/scala/au/com/dius/pact/provider/PactSpec.scala
@@ -9,6 +9,7 @@ import org.jboss.netty.handler.codec.http._
 import java.nio.charset.Charset
 import com.twitter.finagle.Http
 import com.twitter.util.Await
+import com.twitter.util.Future
 
 
 class PactSpec(config: PactConfiguration, pact: Pact) extends FreeSpec with Assertions {
@@ -18,34 +19,35 @@ class PactSpec(config: PactConfiguration, pact: Pact) extends FreeSpec with Asse
       response
     } catch {
       case NonFatal(e) => throw new RuntimeException(
-s"""Unable to convert response:
-  status: ${response.getStatus.getCode}
-  headers: ${response.headers}
-  body: ${response.getContent.toString(Charset.forName("UTF-8"))}
-for request:
-  $request""")
+        s"""Unable to convert response:
+           |   status: ${response.getStatus.getCode}
+           |   headers: ${response.headers}
+           |   body: ${response.getContent.toString(Charset.forName("UTF-8"))}
+           |for request:
+           |   $request""".stripMargin)
     }
   }
 
   pact.interactions.toList.map { interaction =>
-    s"""pact for consumer ${pact.consumer.name} """ +
-      s"""provider ${pact.provider.name} """ +
-      s"""interaction "${interaction.description}" """ +
-      s"""in state: "${interaction.providerState}" """ in {
+    s"""pact for consumer ${pact.consumer.name} 
+       |provider ${pact.provider.name} 
+       |interaction "${interaction.description}"
+       |in state: "${interaction.providerState}" """.stripMargin in {
 
         val http = Http.newService(s"${config.providerRoot.host}:${config.providerRoot.port}")
 
-        val stateResponse = http(EnterStateRequest(config.stateChangeUrl.url, interaction.providerState))
-
-        val httpResponse = stateResponse.flatMap { _ =>
-          http(ServiceInvokeRequest(config.providerRoot.url, interaction.request))
+        
+        val changeFuture = config.stateChangeUrl match {
+          case Some(stateChangeUrl) => http(EnterStateRequest(stateChangeUrl.url, interaction.providerState))
+          case None => Future()
         }
+        
+        val pactResponseFuture = for {
+          _ <- changeFuture
+          httpResponse <- http(ServiceInvokeRequest(config.providerRoot.url, interaction.request))
+        } yield convert(interaction.request, httpResponse)
 
-        val pactResponse = httpResponse.map { it =>
-          convert(interaction.request, it)
-        }
-
-        val actualResponse = Await.result(pactResponse)
+        val actualResponse = Await.result(pactResponseFuture)
 
         assert(ResponseMatching.matchRules(interaction.response, actualResponse) === MatchFound)
       }

--- a/pact-jvm-provider/src/test/scala/au/com/dius/pact/provider/TestService.scala
+++ b/pact-jvm-provider/src/test/scala/au/com/dius/pact/provider/TestService.scala
@@ -7,11 +7,12 @@ import org.jboss.netty.handler.codec.http.{HttpRequest, HttpResponse}
 import com.twitter.util.Future
 import au.com.dius.pact.model.{Request, Response}
 import org.json4s.JsonAST.{JObject, JField, JString}
+import com.twitter.finagle.ListeningServer
 
 object TestService {
   var state: String = ""
 
-  def apply(port:Int) = {
+  def apply(port:Int): ListeningServer = {
     Http.serve(s":$port", service(port))
   }
 


### PR DESCRIPTION
The provider shouldn't be compelled to support the stateChange interface; the two services may have a less formal agreement based on some fixed dataset.

PactConfiguration.stateChangeUrl becomes an Option[Address], and the Spec support has been modified accordingly, in a more monadic style.
