### PR TITLE
Add pact broker publish task for maven provider

### DIFF
--- a/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactPublishMojo.groovy
+++ b/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactPublishMojo.groovy
@@ -1,0 +1,31 @@
+package au.com.dius.pact.provider.maven
+
+import au.com.dius.pact.provider.broker.PactBrokerClient
+import groovy.io.FileType
+import org.apache.maven.plugin.AbstractMojo
+import org.apache.maven.plugin.MojoExecutionException
+import org.apache.maven.plugin.MojoFailureException
+import org.apache.maven.plugins.annotations.Mojo
+import org.apache.maven.plugins.annotations.Parameter
+
+@Mojo(name = 'publish')
+public class PactPublishMojo extends AbstractMojo {
+    @Parameter(required = true, readonly = true, defaultValue = '${project.version}')
+    private String projectVersion
+
+    @Parameter(defaultValue = '${project.build.directory}/pacts')
+    private String pactDirectory
+
+    @Parameter
+    private String pactBrokerUrl
+
+    @Override
+    void execute() throws MojoExecutionException, MojoFailureException {
+        def brokerClient = new PactBrokerClient(pactBrokerUrl)
+        File pactDirectory = pactDirectory as File
+        pactDirectory.eachFileMatch(FileType.FILES, ~/.*\.json/) { pactFile ->
+            print "Publishing ${pactFile.name} ... "
+            println brokerClient.uploadPactFile(pactFile, projectVersion)
+        }
+    }
+}

--- a/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactPublishMojo.groovy
+++ b/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactPublishMojo.groovy
@@ -8,8 +8,11 @@ import org.apache.maven.plugin.MojoFailureException
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 
+/**
+ * Task to push pact files to a pact broker
+ */
 @Mojo(name = 'publish')
-public class PactPublishMojo extends AbstractMojo {
+class PactPublishMojo extends AbstractMojo {
     @Parameter(required = true, readonly = true, defaultValue = '${project.version}')
     private String projectVersion
 


### PR DESCRIPTION
This matches the groovy pact publishing task.

The particular project this is being used in is an Akka project that uses 2.10, hence building it off the 2.x branch.

To use:
```xml
            <plugin>
                <groupId>au.com.dius</groupId>
                <artifactId>pact-jvm-provider-maven_2.10</artifactId>
                <version>2.4.1</version>
                <configuration>
                    <pactBrokerUrl>http://pact-broker.int.local/</pactBrokerUrl>
                </configuration>
                <executions>
                    <execution>
                        <id>pact-publish</id>
                        <goals>
                            <goal>publish</goal>
                        </goals>
                        <phase>deploy</phase>
                    </execution>
                </executions>
            </plugin>
```
