### PR TITLE
bugfix - nested JSON objects get parent nodes prefixed

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -42,7 +42,8 @@ public class PactDslJsonBody extends DslPart {
         for(String matcherName: object.matchers.keySet()) {
             matchers.put(matcherName, object.matchers.get(matcherName));
         }
-        String name = StringUtils.strip(object.root, ".");
+        String elementBase = StringUtils.difference(this.root, object.root);
+        String name = StringUtils.strip(elementBase, ".");
         Pattern p = Pattern.compile("\\['(.+)'\\]");
         Matcher matcher = p.matcher(name);
         if (matcher.matches()) {

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -116,6 +116,28 @@ public class PactDslJsonBodyTest {
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getString("level1"), is(equalTo("l1example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONObject("second")
+                .getString("level2"), is(equalTo("l2example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONObject("second")
+                .getJSONObject("@third")
+                .getString("level3"), is(equalTo("l3example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONObject("second")
+                .getJSONObject("@third")
+                .getJSONObject("fourth")
+                .getString("level4"), is(equalTo("l4example")));
     }
 
     @Test
@@ -134,6 +156,15 @@ public class PactDslJsonBodyTest {
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONArray("first")
+                .getString(0), is(equalTo("l1example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONArray("first")
+                .getJSONArray(1)
+                .getString(0), is(equalTo("l2example")));
     }
 
     @Test
@@ -160,6 +191,29 @@ public class PactDslJsonBodyTest {
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getString("level1"), is(equalTo("l1example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONArray("second")
+                .getString(0), is(equalTo("al2example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONArray("second")
+                .getJSONObject(1)
+                .getString("level2"), is(equalTo("l2example")));
+
+        assertThat(((JSONObject)body.getBody())
+                .getJSONObject("first")
+                .getJSONArray("second")
+                .getJSONObject(1)
+                .getJSONArray("third")
+                .getString(0), is(equalTo("al3example")));
+
     }
 
     @Test


### PR DESCRIPTION
With my last pull request - fixing the matchers for nested objects - i introduced a bug that lead to the output of wrong JSON objects where nested objects got the ids of their preceding objects appended (as matchers do).
This will be fixed with this PR.

...please excuse the inconvenience. =o)
