### PR TITLE
squid:S1444 - "public static" fields should be constant

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/ConsumerPactTest.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/ConsumerPactTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 public abstract class ConsumerPactTest {
-    public static VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
+    public static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
 
     protected abstract PactFragment createFragment(PactDslWithProvider builder);
     protected abstract String providerName();

--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactRule.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/PactRule.java
@@ -30,7 +30,7 @@ public class PactRule extends ExternalResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PactRule.class);
 
-    public static VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
+    public static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
 
     private Map <String, PactFragment> fragments;
     private Object target;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1444 - public static fields should be constant.
squid:ClassVariableVisibilityCheck -  Class variable fields should not have public accessibility.
squid:S3008 - public static fields should be constant.
This pull request removes technical debt of 64 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava