### PR TITLE
Make 'findHeaderByCaseInsensitiveKey' public so user can use it to find a header easily.

### DIFF
--- a/pact-jvm-model/src/main/scala/au/com/dius/pact/model/Pact.scala
+++ b/pact-jvm-model/src/main/scala/au/com/dius/pact/model/Pact.scala
@@ -141,7 +141,7 @@ case class Request(method: String,
 
   private def cookieHeader = findHeaderByCaseInsensitiveKey("cookie")
 
-  private def findHeaderByCaseInsensitiveKey(key: String): Option[(String, String)] = headers.flatMap(_.find(_._1.toLowerCase == key.toLowerCase))
+  def findHeaderByCaseInsensitiveKey(key: String): Option[(String, String)] = headers.flatMap(_.find(_._1.toLowerCase == key.toLowerCase))
 
   override def toString: String = {
     s"\tmethod: $method\n\tpath: $path\n\tquery: $query\n\theaders: $headers\n\tmatchers: $matchers\n\tbody:\n$body"

--- a/pact-jvm-model/src/test/scala/au/com/dius/pact/model/PactSpec.scala
+++ b/pact-jvm-model/src/test/scala/au/com/dius/pact/model/PactSpec.scala
@@ -113,5 +113,12 @@ class PactSpec extends Specification {
 
         }
     }
+
+    "request" should {
+      "provide an way to find a header case insensitive" in {
+        val request = Request(HttpMethod.Get, "", None, Some(Map("Cookie" -> "cookie-value")), None, None)
+        request.findHeaderByCaseInsensitiveKey("cookie") must beSome("Cookie" -> "cookie-value")
+      }
+    }
   }
 }

--- a/pact-specification-test/src/test/scala/specification/RequestSpecificationSpec.scala
+++ b/pact-specification-test/src/test/scala/specification/RequestSpecificationSpec.scala
@@ -34,7 +34,7 @@ class RequestSpecificationSpec extends SpecificationLike
         val fileName = testFile.getName
         implicit val formats = DefaultFormats
         val testJson = parse(testFile)
-        var testData = testJson.transformField {
+        val testData = testJson.transformField {
           case ("body", value) => ("body", JString(pretty(value)))
         }.extract[PactRequestSpecification]
 


### PR DESCRIPTION
Because in the https://github.com/realestate-com-au/pact-jvm-provider-spring-mvc project, I need to get the cookie value from the request, and don't want to implement a duplicate method like `findHeaderByCaseInsensitiveKey` again