### PR TITLE
Add new line after a message 'Consumer 'X' has a pact with Provider 'Y''

### DIFF
--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
@@ -38,7 +38,7 @@ trait PactSpec extends FragmentsFactory {
     def withConsumerTest(test: MockProviderConfig => Result) = {
       val config = MockProviderConfig.createDefault(PactConfig(PactSpecVersion.V2))
       val description = s"Consumer '${pactFragment.consumer.getName}' has a pact with Provider '${pactFragment.provider.getName}': " +
-        pactFragment.interactions.map { i => i.getDescription }.mkString(" and ")
+        pactFragment.interactions.map { i => i.getDescription }.mkString(" and ") + sys.props("line.separator")
 
       fragmentFactory.example(description, {
         pactFragment.duringConsumerSpec(config)(test(config), verify)


### PR DESCRIPTION
Hi,

I am using specs2 implementation on my project.
It works quite well, except there is one tiny detail that could improve the console output for the test results for me.
Here is the screenshot on how the output looks for me now (I have multiple assertions):
<img width="791" alt="screen shot 2016-06-16 at 10 41 28" src="https://cloud.githubusercontent.com/assets/4360611/16110620/efec5fc2-33ae-11e6-8bfe-c24c416e7e27.png">

I would like '**_has valid price_**' in my example to move to a new line (as well as the other assertions).

Thanks!

