### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/MatcherTestUtils.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/MatcherTestUtils.java
@@ -23,6 +23,8 @@ public class MatcherTestUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MatcherTestUtils.class);
 
+    private MatcherTestUtils() {}
+
     public static Set<String> asSet(String... strings) {
         return new TreeSet<String>(Arrays.asList(strings));
     }

--- a/pact-jvm-consumer/src/main/java/nl/flotsam/xeger/XegerUtils.java
+++ b/pact-jvm-consumer/src/main/java/nl/flotsam/xeger/XegerUtils.java
@@ -22,6 +22,8 @@ import java.util.Random;
  */
 public class XegerUtils {
 
+    private XegerUtils() {}
+
     /**
      * Generates a random number within the given bounds.
      *

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/sysprops/PactRunnerExpressionParser.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/sysprops/PactRunnerExpressionParser.java
@@ -7,6 +7,8 @@ public class PactRunnerExpressionParser {
   public static final String START_EXPRESSION = "${";
   public static final char END_EXPRESSION = '}';
 
+  private PactRunnerExpressionParser() {}
+
   public static String parseExpressions(final String value) {
     return parseExpressions(value, new SystemPropertyResolver());
   }

--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiConsole.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiConsole.java
@@ -42,6 +42,8 @@ public class AnsiConsole {
 
     private static int installed;
 
+	private AnsiConsole() {}
+
 	public static OutputStream wrapOutputStream(final OutputStream stream) {
 		return wrapOutputStream(stream, STDOUT_FILENO);
 	}

--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiRenderer.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiRenderer.java
@@ -55,6 +55,8 @@ public class AnsiRenderer
 
     public static final String CODE_LIST_SEPARATOR = ",";
 
+    private AnsiRenderer() {}
+
     static public String render(final String input) throws IllegalArgumentException {
         StringBuffer buff = new StringBuffer();
 

--- a/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/groovysupport/GroovyJavaUtils.java
+++ b/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/groovysupport/GroovyJavaUtils.java
@@ -9,6 +9,8 @@ import java.util.function.Supplier;
 
 public class GroovyJavaUtils {
 
+  private GroovyJavaUtils() {}
+
   public static Consumer<HttpRequest> consumerRequestFilter() {
     return request -> request.addHeader("Java Consumer", "was called");
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 180 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava