### PR TITLE
fixes toString problem in PactDslResponse when DslPart used

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -103,7 +103,13 @@ public class PactDslResponse {
         for (String matcherName : body.matchers.keySet()) {
             responseMatchers.put("$.body" + matcherName, body.matchers.get(matcherName));
         }
-        responseBody = OptionalBody.body(body.getBody().toString());
+
+        if (body.getBody() != null) {
+            responseBody = OptionalBody.body(body.getBody().toString());
+        } else {
+            responseBody = OptionalBody.nullBody();
+        }
+
         if (!responseHeaders.containsKey("Content-Type")) {
             responseHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
         }

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -103,7 +103,7 @@ public class PactDslResponse {
         for (String matcherName : body.matchers.keySet()) {
             responseMatchers.put("$.body" + matcherName, body.matchers.get(matcherName));
         }
-        responseBody = OptionalBody.body(body.toString());
+        responseBody = OptionalBody.body(body.getBody().toString());
         if (!responseHeaders.containsKey("Content-Type")) {
             responseHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
         }


### PR DESCRIPTION
Fixes toString problem in PactDslResponse when DslPart used.

Basically if for example you do something like:

```
PactDslJsonRootValue.stringMatcher("[0-9]+.[0-9]", "123.2");
```

since `PactDslResponse` calls `toString` directly, if the method is not implemented then a weird string representation is shown instead of the value set as example. This is the case when `PactDslJsonRootValue`. Since `toString` is not overriden you cannot use the example value (123.2). And the same would happens with any `DslPart` object not implementing `toString` method. To mitigate this, the `getBody` is used to get the value. 