### PR TITLE
Add missing matchers to arrayEachLike() #145

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/PactDslJsonArray.java
@@ -503,6 +503,7 @@ public class PactDslJsonArray extends DslPart {
      */
     public static PactDslJsonBody arrayEachLike() {
         PactDslJsonArray parent = new PactDslJsonArray("", null, true);
+        parent.matchers.put("", parent.matchMin(0));
         return new PactDslJsonBody(".", parent);
     }
 

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonArrayMatcherTest.groovy
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonArrayMatcherTest.groovy
@@ -40,7 +40,7 @@ class PactDslJsonArrayMatcherTest {
         assert new JsonSlurper().parseText(subject.body.toString()) == [
           [amount: 100, clearedDate: date.format('mm/dd/yyyy'), status: 'STATUS']
         ]
-        assert subject.matchers.keySet() == ['[*].amount', '[*].clearedDate', '[*].status'] as Set
+        assert subject.matchers.keySet() == ['', '[*].amount', '[*].clearedDate', '[*].status'] as Set
     }
 
     @Test


### PR DESCRIPTION
I saw that the matchers were missing from the new arrayEachLike() method, so I just added them in.