### PR TITLE
Allow HttpTarget to set insecure flag

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/HttpTarget.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/HttpTarget.java
@@ -37,6 +37,7 @@ public class HttpTarget implements TestClassAwareTarget {
     private final String host;
     private final int port;
     private final String protocol;
+    private final boolean insecure;
     private TestClass testClass;
     private Object testTarget;
     private ValueResolver valueResolver = new SystemPropertyResolver();
@@ -61,7 +62,7 @@ public class HttpTarget implements TestClassAwareTarget {
     /**
      * @param host host of tested service
      * @param port port of tested service
-     * @param protocol of tested service
+     * @param protocol protocol of tested service
      */
     public HttpTarget(final String protocol, final String host, final int port) {
         this(protocol, host, port, "/");
@@ -70,24 +71,48 @@ public class HttpTarget implements TestClassAwareTarget {
     /**
      * @param host host of tested service
      * @param port port of tested service
-     * @param protocol of tested service
-     * @param path of the tested service
+     * @param protocol protocol of tested service
+     * @param path protocol of the tested service
      */
     public HttpTarget(final String protocol, final String host, final int port, final String path) {
+        this(protocol, host, port, path, false);
+    }
+
+    /**
+     *
+     * @param host host of tested service
+     * @param port port of tested service
+     * @param protocol protocol of the tested service
+     * @param path path of the tested service
+     * @param insecure true if certificates should be ignored
+     */
+    public HttpTarget(final String protocol, final String host, final int port, final String path, final boolean insecure){
         this.host = host;
         this.port = port;
         this.protocol = protocol;
         this.path = path;
+        this.insecure = insecure;
     }
 
     /**
-     * @param url of the tested service
+     * @param url url of the tested service
      */
     public HttpTarget(final URL url) {
+        this(url, false);
+    }
+
+    /**
+     *
+     * @param url url of the tested service
+     * @param insecure true if certificates should be ignored
+     */
+    public HttpTarget(final URL url, final boolean insecure) {
         this(url.getProtocol() == null ? "http" : url.getProtocol(),
                 url.getHost(),
                 url.getPort() == -1 ? 8080 : url.getPort(),
-                url.getPath() == null ? "/" : url.getPath());
+                url.getPath() == null ? "/" : url.getPath(),
+                insecure);
+
     }
 
     /**
@@ -167,6 +192,7 @@ public class HttpTarget implements TestClassAwareTarget {
       providerInfo.setHost(host);
       providerInfo.setProtocol(protocol);
       providerInfo.setPath(path);
+      providerInfo.setInsecure(insecure);
 
       if (testClass != null) {
         final List<FrameworkMethod> methods = testClass.getAnnotatedMethods(TargetRequestFilter.class);


### PR DESCRIPTION
Overloads constructors to allow HttpTarget to disable cert checking/hostname verification.
Implemented by overloading constructors, still secure by default.
Also updated some of constructor javadocs for consistency.

Fixes #273