### PR TITLE
Changed ConsumerPactTest to not swallow exceptions

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/ConsumerPactTest.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/ConsumerPactTest.java
@@ -24,11 +24,7 @@ public abstract class ConsumerPactTest {
 
         VerificationResult result = fragment.runConsumer(config, new TestRun() {
             public void run(MockProviderConfig config) {
-                try {
-                    runTest(config.url());
-                } catch(Exception e) {
-                    fail("error thrown: "+e);
-                }
+                runTest(config.url());
             }
         });
 


### PR DESCRIPTION
Hi,

I have a pact-consumer-test that fails on rare occasions. I've been unable to figure out what goes wrong because ConsumerPactTest swallows the exception. I see no reason for this catch, but I could be wrong.

Current stacktrace:
```
java.lang.RuntimeException: java.lang.AssertionError: error thrown: java.util.NoSuchElementException: No value present
	at au.com.dius.pact.consumer.ConsumerPactTest.testPact(ConsumerPactTest.java:36)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:370)
	at org.apache.maven.surefire.junitcore.pc.InvokerStrategy.schedule(InvokerStrategy.java:47)
	at org.apache.maven.surefire.junitcore.pc.Scheduler.schedule(Scheduler.java:329)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:370)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.AssertionError: error thrown: java.util.NoSuchElementException: No value present
	at org.junit.Assert.fail(Assert.java:88)
	at au.com.dius.pact.consumer.ConsumerPactTest$1.run(ConsumerPactTest.java:30)
	at au.com.dius.pact.model.PactFragment$$anonfun$runConsumer$1.apply$mcV$sp(PactFragment.scala:21)
	at au.com.dius.pact.model.PactFragment$$anonfun$runConsumer$1.apply(PactFragment.scala:21)
	at au.com.dius.pact.model.PactFragment$$anonfun$runConsumer$1.apply(PactFragment.scala:21)
	at au.com.dius.pact.consumer.StatefulMockProvider$$anonfun$runAndClose$1.apply(MockProvider.scala:44)
	at au.com.dius.pact.consumer.StatefulMockProvider$$anonfun$runAndClose$1.apply(MockProvider.scala:42)
	at scala.util.Try$.apply(Try.scala:191)
	at au.com.dius.pact.consumer.StatefulMockProvider.runAndClose(MockProvider.scala:42)
	at au.com.dius.pact.consumer.ConsumerPactRunner.runAndWritePact(ConsumerPactRunner.scala:28)
	at au.com.dius.pact.model.PactFragment.duringConsumerSpec(PactFragment.scala:13)
	at au.com.dius.pact.model.PactFragment.runConsumer(PactFragment.scala:21)
	at au.com.dius.pact.consumer.ConsumerPactTest.testPact(ConsumerPactTest.java:25)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:370)
	at org.apache.maven.surefire.junitcore.pc.InvokerStrategy.schedule(InvokerStrategy.java:47)
	at org.apache.maven.surefire.junitcore.pc.Scheduler.schedule(Scheduler.java:329)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:370)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```