### PR TITLE
bugfix - fix handling nested properties in PactDslJsonBody

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -121,7 +121,7 @@ public class PactDslJsonBody extends DslPart {
     private String matcherKey(String name) {
         String key = root + name;
         if (!name.matches(Parser$.MODULE$.FieldRegex().toString())) {
-            key = StringUtils.strip(root, ".") + "['" + name + "']";
+            key = StringUtils.stripEnd(root, ".") + "['" + name + "']";
         }
         return key;
     }

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -97,6 +97,7 @@ public class PactDslJsonBodyTest {
         DslPart body = new PactDslJsonBody()
                 .object("first")
                 .stringType("level1", "l1example")
+                .stringType("@level1")
                 .object("second")
                 .stringType("level2", "l2example")
                 .object("@third")
@@ -112,7 +113,8 @@ public class PactDslJsonBodyTest {
                 ".first.second['@third'].fourth.level4",
                 ".first.second['@third'].level3",
                 ".first.second.level2",
-                ".first.level1"
+                ".first.level1",
+                ".first['@level1']"
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));


### PR DESCRIPTION
missing initial dot in matching key when property was escaped