### PR TITLE
Add insecure flag to reduce the amount of boiler plate groovy script

### DIFF
--- a/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/Provider.groovy
+++ b/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/Provider.groovy
@@ -17,4 +17,5 @@ class Provider {
     boolean stateChangeUsesBody = true
     def stateChangeRequestFilter
     def createClient
+    boolean insecure = false
 }

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/groovysupport/HttpClientFactory.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/groovysupport/HttpClientFactory.groovy
@@ -1,0 +1,70 @@
+package au.com.dius.pact.provider.groovysupport
+
+import org.apache.http.config.Registry
+import org.apache.http.config.RegistryBuilder
+import org.apache.http.conn.socket.ConnectionSocketFactory
+import org.apache.http.conn.socket.PlainConnectionSocketFactory
+import org.apache.http.conn.ssl.NoopHostnameVerifier
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.client.HttpClients
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+import org.apache.http.ssl.SSLContextBuilder
+
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import java.security.cert.X509Certificate
+
+class HttpClientFactory {
+
+    public CloseableHttpClient newClient(def provider) {
+        if (provider?.createClient != null) {
+            if (provider.createClient instanceof Closure) {
+                provider.createClient(provider)
+            } else {
+                Binding binding = new Binding()
+                binding.setVariable("provider", provider)
+                GroovyShell shell = new GroovyShell(binding)
+                shell.evaluate(provider.createClient as String)
+            }
+        } else if (provider?.insecure) {
+            createInsecure()
+        } else {
+            HttpClients.createDefault()
+        }
+    }
+
+    private static CloseableHttpClient createInsecure() {
+        HttpClientBuilder b = HttpClientBuilder.create()
+
+        // setup a Trust Strategy that allows all certificates.
+        //
+        SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, { X509Certificate[] chain, String authType ->
+            return true
+        }).build()
+        b.setSslcontext(sslContext)
+        // don't check Hostnames, either.
+        //      -- use SSLConnectionSocketFactory.getDefaultHostnameVerifier(), if you don't want to weaken
+        HostnameVerifier hostnameVerifier = NoopHostnameVerifier.INSTANCE
+
+        // here's the special part:
+        //      -- need to create an SSL Socket Factory, to use our weakened "trust strategy";
+        //      -- and create a Registry, to register it.
+        //
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext, hostnameVerifier)
+        Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory> create()
+                .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                .register("https", sslSocketFactory)
+                .build()
+
+        // now, we create connection-manager using our Registry.
+        //      -- allows multi-threaded use
+        PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager(socketFactoryRegistry)
+        b.setConnectionManager(connMgr)
+
+        // finally, build the HttpClient;
+        //      -- done!
+        return b.build()
+    }
+}


### PR DESCRIPTION
Add insecure flag to reduce the amount of boiler plate groovy scriptthat is needed in the pom.xml file to allow tests to connect to https endpoints.

I attempted to add an integration test using the inbuilt Java com.sun.net.httpserver.HttpsServer server but it I couldn't get it working in a reasonable amount of time.

This flag turns this:
```
          <createClient>
            // This is a Groovy script that will enable the client to accept self-signed certificates
            import org.apache.http.ssl.SSLContextBuilder
            import org.apache.http.conn.ssl.NoopHostnameVerifier
            import org.apache.http.impl.client.HttpClients
            HttpClients.custom().setSSLHostnameVerifier(new NoopHostnameVerifier())
                .setSslcontext(new SSLContextBuilder().loadTrustMaterial(null, { x509Certificates, s -> true })
                    .build())
            .build()
          </createClient>
```
into
```xml
<insecure>true</insecure>
```