### PR TITLE
#bugfix matcher did not support nested objects

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -413,9 +413,9 @@ public class PactDslJsonBody extends DslPart {
      * @param name field name
      */
     public PactDslJsonBody object(String name) {
-        String base = "." + name;
+        String base = root + name;
         if (!name.matches(Parser$.MODULE$.FieldRegex().toString())) {
-            base = "['" + name + "']";
+            base = StringUtils.substringBeforeLast(root, ".") + "['" + name + "']";
         }
         return new PactDslJsonBody(base + ".", this);
     }

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -12,7 +12,6 @@ import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -91,6 +90,76 @@ public class PactDslJsonBodyTest {
 
         assertThat(((JSONObject) body.getBody()).keySet(), is(equalTo((Set)
                 new HashSet(Arrays.asList("ids")))));
+    }
+
+    @Test
+    public void nestedObjectMatcherTest() {
+        DslPart body = new PactDslJsonBody()
+                .object("first")
+                .stringType("level1", "l1example")
+                .object("second")
+                .stringType("level2", "l2example")
+                .object("@third")
+                .stringType("level3", "l3example")
+                .object("fourth")
+                .stringType("level4", "l4example")
+                .closeObject()
+                .closeObject()
+                .closeObject()
+                .closeObject();
+
+        Set<String> expectedMatchers = new HashSet<>(Arrays.asList(
+                ".first.second['@third'].fourth.level4",
+                ".first.second['@third'].level3",
+                ".first.second.level2",
+                ".first.level1"
+        ));
+
+        assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
+    }
+
+    @Test
+    public void nestedArrayMatcherTest() {
+        DslPart body = new PactDslJsonBody()
+                .array("first")
+                .stringType("l1example")
+                .array()
+                .stringType("l2example")
+                .closeArray()
+                .closeArray();
+
+        Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
+                ".first[0]",
+                ".first[1][0]"
+        ));
+
+        assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
+    }
+
+    @Test
+    public void nestedArrayAndObjectMatcherTest() {
+        DslPart body = new PactDslJsonBody()
+                .object("first")
+                .stringType("level1", "l1example")
+                .array("second")
+                .stringType("al2example")
+                .object()
+                .stringType("level2", "l2example")
+                .array("third")
+                .stringType("al3example")
+                .closeArray()
+                .closeObject()
+                .closeArray()
+                .closeObject();
+
+        Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
+                ".first.level1",
+                ".first.second[1].level2",
+                ".first.second[0]",
+                ".first.second[1].third[0]"
+        ));
+
+        assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
     }
 
     @Test


### PR DESCRIPTION
When having nested objects in the json body, the matcher-entries (and thus the generated MatchingRules) did not correspond to the json structure - just the root entry (".") and the last object + key were added to the matcher (@see PactDslJsonBodyTest.nestedObjectMatcherTest())
