### PR TITLE
Matching fails when JSON contains maps and keys are not alphabetically ordered

### DIFF
--- a/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/ResponseComparisonTest.groovy
+++ b/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/ResponseComparisonTest.groovy
@@ -71,6 +71,13 @@ class ResponseComparisonTest {
   }
 
   @Test
+  void 'comparing bodies should pass when the order of elements in the actual response is different'() {
+    response = new Response(200, ['Content-Type': 'application/json'], OptionalBody.body('{"moar_stuff": {"a": "is also good", "b": "is even better"}, "stuff": "is good"}'), [:])
+    actualBody = '{"stuff": "is good", "moar_stuff": {"b": "is even better", "a": "is also good"}}'
+    assert testSubject().body == [:]
+  }
+
+  @Test
   void 'comparing bodies should show all the differences'() {
     actualBody = '{"stuff": "should make the test fail"}'
     def result = testSubject().body

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ResponseComparison.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ResponseComparison.groovy
@@ -125,7 +125,9 @@ class ResponseComparison {
       String actualBodyString = ''
       if (actualBody) {
           if (actual.contentType.mimeType ==~ 'application/.*json') {
-              actualBodyString = JsonOutput.prettyPrint(actualBody)
+              def bodyMap = new JsonSlurper().parseText(actualBody)
+              def bodyJson = JsonOutput.toJson(bodyMap)
+              actualBodyString = JsonOutput.prettyPrint(bodyJson)
           } else {
               actualBodyString = actualBody
           }


### PR DESCRIPTION
I've run into an issue where my expected result JSON is failing to match, and being re-ordered before diffing which is producing an incorrect and strange result. 

My JSON looks something like this - ignoring the ugliness of this output, the test was failing because it was expecting things to be in a different order, specifically it was expecting the keys to be alphabetical. 

```
{
  "md": {},
  "r": [
    {
      "dt": 1321401600000
    },
    {
      "dt": 1321488000000
    },
    {
      "dt": 1321574400000,
      "participation": {
        "pa": {
          "e": 0,
          "r": 0,
          "mb": 0,
          "a": 0,
          "m1": 5,
          "m3": 0,
          "m12": 0
        }
      }
    }
  ],
  "km": {
    "5295d6aadb4d08a0cb00101d": "0",
    "5295d6a9db4d08a0cb00101a": "1",
    "5295d6aadb4d08a0cb00101e": "2",
    "5295d6a9db4d08a0cb00101b": "3",
    "5295d6aadb4d08a0cb00101f": "4",
    "5295d6a9db4d08a0cb00101c": "5",
    "5295d6aadb4d08a0cb001022": "6",
    "5295d6aadb4d08a0cb001020": "7",
    "5295d6aadb4d08a0cb001021": "8",
    "4ef025c218072e09ab0000f3": "e",
    "4ef025c218072e09ab0000f4": "f",
    "5295d6a9db4d08a0cb001019": "9",
    "5295d6a9db4d08a0cb001018": "a",
    "5295d6a9db4d08a0cb001017": "b",
    "5295d6a9db4d08a0cb001016": "c",
    "5295d6a9db4d08a0cb001015": "d"
  }
}
```

I've stepped through the code and this is what I think's happening: 

**1. It uses `JsonSlurper.parse` to read the file containing my expected body JSON into a map in `private static loadFile` method in PactReader.groovy**

**2. It use `JsonOutput.toJson` to extract the body contents from the JSON into a string, in `static extractBody` method in PactReader.groovy** 

This has the side effect of re-ordering the JSON keys to be alphabetical, which *shouldn't* matter in most cases, however ... 

**3. In `JsonBodyMatcher.scala`, for some reason it's failing to match the JSON.**

This is using some Scala libraries to turn the json into an object map. It seems to deal OK with simple string values being in a different order, but when one of the values is a map with its own keys in a different order, it fails. 

**4. It then runs through the groovy code in `compareBody` in `ResponseComparison.groovy`, and fails to match, because the `expectedBody` now has its keys reordered, and does not match the `actualBody`.**

I've made a change that fixes the problem by loading the `actualBody` through the `JsonSlurper` and then running `JsonOutput.toJson` before pretty printing it, but I don't really think it's a great fix. I'm making a PR of it anyway in the hopes that it's clear enough to show you what the issue is, and maybe you can suggest a better fix. It seems like the real issue is in the JSON comparison in the Scala, but I really didn't know how to go about fixing that.

I've also written a test in `ResponseComparisonTest.groovy` (which does fail if you reverse my change, so this should at least help to track down the issue). 