### PR TITLE
Fixing the problem of evaluating mime type even if no body is specified....

### DIFF
--- a/pact-jvm-matchers/src/main/scala/au/com/dius/pact/model/Matching.scala
+++ b/pact-jvm-matchers/src/main/scala/au/com/dius/pact/model/Matching.scala
@@ -99,14 +99,14 @@ object Matching {
         result.get._2.matchBody(expected, actual, diffConfig)
       } else {
         (expected.body, actual.body) match {
-          case (None, None) => List()
-          case (None, b) => List()
+          case (None, _) => List()
           case (a, None) => List(BodyMismatch(a, None))
           case (a, b) => if (a == b) List() else List(BodyMismatch(a, b))
         }
       }
     } else {
-      List(BodyTypeMismatch(expected.mimeType, actual.mimeType))
+      if (expected.body == None) List()
+      else List(BodyTypeMismatch(expected.mimeType, actual.mimeType))
     }
   }
 

--- a/pact-jvm-matchers/src/test/scala/au/com/dius/pact/model/MatchingSpec.scala
+++ b/pact-jvm-matchers/src/test/scala/au/com/dius/pact/model/MatchingSpec.scala
@@ -31,7 +31,7 @@ class MatchingSpec extends Specification {
 
       "Handle different mime types" in {
         val expected = List(BodyTypeMismatch("a", "b"))
-        matchBody(Request("", "", None, Some(Map("Content-Type" -> "a")), None, None),
+        matchBody(Request("", "", None, Some(Map("Content-Type" -> "a")), request.body, None),
           Request("", "", None, Some(Map("Content-Type" -> "b")), request.body, None), config) must beEqualTo(expected)
       }
 

--- a/pact-specification-test/src/main/resources/request/body/no body no content type.json
+++ b/pact-specification-test/src/main/resources/request/body/no body no content type.json
@@ -1,0 +1,20 @@
+{
+  "match": true,
+  "comment": "No body, no content-type",
+  "expected" : {
+    "method": "POST",
+    "path": "/",
+    "query": ""
+  },
+  "actual": {
+    "method": "POST",
+    "path": "/",
+    "query": "",
+    "headers": {"Content-Type": "application/json"},
+    "body": {
+      "alligator": {
+        "age": 3
+      }
+    }
+  }
+}

--- a/pact-specification-test/src/main/resources/response/body/no body no content type.json
+++ b/pact-specification-test/src/main/resources/response/body/no body no content type.json
@@ -1,0 +1,16 @@
+{
+  "match": true,
+  "comment": "No body, no content-type",
+  "expected" : {
+  },
+  "actual": {
+    "headers": {"Content-Type": "application/json"},
+    "body": {
+      "alligator":{
+        "feet": 4,
+        "name": "Mary",
+        "favouriteColours": ["red","blue"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
... In this case "fallback" mime type "text/plain" is used, which makes test failing if provider returns some json or xml. #85.