### PR TITLE
Scan classpath is not set in pact-jvm-provider-maven v3 pact verifier

### DIFF
--- a/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactProviderMojo.groovy
+++ b/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactProviderMojo.groovy
@@ -17,8 +17,8 @@ import org.fusesource.jansi.AnsiConsole
 class PactProviderMojo extends AbstractMojo {
 
   @Parameter(defaultValue = '${project.runtimeClasspathElements}', required = true, readonly = true)
-  private List<String> classpathElements;
-	
+  private List<String> classpathElements
+
   @Parameter
   private List<Provider> serviceProviders
 
@@ -37,17 +37,15 @@ class PactProviderMojo extends AbstractMojo {
       "You must specify the pactfile to execute for consumer '${consumer.name}' (use <pactFile> or <pactUrl>)"
     }
     verifier.isBuildSpecificTask = { false }
-	
+
 	verifier.projectClasspath = {
 		List<URL> urls = []
-		
 		for (element in classpathElements) {
 			urls.add(new File(element).toURI().toURL())
 		}
-		
 		urls as URL[]
 	}
-	
+
     serviceProviders.each { provider ->
       List consumers = []
       consumers.addAll(provider.consumers)

--- a/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactProviderMojo.groovy
+++ b/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactProviderMojo.groovy
@@ -16,6 +16,9 @@ import org.fusesource.jansi.AnsiConsole
 @Mojo(name = 'verify')
 class PactProviderMojo extends AbstractMojo {
 
+  @Parameter(defaultValue = '${project.runtimeClasspathElements}', required = true, readonly = true)
+  private List<String> classpathElements;
+	
   @Parameter
   private List<Provider> serviceProviders
 
@@ -34,7 +37,17 @@ class PactProviderMojo extends AbstractMojo {
       "You must specify the pactfile to execute for consumer '${consumer.name}' (use <pactFile> or <pactUrl>)"
     }
     verifier.isBuildSpecificTask = { false }
-
+	
+	verifier.projectClasspath = {
+		List<URL> urls = []
+		
+		for (element in classpathElements) {
+			urls.add(new File(element).toURI().toURL())
+		}
+		
+		urls as URL[]
+	}
+	
     serviceProviders.each { provider ->
       List consumers = []
       consumers.addAll(provider.consumers)


### PR DESCRIPTION
When the v3 pact verifier runs, it needs to scan the runtime classpath for annotated methods. In the maven plugin, the plugin code does not set the projectClassPath which causes an error when the verifier runs.

Sorry, I am not very good with Git and somehow, two commits were pulled into this request. You only need the "Fix for no project classpath in maven v3 pact verifier" commit