### PR TITLE
Added one line description of ConsumerService to README example that …

### DIFF
--- a/pact-jvm-consumer-specs2/README.md
+++ b/pact-jvm-consumer-specs2/README.md
@@ -26,6 +26,8 @@ dependencies {
 
 To author a test, mix `PactSpec` into your spec
 
+First we define a service client called `ConsumerService`. In our example this is a simple wrapper for `dispatch`, an HTTP client. The source code can be found in the test folder alongside the `ExamplePactSpec`.
+
 Here is a simple example:
 
 ```


### PR DESCRIPTION
…would have saved me 20 minutes...

It's a small thing but I think new comers expect that, once you add the library dependency, you should be able to copy and paste example code with an expectation of it compiling, or an explanation for why it won't. :-)