### PR TITLE
Implement missing parts of XmlBodyMatcher

### DIFF
--- a/pact-jvm-matchers/src/main/scala/au/com/dius/pact/matchers/XmlBodyMatcher.scala
+++ b/pact-jvm-matchers/src/main/scala/au/com/dius/pact/matchers/XmlBodyMatcher.scala
@@ -1,8 +1,8 @@
 package au.com.dius.pact.matchers
 
-import au.com.dius.pact.model.{BodyMismatch, DiffConfig, HttpPart}
+import au.com.dius.pact.model.{BodyMismatchFactory, BodyMismatch, DiffConfig, HttpPart}
 
-import scala.xml.{Elem, XML}
+import scala.xml._
 
 class XmlBodyMatcher extends BodyMatcher {
 
@@ -11,158 +11,104 @@ class XmlBodyMatcher extends BodyMatcher {
       case (None, None) => List[BodyMismatch]()
       case (None, b) => List[BodyMismatch]()
       case (a, None) => List(BodyMismatch(a, None))
-      case (Some(a), Some(b)) => compareElem("$.body", parse(a), parse(b), diffConfig, expected.matchers)
+      case (Some(a), Some(b)) => compare(Seq("$","body"), parse(a), parse(b), diffConfig, expected.matchers)
     }
   }
 
   def parse(xmlData: String) = {
-    XML.loadString(xmlData)
+    Utility.trim(XML.loadString(xmlData))
   }
 
-  def compareElem(path: String, expected: Elem, actual: Elem, config: DiffConfig,
-              matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
-      if (actual.label != expected.label) {
-        List(BodyMismatch(expected, actual, Some(s"Expected element ${expected.label} but received ${actual.label}"), path))
+  def appendIndex(path:Seq[String], index:Integer): Seq[String] = {
+    val last = path.last
+    val lastWithIndex = last + "[" + index.toString + "]"
+
+    path.dropRight(1) :+ lastWithIndex
+  }
+
+  def appendAttribute(path:Seq[String], attribute:String) : Seq[String] = {
+    path :+ attribute
+  }
+
+  def mkPathString(path:Seq[String]) = path.mkString(".")
+
+
+  def compareText(path: Seq[String], expected: Node, actual: Node, config: DiffConfig,
+                  matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
+    if (expected.text != actual.text) {
+      List(BodyMismatch(expected,actual,Some(s"Expected value '${expected.text}' but received '${actual.text}'"),mkPathString(path)))
+    } else {
+      List()
+    }
+  }
+
+  def compare(path: Seq[String], expected: Node, actual: Node, config: DiffConfig,
+                  matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
+    expected match {
+        case _ : Text => compareText(path,expected,actual,config,matchers)
+        case _ : Elem => compareNode(path,expected,actual,config,matchers)
+    }
+  }
+  
+  def compareNode(path: Seq[String], expected: Node, actual: Node, config: DiffConfig,
+                  matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
+    if (actual.label != expected.label) {
+      List(BodyMismatch(expected, actual, Some(s"Expected element ${expected.label} but received ${actual.label}"), mkPathString(path)))
+    } else {
+      val newPath = path :+ actual.label
+      compareAttributes(newPath,expected,actual,config,matchers) ++ compareChildren(newPath,expected,actual,config,matchers)
+    }
+  }
+
+  private def compareChildren(path: Seq[String], expected: Node, actual: Node, config: DiffConfig,
+                           matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
+    if (expected.child.isEmpty && actual.child.nonEmpty) {
+      List(BodyMismatch(expected, actual, Some(s"Expected an empty List but received ${actual.child.mkString(",")}"),mkPathString(path)))
+    } else if (expected.child.size != actual.child.size) {
+      val missingChilds = expected.child.diff(actual.child)
+      val result = missingChilds.map(child => BodyMismatch(expected, actual, Some(s"Expected $child but was missing"),mkPathString(path)))
+      result.toList :+ BodyMismatch(expected, actual, Some(s"Expected a List with ${expected.child.size} elements but received ${actual.child.size} elements"),mkPathString(path))
+    } else {
+      expected.child
+        .zipWithIndex
+        .zip(actual.child)
+        .flatMap(x => compare(appendIndex(path,x._1._2),x._1._1,x._2,config,matchers)).toList
+    }
+  }
+
+  private def compareAttributes(path: Seq[String], expected: Node, actual: Node, config: DiffConfig,
+                              matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
+      val expectedAttrs = expected.attributes.asAttrMap
+      val actualAttrs = actual.attributes.asAttrMap
+
+      val wrongSize = if (expectedAttrs.size != actualAttrs.size) {
+        List(BodyMismatch(expected, actual, Some(s"Expected a Tag with at least ${expected.attributes.size} attributes but received ${actual.attributes.size} attributes"),mkPathString(path)))
       } else {
-        List[BodyMismatch]()
-      }
-
-//    if (expectedValues.isEmpty && actualValues.nonEmpty) {
-//      List(BodyMismatch(a, b, Some(s"Expected an empty Map but received ${valueOf(actualValues)}"), path))
-//    } else {
-//      var result = List[BodyMismatch]()
-//      if ((diffConfig.allowUnexpectedKeys && expectedValues.size > actualValues.size) ||
-//        (!diffConfig.allowUnexpectedKeys && expectedValues.size != actualValues.size)) {
-//        result = result :+ BodyMismatch(a, b, Some(s"Expected a Map with at least ${expectedValues.size} elements but received ${actualValues.size} elements"), path)
-//      }
-//      expectedValues.foreach(entry => {
-//        val s = path + "." + entry._1
-//        if (actualValues.contains(entry._1)) {
-//          result = result ++: compare(s, entry._2, actualValues(entry._1), diffConfig, matchers)
-//        } else {
-//          result = result :+ BodyMismatch(a, b, Some(s"Expected ${entry._1}=${valueOf(entry._2)} but was missing"), path)
-//        }
-//      })
-//      result
-//    }
-  }
-
-  /*implicit lazy val formats = DefaultFormats
-
-  def matchBody(expected: HttpPart, actual: HttpPart, diffConfig: DiffConfig): List[BodyMismatch] = {
-    (expected.body, actual.body) match {
-      case (None, None) => List()
-      case (None, b) => if (diffConfig.structural) {
         List()
-      } else {
-        List(BodyMismatch(None, b))
       }
-      case (a, None) => List(BodyMismatch(a, None))
-      case (Some(a), Some(b)) => compare("$.body", parse(a), parse(b), diffConfig, expected.matchers)
-    }
+
+      val mismatchingAttributeValues = expectedAttrs.keys
+        .map(k => (k,expectedAttrs.get(k),actualAttrs.get(k)))
+        .filter(t => t._2 != t._3)
+
+      val attributesWithWrongValue = mismatchingAttributeValues
+        .filter(t => t._3.nonEmpty)
+        .flatMap(t => {
+          val attributePath = appendAttribute(path,t._1)
+          if (Matchers.matcherDefined(attributePath,matchers)) {
+            Matchers.domatch[BodyMismatch](matchers,attributePath,t._2.get,t._3.get,BodyMismatchFactory)
+          } else {
+            List(BodyMismatch(expected, actual, Some(s"Expected ${t._1}=${t._2.get} but received ${t._3.get}"),mkPathString(attributePath)))
+          }
+        })
+
+      val attributesWithMissingValue = mismatchingAttributeValues
+        .filter(t => t._3.isEmpty)
+        .map(attr => {
+          BodyMismatch(expected, actual, Some(s"Expected ${attr._1}=${attr._2.get} but was missing"),mkPathString(appendAttribute(path,attr._1)))
+        })
+
+      attributesWithMissingValue.toList ++ attributesWithWrongValue.toList ++ wrongSize
   }
-
-  def valueOf(value: Any) = {
-    value match {
-      case s: String => s"'$value'"
-      case null => "null"
-      case _ => value.toString
-    }
-  }
-
-  def typeOf(value: Any) = {
-    if (value == null) {
-      "Null"
-    } else value match {
-      case _: Map[Any, Any] =>
-        "Map"
-      case _: List[Any] =>
-        "List"
-      case _ =>
-        value.getClass.getSimpleName
-    }
-  }
-
-  def compare(path: String, expected: Any, actual: Any, diffConfig: DiffConfig, matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
-    (expected, actual) match {
-      case (a: JObject, b: JObject) => compareMaps(a.values, b.values, a, b, path, diffConfig, matchers)
-      case (a: Map[String, Any], b: Map[String, Any]) => compareMaps(a, b, a, b, path, diffConfig, matchers)
-      case (a: JArray, b: JArray) => compareLists(a.values, b.values, a, b, path, diffConfig, matchers)
-      case (a: List[Any], b: List[Any]) => compareLists(a, b, a, b, path, diffConfig, matchers)
-      case (_, _) =>
-        if ((expected.isInstanceOf[JObject] && !actual.isInstanceOf[JObject]) ||
-          (expected.isInstanceOf[JArray] && !actual.isInstanceOf[JArray])) {
-          List(BodyMismatch(expected, actual, Some(s"Type mismatch: Expected ${typeOf(expected)} ${valueOf(expected)} but received ${typeOf(actual)} ${valueOf(actual)}"), path))
-        } else {
-          compareValues(path, expected, actual, matchers)
-        }
-    }
-  }
-
-  def compareLists(expectedValues: List[Any], actualValues: List[Any], a: Any, b: Any, path: String,
-                   diffConfig: DiffConfig, matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
-    def compareListContent = {
-      var result = List[BodyMismatch]()
-      for ((value, index) <- expectedValues.view.zipWithIndex) {
-        val s = path + "." + (index + 1)
-        if (index < actualValues.size) {
-          result = result ++: compare(s, value, actualValues(index), diffConfig, matchers)
-        } else {
-          result = result :+ BodyMismatch(a, b, Some(s"Expected ${valueOf(value)} but was missing"), path)
-        }
-      }
-      result
-    }
-
-    var result = List[BodyMismatch]()
-    if (Matchers.matcherDefined(path, matchers)) {
-      result = Matchers.domatch[BodyMismatch](matchers.get(path), path, expectedValues, actualValues,
-        BodyMismatchFactory) ++ compareListContent
-    } else {
-      if (expectedValues.isEmpty && actualValues.nonEmpty) {
-        result = List(BodyMismatch(a, b, Some(s"Expected an empty List but received ${valueOf(actualValues)}"), path))
-      } else {
-        if (expectedValues.size != actualValues.size) {
-          result = result :+ BodyMismatch(a, b, Some(s"Expected a List with ${expectedValues.size} elements but received ${actualValues.size} elements"), path)
-        }
-        result = result ++ compareListContent
-      }
-    }
-    result
-  }
-
-  def compareMaps(expectedValues: Map[String, Any], actualValues: Map[String, Any], a: Any, b: Any, path: String,
-                  diffConfig: DiffConfig, matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
-    if (expectedValues.isEmpty && actualValues.nonEmpty) {
-      List(BodyMismatch(a, b, Some(s"Expected an empty Map but received ${valueOf(actualValues)}"), path))
-    } else {
-      var result = List[BodyMismatch]()
-      if ((diffConfig.allowUnexpectedKeys && expectedValues.size > actualValues.size) ||
-        (!diffConfig.allowUnexpectedKeys && expectedValues.size != actualValues.size)) {
-        result = result :+ BodyMismatch(a, b, Some(s"Expected a Map with at least ${expectedValues.size} elements but received ${actualValues.size} elements"), path)
-      }
-      expectedValues.foreach(entry => {
-        val s = path + "." + entry._1
-        if (actualValues.contains(entry._1)) {
-          result = result ++: compare(s, entry._2, actualValues(entry._1), diffConfig, matchers)
-        } else {
-          result = result :+ BodyMismatch(a, b, Some(s"Expected ${entry._1}=${valueOf(entry._2)} but was missing"), path)
-        }
-      })
-      result
-    }
-  }
-
-  def compareValues(path: String, expected: Any, actual: Any, matchers: Option[Map[String, Map[String, String]]]): List[BodyMismatch] = {
-    if (Matchers.matcherDefined(path, matchers)) {
-      Matchers.domatch[BodyMismatch](matchers.get(path), path, expected, actual, BodyMismatchFactory)
-    } else {
-      if (expected == actual) {
-        List[BodyMismatch]()
-      } else {
-        List(BodyMismatch(expected, actual, Some(s"Expected ${valueOf(expected)} but received ${valueOf(actual)}"), path))
-      }
-    }
-  }*/
 
 }

--- a/pact-jvm-matchers/src/main/scala/au/com/dius/pact/model/Matching.scala
+++ b/pact-jvm-matchers/src/main/scala/au/com/dius/pact/model/Matching.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 
 object PactConfig {
     var bodyMatchers = mutable.HashMap[String, BodyMatcher](
-//      "application/.*xml" -> new XmlBodyMatcher(),
+      "application/.*xml" -> new XmlBodyMatcher(),
       "application/.*json" -> new JsonBodyMatcher()
     )
 }


### PR DESCRIPTION
The `XmlBodyMatcher` is currently disabled because it's incomplete. So here's a pull request to make it more complete and hopefully ready for the next release.  
I might not have covered all special cases but I hope this implementation is a start. 

Regarding the paths I'm not quite sure: At the moment, I'm sticking with the JSONPath syntax the `JsonBodyMatcher` is using since the Matchers seem to require it. It feels a bit strange for XML though and I'm not sure if it's expressive enough. 