### PR TITLE
Test without pact verification still gets run as a pact consumer

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactRule.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactRule.java
@@ -58,6 +58,7 @@ public class PactRule extends ExternalResource {
                 //no pactVerification? execute the test normally
                 if (pactDef == null) {
                     base.evaluate();
+                    return;
                 }
 
 


### PR DESCRIPTION
I have an integration test class that includes tests both with and without pact verification. Without this change, I cannot get the tests with no pact verification to pass as I get a NPE on line 64 of PactRule. I see a guard is in place to execute tests without pact verification normally, but without the return, the rule continues to execute the test as a pact consumer.