### PR TITLE
Adds support for generating consumers from pact file location

### DIFF
--- a/pact-jvm-provider-gradle/README.md
+++ b/pact-jvm-provider-gradle/README.md
@@ -55,9 +55,18 @@ pact {
             // Again, you can define as many consumers for each provider as you need, but each must have a unique name
             hasPactWith('consumer1') {
 
-                // currenty supports a file path using file() or a URL using url()
+                // currently supports a file path using file() or a URL using url()
                 pactFile = file('path/to/provider1-consumer1-pact.json')
 
+            }
+            
+            // Or if you have many pact files in a directory
+            hasPactsWith('manyConsumers') {
+
+                // Will define a consumer for each pact file in the directory. 
+                // Consumer name is read from contents of pact file 
+                pactFileLocation = file('path/to/pacts')
+                               
             }
 
         }
@@ -164,6 +173,13 @@ pact {
 
             hasPactWith('consumer1') {
                 pactFile = file('path/to/provider1-consumer1-pact.json')
+                stateChange = url('http://localhost:8001/tasks/pactStateChange')
+                stateChangeUsesBody = false // defaults to true
+            }
+            
+            // or
+            hasPactsWith('consumers') {
+                pactFileLocation = file('path/to/pacts')                
                 stateChange = url('http://localhost:8001/tasks/pactStateChange')
                 stateChangeUsesBody = false // defaults to true
             }

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/ConsumersGroup.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/ConsumersGroup.groovy
@@ -1,0 +1,16 @@
+package au.com.dius.pact.provider.gradle
+
+import groovy.transform.ToString
+
+@ToString
+class ConsumersGroup {
+    def name
+    File pactFileLocation
+    def stateChange
+    boolean stateChangeUsesBody = false
+
+    def url(String path) {
+        stateChange = new URL(path)
+    }
+
+}

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -7,15 +7,14 @@ class PactPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.extensions.create('pact', PactPluginExtension)
 
-        def providers = project.container(ProviderInfo)
-        project.pact.extensions.serviceProviders = providers
+        // Create and install the extension object
+        project.extensions.create("pact", PactPluginExtension, project.container(ProviderInfo))
 
         project.task('pactVerify', description: 'Verify your pacts against your providers')
 
         project.afterEvaluate {
-            providers.all { ProviderInfo provider ->
+            project.pact.serviceProviders.all { ProviderInfo provider ->
                 def providerTask = project.task("pactVerify_${provider.name}",
                     description: "Verify the pacts against ${provider.name}", type: PactVerificationTask) {
                     providerToVerify = provider
@@ -33,5 +32,4 @@ class PactPlugin implements Plugin<Project> {
             }
         }
     }
-
 }

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPluginExtension.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPluginExtension.groovy
@@ -1,5 +1,16 @@
 package au.com.dius.pact.provider.gradle
 
+import org.gradle.api.NamedDomainObjectContainer
+
 class PactPluginExtension {
 
+    final NamedDomainObjectContainer<ProviderInfo> serviceProviders
+
+    public PactPluginExtension(serviceProviders) {
+        this.serviceProviders = serviceProviders
+    }
+
+    def serviceProviders(Closure closure) {
+        serviceProviders.configure(closure)
+    }
 }

--- a/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginTest.groovy
+++ b/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginTest.groovy
@@ -24,13 +24,15 @@ class PactPluginTest {
 
     @Test
     public void 'defines a task for each defined provider'() {
-        project.extensions.pact.serviceProviders {
-            provider1 {
+        project.pact {
+            serviceProviders {
+                provider1 {
 
-            }
+                }
 
-            provider2 {
+                provider2 {
 
+                }
             }
         }
 
@@ -40,4 +42,26 @@ class PactPluginTest {
         assert project.tasks.pactVerify_provider2
     }
 
+    @Test
+    public void 'defines a task for each file in the pact file directory'() {
+        def resource = getClass().classLoader.getResource('pacts/foo_pact.json')
+        File pactFileDirectory = new File(resource.file).parentFile
+        project.pact {
+            serviceProviders {
+                provider1 {
+                    hasPactsWith("many consumers") {
+                        pactFileLocation = project.file("${pactFileDirectory.absolutePath}")
+                        stateChange = "http://localhost:8080/state"
+                    }
+                }
+            }
+        }
+        project.evaluate()
+
+
+        def consumers = project.tasks.pactVerify_provider1.providerToVerify.consumers
+        assert consumers.size() == 2
+        assert consumers.find { it.name == 'Foo Consumer'}
+        assert consumers.find { it.name == 'Bar Consumer'}
+    }
 }

--- a/pact-jvm-provider-gradle/src/test/resources/pacts/bar_pact.json
+++ b/pact-jvm-provider-gradle/src/test/resources/pacts/bar_pact.json
@@ -1,0 +1,9 @@
+{
+    "provider" : {
+        "name" : "Provider"
+    },
+    "consumer" : {
+        "name" : "Bar Consumer"
+    },
+    "interactions" : []
+}

--- a/pact-jvm-provider-gradle/src/test/resources/pacts/foo_pact.json
+++ b/pact-jvm-provider-gradle/src/test/resources/pacts/foo_pact.json
@@ -1,0 +1,9 @@
+{
+    "provider" : {
+        "name" : "Provider"
+    },
+    "consumer" : {
+        "name" : "Foo Consumer"
+    },
+    "interactions" : []
+}


### PR DESCRIPTION
  Adds new hasPactsWith dsl, which allow specifying a
  pact file location. A consumer will be created for each pact
  file in this location.
