### PR TITLE
Allow PactDslJsonArray to be at the root of a response

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactDslJsonArray.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactDslJsonArray.java
@@ -13,6 +13,10 @@ public class PactDslJsonArray extends DslPart {
 
     private final JSONArray body;
 
+	public PactDslJsonArray() {
+		this("$.body", null);
+	}
+	
     public PactDslJsonArray(String root, DslPart parent) {
         super(parent, root);
         body = new JSONArray();
@@ -209,6 +213,11 @@ public class PactDslJsonArray extends DslPart {
         matchers.put(root + appendArrayIndex(), regexp("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
         return this;
     }
+	
+	@Override
+	public String toString() {
+		return body.toString();
+	}
 
     private String appendArrayIndex() {
         return "[" + (body.length() - 1) + "]";

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerClient.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerClient.java
@@ -5,7 +5,9 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ConsumerClient{
@@ -15,11 +17,17 @@ public class ConsumerClient{
         this.url = url;
     }
 
-    public Map get(String path) throws IOException {
+    public Map getAsMap(String path) throws IOException {
         return jsonToMap(Request.Get(url + path)
                 .addHeader("testreqheader", "testreqheadervalue")
                 .execute().returnContent().asString());
     }
+
+	public List getAsList(String path) throws IOException {
+		return jsonToList(Request.Get(url + path)
+				.addHeader("testreqheader", "testreqheadervalue")
+				.execute().returnContent().asString());
+	}
 
     public Map post(String path, String body, ContentType mimeType) throws IOException {
         String respBody = Request.Post(url + path)
@@ -32,6 +40,10 @@ public class ConsumerClient{
     private HashMap jsonToMap(String respBody) throws IOException {
         return new ObjectMapper().readValue(respBody, HashMap.class);
     }
+	
+	private List jsonToList(String respBody) throws IOException {
+		return new ObjectMapper().readValue(respBody, ArrayList.class);		
+	}
 
     public int options(String path) throws IOException {
         return Request.Options(url + path)

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/PactDslJsonArrayTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/PactDslJsonArrayTest.java
@@ -1,0 +1,49 @@
+package au.com.dius.pact.consumer;
+
+import au.com.dius.pact.model.PactFragment;
+
+public class PactDslJsonArrayTest extends ConsumerPactTest {
+	@Override
+	protected PactFragment createFragment(ConsumerPactBuilder.PactDslWithProvider builder) {
+		DslPart body = new PactDslJsonArray()
+				.object()
+					.id()
+					.stringValue("name", "Rogger the Dogger")
+					.timestamp()
+					.date("dob", "MM/dd/yyyy")
+				.closeObject()
+				.object()
+					.id()
+					.stringValue("name", "Cat in the Hat")
+					.timestamp()
+					.date("dob", "MM/dd/yyyy")
+				.closeObject();
+		return builder
+				.uponReceiving("java test interaction with a DSL array body")
+					.path("/")
+					.method("GET")
+				.willRespondWith()
+					.status(200)
+					.body(body)
+				.toFragment();
+	}
+
+	@Override
+	protected String providerName() {
+		return "test_provider";
+	}
+
+	@Override
+	protected String consumerName() {
+		return "test_consumer";
+	}
+
+	@Override
+	protected void runTest(String url) {
+		try {
+			new ConsumerClient(url).getAsList("/");
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -2,11 +2,6 @@ package au.com.dius.pact.consumer;
 
 import au.com.dius.pact.model.PactFragment;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-
 public class PactDslJsonBodyTest extends ConsumerPactTest {
 
     @Override
@@ -53,7 +48,7 @@ public class PactDslJsonBodyTest extends ConsumerPactTest {
     @Override
     protected void runTest(String url) {
         try {
-            new ConsumerClient(url).get("/");
+            new ConsumerClient(url).getAsMap("/");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/examples/ExampleJavaConsumerPactRuleTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/examples/ExampleJavaConsumerPactRuleTest.java
@@ -57,7 +57,7 @@ public class ExampleJavaConsumerPactRuleTest {
             Map expectedResponse = new HashMap();
             expectedResponse.put("responsetest", true);
             expectedResponse.put("name", "harry");
-            assertEquals(new ConsumerClient("http://localhost:8080").get("/"), expectedResponse);
+            assertEquals(new ConsumerClient("http://localhost:8080").getAsMap("/"), expectedResponse);
         } catch (Exception e) {
             // NOTE: if you want to see any pact failure, do not throw an exception here. This should be
             // fixed at some point (see Issue #40 https://github.com/DiUS/pact-jvm/issues/40)

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/examples/ExampleJavaConsumerPactTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/examples/ExampleJavaConsumerPactTest.java
@@ -58,7 +58,7 @@ public class ExampleJavaConsumerPactTest extends ConsumerPactTest {
             Map expectedResponse = new HashMap();
             expectedResponse.put("responsetest", true);
             expectedResponse.put("name", "harry");
-            assertEquals(new ConsumerClient(url).get("/"), expectedResponse);
+            assertEquals(new ConsumerClient(url).getAsMap("/"), expectedResponse);
             assertEquals(new ConsumerClient(url).options("/second"), 200);
         } catch (Exception e) {
             // NOTE: if you want to see any pact failure, do not throw an exception here. This should be


### PR DESCRIPTION
Allow PactDslJsonArray to be at the root of a response