### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/Ansi.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/Ansi.java
@@ -527,7 +527,7 @@ public class Ansi {
 		return this;
 	}
 
-	public au.com.dius.pact.provider.org.fusesource.jansi.Ansi a(StringBuffer value) {
+	public au.com.dius.pact.provider.org.fusesource.jansi.Ansi a(StringBuilder value) {
 		flushAttributes();
 		builder.append(value);
 		return this;

--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiRenderer.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiRenderer.java
@@ -56,7 +56,7 @@ public class AnsiRenderer
     public static final String CODE_LIST_SEPARATOR = ",";
 
     static public String render(final String input) throws IllegalArgumentException {
-        StringBuffer buff = new StringBuffer();
+        StringBuilder buff = new StringBuilder();
 
         int i = 0;
         int j, k;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava