### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactBuilder.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactBuilder.java
@@ -20,6 +20,10 @@ import au.com.dius.pact.model.v3.messaging.MessagePact;
  */
 public class MessagePactBuilder {
   /**
+   * String constant "Content-type".
+   */
+  private static final String CONTENT_TYPE = "Content-Type";
+  /**
    * The consumer for the pact.
    */
   private Consumer consumer;
@@ -117,9 +121,9 @@ public class MessagePactBuilder {
     Map<String, String> metadata = message.getMetaData();
     if (metadata == null) {
       metadata = new HashMap<String, String>(1);
-      metadata.put("Content-Type", ContentType.APPLICATION_JSON.toString());
-    } else if (!metadata.containsKey("Content-Type")) {
-      metadata.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+      metadata.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+    } else if (!metadata.containsKey(CONTENT_TYPE)) {
+      metadata.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
     }
 
     message.setContents(OptionalBody.body(body.toString()));

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerPactWithThriftMimeTypeTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerPactWithThriftMimeTypeTest.java
@@ -20,6 +20,7 @@ public class ConsumerPactWithThriftMimeTypeTest {
         "}}},\"6\":{\"str\":\"http://xxx.com/Users:ggloin:PortraitUrl?AWSAccessKeyId=aaaa&Expires=" +
         "2147483647&Signature=aaaa4%2B4%3D\"},\"7\":{\"str\":\"2014-02-01T13:22:52.585Z\"},\"8\":" +
         "{\"str\":\"1\"}}";
+    private static final String APPLICATION_X_THRIFT_JSON = "application/x-thrift+json";
 
     @Rule
     public PactProviderRule provider = new PactProviderRule("test_provider", "localhost", 8080, this);
@@ -27,7 +28,7 @@ public class ConsumerPactWithThriftMimeTypeTest {
     @Pact(provider="test_provider", consumer="test_consumer")
     public PactFragment createFragment(PactDslWithProvider builder) {
         Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Accept", "application/x-thrift+json");
+        headers.put("Accept", APPLICATION_X_THRIFT_JSON);
 
         return builder
             .given("test state")

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect215Test.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect215Test.java
@@ -21,6 +21,10 @@ public class Defect215Test {
 
   private static final String MY_SERVICE = "MY_service";
   private static final String EXPECTED_USER_ID = "abcdefghijklmnop";
+  private static final String CONTENT_TYPE = "Content-Type";
+  private static final String APPLICATION_JSON = "application/json.*";
+  private static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=UTF-8";
+  private static final String SOME_SERVICE_USER = "/some-service/user/";
   @Rule
   public PactProviderRule mockProvider = new PactProviderRule(MY_SERVICE, "localhost", PORT, this);
 
@@ -46,18 +50,18 @@ public class Defect215Test {
         .path("/some-service/users")
         .method("POST")
         .body(getUser())
-        .matchHeader("Content-Type", "application/json.*", "application/json; charset=UTF-8")
+        .matchHeader(CONTENT_TYPE, APPLICATION_JSON, APPLICATION_JSON_CHARSET_UTF_8)
       .willRespondWith()
         .status(201)
         .matchHeader("Location", "http(s)?://\\S+:\\d+//some-service/user/\\S{36}$")
       .given("An automation user with id: " + EXPECTED_USER_ID)
       .uponReceiving("existing user lookup")
-        .path("/some-service/user/" + EXPECTED_USER_ID)
+        .path(SOME_SERVICE_USER + EXPECTED_USER_ID)
         .method("GET")
-        .matchHeader("Content-Type", "application/json.*", "application/json; charset=UTF-8")
+        .matchHeader("Content-Type", "application/json.*", APPLICATION_JSON_CHARSET_UTF_8)
       .willRespondWith()
         .status(200)
-        .matchHeader("Content-Type", "application/json.*", "application/json; charset=UTF-8")
+        .matchHeader("Content-Type", "application/json.*", APPLICATION_JSON_CHARSET_UTF_8)
         .body(getUser())
       .toFragment();
   }
@@ -73,7 +77,7 @@ public class Defect215Test {
       .post("/some-service/users")
       .then()
       .statusCode(201)
-      .header("location", Matchers.containsString("/some-service/user/"));
+      .header("location", Matchers.containsString(SOME_SERVICE_USER));
 
     RestAssured.reset();
 
@@ -81,7 +85,7 @@ public class Defect215Test {
       .given()
       .port(mockProvider.getConfig().port())
       .contentType(ContentType.JSON)
-      .get("/some-service/user/" + EXPECTED_USER_ID)
+      .get(SOME_SERVICE_USER + EXPECTED_USER_ID)
       .then()
       .statusCode(200);
 

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect221Test.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect221Test.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 
 public class Defect221Test {
 
+    private static final String APPLICATION_JSON = "application/json";
     @Rule
     public PactProviderRule provider = new PactProviderRule("221_provider", "localhost", 8080, this);
 
@@ -23,10 +24,10 @@ public class Defect221Test {
             .uponReceiving("A request with double precision number")
                 .path("/numbertest")
                 .method("PUT")
-                .body("{\"name\": \"harry\",\"data\": 1234.0 }", "application/json")
+                .body("{\"name\": \"harry\",\"data\": 1234.0 }", APPLICATION_JSON)
             .willRespondWith()
                 .status(200)
-                .body("{\"responsetest\": true, \"name\": \"harry\",\"data\": 1234.0 }", "application/json")
+                .body("{\"responsetest\": true, \"name\": \"harry\",\"data\": 1234.0 }", APPLICATION_JSON)
             .toFragment();
     }
 
@@ -34,7 +35,7 @@ public class Defect221Test {
     @PactVerification("221_provider")
     public void runTest() throws IOException {
         assertEquals(Request.Put("http://localhost:8080/numbertest")
-            .addHeader("Accept", "application/json")
+            .addHeader("Accept", APPLICATION_JSON)
             .bodyString("{\"name\": \"harry\",\"data\": 1234.0 }", ContentType.APPLICATION_JSON)
             .execute().returnContent().asString(), "{\"responsetest\": true, \"name\": \"harry\",\"data\": 1234.0 }");
     }

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerClient.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerClient.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ConsumerClient{
+    private static final String TESTREQHEADER = "testreqheader";
+    private static final String TESTREQHEADERVALUE = "testreqheadervalue";
     private String url;
 
     public ConsumerClient(String url) {
@@ -36,7 +38,7 @@ public class ConsumerClient{
             uriBuilder.setParameters(parseQueryString(queryString));
         }
         return jsonToMap(Request.Get(uriBuilder.toString())
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .execute().returnContent().asString());
     }
 
@@ -52,13 +54,13 @@ public class ConsumerClient{
 
     public List getAsList(String path) throws IOException {
 		return jsonToList(Request.Get(url + encodePath(path))
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .execute().returnContent().asString());
 	}
 
     public Map post(String path, String body, ContentType mimeType) throws IOException {
         String respBody = Request.Post(url + encodePath(path))
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .bodyString(body, mimeType)
                 .execute().returnContent().asString();
         return jsonToMap(respBody);
@@ -74,7 +76,7 @@ public class ConsumerClient{
 
     public int options(String path) throws IOException {
         return Request.Options(url + encodePath(path))
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .execute().returnResponse().getStatusLine().getStatusCode();
     }
 
@@ -86,7 +88,7 @@ public class ConsumerClient{
 
     public Map putAsMap(String path, String body) throws IOException {
         String respBody = Request.Put(url + encodePath(path))
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .bodyString(body, ContentType.APPLICATION_JSON)
                 .execute().returnContent().asString();
         return jsonToMap(respBody);

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerHttpsClient.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerHttpsClient.java
@@ -20,7 +20,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ConsumerHttpsClient {
-  private String url;
+    private static final String TESTREQHEADERVALUE = "testreqheadervalue";
+    private static final String TESTREQHEADER = "testreqheader";
+    private String url;
 
   public ConsumerHttpsClient(String url) {
     this.url = url.replaceFirst("http:", "https:");
@@ -37,7 +39,7 @@ public class ConsumerHttpsClient {
           uriBuilder.setParameters(parseQueryString(queryString));
       }
       return jsonToMap(InsecureHttpsRequest.Get(uriBuilder.toString())
-              .addHeader("testreqheader", "testreqheadervalue")
+              .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
               .execute().returnContent().asString());
   }
 
@@ -53,13 +55,13 @@ public class ConsumerHttpsClient {
 
   public List getAsList(String path) throws IOException {
     return jsonToList(InsecureHttpsRequest.Get(url + encodePath(path))
-                .addHeader("testreqheader", "testreqheadervalue")
+                .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
                 .execute().returnContent().asString());
   }
 
   public Map post(String path, String body, ContentType mimeType) throws IOException {
       String respBody = InsecureHttpsRequest.Post(url + encodePath(path))
-              .addHeader("testreqheader", "testreqheadervalue")
+              .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
               .bodyString(body, mimeType)
               .execute().returnContent().asString();
       return jsonToMap(respBody);
@@ -75,7 +77,7 @@ public class ConsumerHttpsClient {
 
   public int options(String path) throws IOException {
       return InsecureHttpsRequest.Options(url + encodePath(path))
-              .addHeader("testreqheader", "testreqheadervalue")
+              .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
               .execute().returnResponse().getStatusLine().getStatusCode();
   }
 
@@ -87,7 +89,7 @@ public class ConsumerHttpsClient {
 
   public Map putAsMap(String path, String body) throws IOException {
       String respBody = InsecureHttpsRequest.Put(url + encodePath(path))
-              .addHeader("testreqheader", "testreqheadervalue")
+              .addHeader(TESTREQHEADER, TESTREQHEADERVALUE)
               .bodyString(body, ContentType.APPLICATION_JSON)
               .execute().returnContent().asString();
       return jsonToMap(respBody);

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/pactproviderrule/PactMultiProviderTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/pactproviderrule/PactMultiProviderTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 public class PactMultiProviderTest {
 
+    private static final String NAME_LARRY_JSON = "{\"name\": \"larry\"}";
     @Rule
     public PactProviderRule mockTestProvider = new PactProviderRule("test_provider", this);
 
@@ -58,7 +59,7 @@ public class PactMultiProviderTest {
                 .uponReceiving("PactProviderTest test interaction")
                 .path("/")
                 .method("PUT")
-                .body("{\"name\": \"larry\"}")
+                .body(NAME_LARRY_JSON)
                 .willRespondWith()
                 .status(200)
                 .body("{\"responsetest\": true, \"name\": \"larry\"}")
@@ -68,20 +69,20 @@ public class PactMultiProviderTest {
     @Test
     @PactVerification({"test_provider", "test_provider2"})
     public void allPass() throws IOException {
-        doTest("/", "{\"name\": \"larry\"}");
+        doTest("/", NAME_LARRY_JSON);
     }
 
     @Test(expected = RuntimeException.class)
     @PactVerification({"test_provider", "test_provider2"})
     public void consumerTestFails() throws IOException, InterruptedException {
-        doTest("/", "{\"name\": \"larry\"}");
+        doTest("/", NAME_LARRY_JSON);
         throw new RuntimeException("Oops");
     }
 
     @Test(expected = RuntimeException.class)
     @PactVerification(value = {"test_provider", "test_provider2"}, expectMismatch = true)
     public void provider1Fails() throws IOException, InterruptedException {
-        doTest("/abc", "{\"name\": \"larry\"}");
+        doTest("/abc", NAME_LARRY_JSON);
     }
 
     @Test(expected = RuntimeException.class)

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/DslPart.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/DslPart.java
@@ -10,6 +10,7 @@ public abstract class DslPart {
     public static final String HEXADECIMAL = "[0-9a-fA-F]+";
     public static final String IP_ADDRESS = "(\\d{1,3}\\.)+\\d{1,3}";
     public static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+    private static final String MATCH = "match";
 
     protected final DslPart parent;
     protected final String root;
@@ -172,7 +173,7 @@ public abstract class DslPart {
 
     protected Map<String, Object> matchType(String type) {
         Map<String, Object> jsonObject = new HashMap<String, Object>();
-        jsonObject.put("match", type);
+        jsonObject.put(MATCH, type);
         return jsonObject;
     }
 
@@ -203,14 +204,14 @@ public abstract class DslPart {
     protected Map<String, Object> matchMin(Integer min) {
         Map<String, Object> jsonObject = new HashMap<String, Object>();
         jsonObject.put("min", min);
-        jsonObject.put("match", "type");
+        jsonObject.put(MATCH, "type");
         return jsonObject;
     }
 
     protected Map<String, Object> matchMax(Integer max) {
         Map<String, Object> jsonObject = new HashMap<String, Object>();
         jsonObject.put("max", max);
-        jsonObject.put("match", "type");
+        jsonObject.put(MATCH, "type");
         return jsonObject;
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -17,6 +17,7 @@ import java.util.UUID;
  */
 public class PactDslJsonArray extends DslPart {
 
+    private static final String EXAMPLE = "Example \"";
     private final JSONArray body;
     private boolean wildCard;
     private int numberExamples = 1;
@@ -345,7 +346,7 @@ public class PactDslJsonArray extends DslPart {
      */
     public PactDslJsonArray stringMatcher(String regex, String value) {
         if (!value.matches(regex)) {
-            throw new InvalidMatcherException("Example \"" + value + "\" does not match regular expression \"" +
+            throw new InvalidMatcherException(EXAMPLE + value + "\" does not match regular expression \"" +
                 regex + "\"");
         }
         body.put(value);
@@ -543,7 +544,7 @@ public class PactDslJsonArray extends DslPart {
      */
     public PactDslJsonArray hexValue(String hexValue) {
         if (!hexValue.matches(HEXADECIMAL)) {
-            throw new InvalidMatcherException("Example \"" + hexValue + "\" is not a hexadecimal value");
+            throw new InvalidMatcherException(EXAMPLE + hexValue + "\" is not a hexadecimal value");
         }
         body.put(hexValue);
         matchers.put(root + appendArrayIndex(0), regexp("[0-9a-fA-F]+"));
@@ -582,7 +583,7 @@ public class PactDslJsonArray extends DslPart {
      */
     public PactDslJsonArray uuid(String uuid) {
         if (!uuid.matches(UUID_REGEX)) {
-            throw new InvalidMatcherException("Example \"" + uuid + "\" is not an UUID");
+            throw new InvalidMatcherException(EXAMPLE + uuid + "\" is not an UUID");
         }
         body.put(uuid);
         matchers.put(root + appendArrayIndex(0), regexp(UUID_REGEX));

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  */
 public class PactDslJsonBody extends DslPart {
 
+    private static final String EXAMPLE = "Example \"";
     private final JSONObject body;
 
     public PactDslJsonBody() {
@@ -255,7 +256,7 @@ public class PactDslJsonBody extends DslPart {
      */
     public PactDslJsonBody stringMatcher(String name, String regex, String value) {
         if (!value.matches(regex)) {
-            throw new InvalidMatcherException("Example \"" + value + "\" does not match regular expression \"" +
+            throw new InvalidMatcherException(EXAMPLE + value + "\" does not match regular expression \"" +
                 regex + "\"");
         }
         body.put(name, value);
@@ -709,7 +710,7 @@ public class PactDslJsonBody extends DslPart {
      */
     public PactDslJsonBody hexValue(String name, String hexValue) {
         if (!hexValue.matches(HEXADECIMAL)) {
-            throw new InvalidMatcherException("Example \"" + hexValue + "\" is not a hexadecimal value");
+            throw new InvalidMatcherException(EXAMPLE + hexValue + "\" is not a hexadecimal value");
         }
         body.put(name, hexValue);
         matchers.put(matcherKey(name), regexp("[0-9a-fA-F]+"));
@@ -772,7 +773,7 @@ public class PactDslJsonBody extends DslPart {
      */
     public PactDslJsonBody uuid(String name, String uuid) {
         if (!uuid.matches(UUID_REGEX)) {
-            throw new InvalidMatcherException("Example \"" + uuid + "\" is not an UUID");
+            throw new InvalidMatcherException(EXAMPLE + uuid + "\" is not an UUID");
         }
         body.put(name, uuid);
         matchers.put(matcherKey(name), regexp(UUID_REGEX));

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonRootValue.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonRootValue.java
@@ -13,6 +13,10 @@ import java.util.UUID;
 
 public class PactDslJsonRootValue extends DslPart {
 
+  private static final String USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS = "Use PactDslJsonArray for arrays";
+  private static final String USE_PACT_DSL_JSON_BODY_FOR_OBJECTS = "Use PactDslJsonBody for objects";
+  private static final String EXAMPLE = "Example \"";
+
   private Object value;
 
   public PactDslJsonRootValue() {
@@ -39,7 +43,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonArray array(String name) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -47,7 +51,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonArray array() {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -55,7 +59,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public DslPart closeArray() {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -63,7 +67,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody arrayLike(String name) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -71,7 +75,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody arrayLike() {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -79,7 +83,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody eachLike(String name) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -87,7 +91,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody eachLike(int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -95,7 +99,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody eachLike(String name, int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -103,7 +107,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody eachLike() {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -111,7 +115,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody minArrayLike(String name, Integer size) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -119,7 +123,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody minArrayLike(Integer size) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -127,7 +131,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody minArrayLike(String name, Integer size, int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -135,7 +139,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody minArrayLike(Integer size, int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -143,7 +147,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody maxArrayLike(String name, Integer size) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -151,7 +155,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody maxArrayLike(Integer size) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -159,7 +163,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody maxArrayLike(String name, Integer size, int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -167,7 +171,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody maxArrayLike(Integer size, int numberExamples) {
-    throw new UnsupportedOperationException("Use PactDslJsonArray for arrays");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_ARRAY_FOR_ARRAYS);
   }
 
   /**
@@ -175,7 +179,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody object(String name) {
-    throw new UnsupportedOperationException("Use PactDslJsonBody for objects");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_BODY_FOR_OBJECTS);
   }
 
   /**
@@ -183,7 +187,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public PactDslJsonBody object() {
-    throw new UnsupportedOperationException("Use PactDslJsonBody for objects");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_BODY_FOR_OBJECTS);
   }
 
   /**
@@ -191,7 +195,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   @Override
   public DslPart closeObject() {
-    throw new UnsupportedOperationException("Use PactDslJsonBody for objects");
+    throw new UnsupportedOperationException(USE_PACT_DSL_JSON_BODY_FOR_OBJECTS);
   }
 
   @Override
@@ -317,7 +321,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   public static PactDslJsonRootValue stringMatcher(String regex, String value) {
     if (!value.matches(regex)) {
-      throw new InvalidMatcherException("Example \"" + value + "\" does not match regular expression \"" +
+      throw new InvalidMatcherException(EXAMPLE + value + "\" does not match regular expression \"" +
         regex + "\"");
     }
     PactDslJsonRootValue rootValue = new PactDslJsonRootValue();
@@ -456,7 +460,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   public static PactDslJsonRootValue hexValue(String hexValue) {
     if (!hexValue.matches(HEXADECIMAL)) {
-      throw new InvalidMatcherException("Example \"" + hexValue + "\" is not a hexadecimal value");
+      throw new InvalidMatcherException(EXAMPLE + hexValue + "\" is not a hexadecimal value");
     }
     PactDslJsonRootValue value = new PactDslJsonRootValue();
     value.setValue(hexValue);
@@ -485,7 +489,7 @@ public class PactDslJsonRootValue extends DslPart {
    */
   public static PactDslJsonRootValue uuid(String uuid) {
     if (!uuid.matches(UUID_REGEX)) {
-      throw new InvalidMatcherException("Example \"" + uuid + "\" is not an UUID");
+      throw new InvalidMatcherException(EXAMPLE + uuid + "\" is not an UUID");
     }
 
     PactDslJsonRootValue value = new PactDslJsonRootValue();

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PactDslRequestWithPath {
+    private static final String CONTENT_TYPE = "Content-Type";
     private final ConsumerPactBuilder consumerPactBuilder;
 
     Consumer consumer;
@@ -112,7 +113,7 @@ public class PactDslRequestWithPath {
      */
     public PactDslRequestWithPath body(String body, String mimeType) {
         requestBody = OptionalBody.body(body);
-        requestHeaders.put("Content-Type", mimeType);
+        requestHeaders.put(CONTENT_TYPE, mimeType);
         return this;
     }
 
@@ -132,8 +133,8 @@ public class PactDslRequestWithPath {
      */
     public PactDslRequestWithPath body(JSONObject body) {
         requestBody = OptionalBody.body(body.toString());
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -149,8 +150,8 @@ public class PactDslRequestWithPath {
             requestMatchers.put("$.body" + matcherName, parent.matchers.get(matcherName));
         }
         requestBody = OptionalBody.body(parent.toString());
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -162,8 +163,8 @@ public class PactDslRequestWithPath {
      */
     public PactDslRequestWithPath body(Document body) throws TransformerException {
         requestBody = OptionalBody.body(ConsumerPactBuilder.xmlToString(body));
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_XML.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_XML.toString());
         }
         return this;
     }

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static au.com.dius.pact.consumer.ConsumerPactBuilder.xmlToString;
 
 public class PactDslRequestWithoutPath {
+    private static final String CONTENT_TYPE = "Content-Type";
     private final ConsumerPactBuilder consumerPactBuilder;
     private PactDslWithState pactDslWithState;
     private String description;
@@ -82,7 +83,7 @@ public class PactDslRequestWithoutPath {
      */
     public PactDslRequestWithoutPath body(String body, String mimeType) {
         requestBody = OptionalBody.body(body);
-        requestHeaders.put("Content-Type", mimeType);
+        requestHeaders.put(CONTENT_TYPE, mimeType);
         return this;
     }
 
@@ -102,8 +103,8 @@ public class PactDslRequestWithoutPath {
      */
     public PactDslRequestWithoutPath body(JSONObject body) {
         requestBody = OptionalBody.body(body.toString());
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -120,8 +121,8 @@ public class PactDslRequestWithoutPath {
             requestMatchers.put("$.body" + matcherName, parent.matchers.get(matcherName));
         }
         requestBody = OptionalBody.body(parent.toString());
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -133,8 +134,8 @@ public class PactDslRequestWithoutPath {
      */
     public PactDslRequestWithoutPath body(Document body) throws TransformerException {
         requestBody = OptionalBody.body(xmlToString(body));
-        if (!requestHeaders.containsKey("Content-Type")) {
-            requestHeaders.put("Content-Type", ContentType.APPLICATION_XML.toString());
+        if (!requestHeaders.containsKey(CONTENT_TYPE)) {
+            requestHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_XML.toString());
         }
         return this;
     }

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PactDslResponse {
+    private static final String CONTENT_TYPE = "Content-Type";
     private final ConsumerPactBuilder consumerPactBuilder;
     private PactDslRequestWithPath request;
 
@@ -68,7 +69,7 @@ public class PactDslResponse {
      */
     public PactDslResponse body(String body, String mimeType) {
         responseBody = OptionalBody.body(body);
-        responseHeaders.put("Content-Type", mimeType);
+        responseHeaders.put(CONTENT_TYPE, mimeType);
         return this;
     }
 
@@ -88,8 +89,8 @@ public class PactDslResponse {
      */
     public PactDslResponse body(JSONObject body) {
         this.responseBody = OptionalBody.body(body.toString());
-        if (!responseHeaders.containsKey("Content-Type")) {
-            responseHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!responseHeaders.containsKey(CONTENT_TYPE)) {
+            responseHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -111,8 +112,8 @@ public class PactDslResponse {
             responseBody = OptionalBody.nullBody();
         }
 
-        if (!responseHeaders.containsKey("Content-Type")) {
-            responseHeaders.put("Content-Type", ContentType.APPLICATION_JSON.toString());
+        if (!responseHeaders.containsKey(CONTENT_TYPE)) {
+            responseHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -124,8 +125,8 @@ public class PactDslResponse {
      */
     public PactDslResponse body(Document body) throws TransformerException {
         responseBody = OptionalBody.body(ConsumerPactBuilder.xmlToString(body));
-        if (!responseHeaders.containsKey("Content-Type")) {
-            responseHeaders.put("Content-Type", ContentType.APPLICATION_XML.toString());
+        if (!responseHeaders.containsKey(CONTENT_TYPE)) {
+            responseHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_XML.toString());
         }
         return this;
     }

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
@@ -19,20 +19,24 @@ import java.util.Map;
 
 public class MatchingTest {
     private static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
+    private static final String HARRY = "harry";
+    private static final String HELLO = "/hello";
+    private static final String TEST_CONSUMER = "test_consumer";
+    private static final String TEST_PROVIDER = "test_provider";
 
     @Test
     public void testRegexpMatchingOnBody() {
         PactDslJsonBody body = new PactDslJsonBody()
-            .stringMatcher("name", "\\w+", "harry")
+            .stringMatcher("name", "\\w+", HARRY)
             .stringMatcher("position", "staff|contactor");
 
         PactDslJsonBody responseBody = new PactDslJsonBody()
-            .stringMatcher("name", "\\w+", "harry");
+            .stringMatcher("name", "\\w+", HARRY);
 
         HashMap<String, String> expectedResponse = new HashMap<String, String>();
-        expectedResponse.put("name", "harry");
+        expectedResponse.put("name", HARRY);
         runTest(buildPactFragment(body, responseBody, "a test interaction that requires regex matching"),
-            "{\"name\": \"Arnold\", \"position\": \"staff\"}", expectedResponse, "/hello");
+            "{\"name\": \"Arnold\", \"position\": \"staff\"}", expectedResponse, HELLO);
     }
 
     @Test
@@ -63,14 +67,14 @@ public class MatchingTest {
                 .put("age2", 200)
                 .put("timestamp", DateFormatUtils.ISO_DATETIME_FORMAT.format(new Date()))
                 .toString(),
-            expectedResponse, "/hello");
+            expectedResponse, HELLO);
     }
 
     @Test
     public void testRegexpMatchingOnPath() {
         PactDslResponse fragment = ConsumerPactBuilder
-            .consumer("test_consumer")
-            .hasPactWith("test_provider")
+            .consumer(TEST_CONSUMER)
+            .hasPactWith(TEST_PROVIDER)
             .uponReceiving("a request to match on path")
             .matchPath("/hello/[0-9]{4}")
             .method("POST")
@@ -84,10 +88,10 @@ public class MatchingTest {
     @Test
     public void testRegexpMatchingOnHeaders() {
         PactDslResponse fragment = ConsumerPactBuilder
-                .consumer("test_consumer")
-                .hasPactWith("test_provider")
+                .consumer(TEST_CONSUMER)
+                .hasPactWith(TEST_PROVIDER)
                 .uponReceiving("a request to match on headers")
-                    .path("/hello")
+                    .path(HELLO)
                     .method("POST")
                     .matchHeader("testreqheader", "test.*value", "testreqheadervalue")
                 .body("{}", ContentType.APPLICATION_JSON)
@@ -95,7 +99,7 @@ public class MatchingTest {
                 .status(200)
                     .matchHeader("Location", ".*/hello/[0-9]+", "/hello/1234");
         Map expectedResponse = new HashMap();
-        runTest(fragment, "{}", expectedResponse, "/hello");
+        runTest(fragment, "{}", expectedResponse, HELLO);
     }
 
     private void runTest(PactDslResponse pactFragment, final String body, final Map expectedResponse, final String path) {
@@ -119,10 +123,10 @@ public class MatchingTest {
 
     private PactDslResponse buildPactFragment(PactDslJsonBody body, PactDslJsonBody responseBody, String description) {
         return ConsumerPactBuilder
-            .consumer("test_consumer")
-            .hasPactWith("test_provider")
+            .consumer(TEST_CONSUMER)
+            .hasPactWith(TEST_PROVIDER)
             .uponReceiving(description)
-                .path("/hello")
+                .path(HELLO)
                 .method("POST")
                 .body(body)
             .willRespondWith()

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -17,6 +17,16 @@ import static org.hamcrest.core.IsEqual.equalTo;
 
 public class PactDslJsonBodyTest {
 
+    private static final String NUMBERS = "numbers";
+    private static final String K_DEPRECIATION_BIPS = "10k-depreciation-bips";
+    private static final String FIRST = "first";
+    private static final String LEVEL_1 = "level1";
+    private static final String L_1_EXAMPLE = "l1example";
+    private static final String SECOND = "second";
+    private static final String LEVEL_2 = "level2";
+    private static final String L_2_EXAMPLE = "l2example";
+    private static final String THIRD = "@third";
+
     @Test
     public void guardAgainstObjectNamesThatDontConformToGatlingFields() {
         DslPart body = new PactDslJsonBody()
@@ -25,7 +35,7 @@ public class PactDslJsonBodyTest {
                 .id()
                 .stringValue("test", "A Test String")
             .closeObject()
-            .array("numbers")
+            .array(NUMBERS)
                 .id()
                 .number(100)
                 .numberValue(101)
@@ -35,7 +45,7 @@ public class PactDslJsonBodyTest {
                     .stringValue("name", "Rogger the Dogger")
                     .timestamp()
                     .date("dob", "MM/dd/yyyy")
-                    .object("10k-depreciation-bips")
+                    .object(K_DEPRECIATION_BIPS)
                         .id()
                     .closeObject()
                 .closeObject()
@@ -54,7 +64,7 @@ public class PactDslJsonBodyTest {
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
         assertThat(((JSONObject) body.getBody()).keySet(), is(equalTo((Set)
-                new HashSet(Arrays.asList("2", "numbers", "id")))));
+                new HashSet(Arrays.asList("2", NUMBERS, "id")))));
     }
 
     @Test
@@ -63,7 +73,7 @@ public class PactDslJsonBodyTest {
                 .id("1")
                 .stringType("@field")
                 .hexValue("200", "abc")
-                .integerType("10k-depreciation-bips");
+                .integerType(K_DEPRECIATION_BIPS);
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
                 "['200']", "['1']", "['@field']", "['10k-depreciation-bips']"
@@ -71,7 +81,7 @@ public class PactDslJsonBodyTest {
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
         assertThat(((JSONObject) body.getBody()).keySet(), is(equalTo((Set)
-                new HashSet(Arrays.asList("200", "10k-depreciation-bips", "1", "@field")))));
+                new HashSet(Arrays.asList("200", K_DEPRECIATION_BIPS, "1", "@field")))));
     }
 
     @Test
@@ -95,12 +105,12 @@ public class PactDslJsonBodyTest {
     @Test
     public void nestedObjectMatcherTest() {
         DslPart body = new PactDslJsonBody()
-                .object("first")
-                .stringType("level1", "l1example")
+                .object(FIRST)
+                .stringType(LEVEL_1, L_1_EXAMPLE)
                 .stringType("@level1")
-                .object("second")
-                .stringType("level2", "l2example")
-                .object("@third")
+                .object(SECOND)
+                .stringType(LEVEL_2, L_2_EXAMPLE)
+                .object(THIRD)
                 .stringType("level3", "l3example")
                 .object("fourth")
                 .stringType("level4", "l4example")
@@ -120,24 +130,24 @@ public class PactDslJsonBodyTest {
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getString("level1"), is(equalTo("l1example")));
+                .getJSONObject(FIRST)
+                .getString(LEVEL_1), is(equalTo(L_1_EXAMPLE)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONObject("second")
-                .getString("level2"), is(equalTo("l2example")));
+                .getJSONObject(FIRST)
+                .getJSONObject(SECOND)
+                .getString(LEVEL_2), is(equalTo(L_2_EXAMPLE)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONObject("second")
-                .getJSONObject("@third")
+                .getJSONObject(FIRST)
+                .getJSONObject(SECOND)
+                .getJSONObject(THIRD)
                 .getString("level3"), is(equalTo("l3example")));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONObject("second")
-                .getJSONObject("@third")
+                .getJSONObject(FIRST)
+                .getJSONObject(SECOND)
+                .getJSONObject(THIRD)
                 .getJSONObject("fourth")
                 .getString("level4"), is(equalTo("l4example")));
     }
@@ -145,10 +155,10 @@ public class PactDslJsonBodyTest {
     @Test
     public void nestedArrayMatcherTest() {
         DslPart body = new PactDslJsonBody()
-                .array("first")
-                .stringType("l1example")
+                .array(FIRST)
+                .stringType(L_1_EXAMPLE)
                 .array()
-                .stringType("l2example")
+                .stringType(L_2_EXAMPLE)
                 .closeArray()
                 .closeArray();
 
@@ -160,24 +170,24 @@ public class PactDslJsonBodyTest {
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONArray("first")
-                .getString(0), is(equalTo("l1example")));
+                .getJSONArray(FIRST)
+                .getString(0), is(equalTo(L_1_EXAMPLE)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONArray("first")
+                .getJSONArray(FIRST)
                 .getJSONArray(1)
-                .getString(0), is(equalTo("l2example")));
+                .getString(0), is(equalTo(L_2_EXAMPLE)));
     }
 
     @Test
     public void nestedArrayAndObjectMatcherTest() {
         DslPart body = new PactDslJsonBody()
-                .object("first")
-                .stringType("level1", "l1example")
-                .array("second")
+                .object(FIRST)
+                .stringType(LEVEL_1, L_1_EXAMPLE)
+                .array(SECOND)
                 .stringType("al2example")
                 .object()
-                .stringType("level2", "l2example")
+                .stringType(LEVEL_2, L_2_EXAMPLE)
                 .array("third")
                 .stringType("al3example")
                 .closeArray()
@@ -195,23 +205,23 @@ public class PactDslJsonBodyTest {
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getString("level1"), is(equalTo("l1example")));
+                .getJSONObject(FIRST)
+                .getString(LEVEL_1), is(equalTo(L_1_EXAMPLE)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONArray("second")
+                .getJSONObject(FIRST)
+                .getJSONArray(SECOND)
                 .getString(0), is(equalTo("al2example")));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONArray("second")
+                .getJSONObject(FIRST)
+                .getJSONArray(SECOND)
                 .getJSONObject(1)
-                .getString("level2"), is(equalTo("l2example")));
+                .getString(LEVEL_2), is(equalTo(L_2_EXAMPLE)));
 
         assertThat(((JSONObject)body.getBody())
-                .getJSONObject("first")
-                .getJSONArray("second")
+                .getJSONObject(FIRST)
+                .getJSONArray(SECOND)
                 .getJSONObject(1)
                 .getJSONArray("third")
                 .getString(0), is(equalTo("al3example")));
@@ -227,17 +237,17 @@ public class PactDslJsonBodyTest {
             .stringValue("test", null)
             .nullValue("nullValue")
           .closeObject()
-          .array("numbers")
+          .array(NUMBERS)
             .id()
             .nullValue()
             .stringValue(null)
           .closeArray();
 
         JSONObject jsonObject = (JSONObject) body.getBody();
-        assertThat(jsonObject.keySet(), is(equalTo((Set) new HashSet(Arrays.asList("2", "numbers", "id")))));
+        assertThat(jsonObject.keySet(), is(equalTo((Set) new HashSet(Arrays.asList("2", NUMBERS, "id")))));
 
         assertThat(jsonObject.getJSONObject("2").get("test"), is(JSONObject.NULL));
-        JSONArray numbers = jsonObject.getJSONArray("numbers");
+        JSONArray numbers = jsonObject.getJSONArray(NUMBERS);
         assertThat(numbers.length(), is(3));
         assertThat(numbers.get(0), is(notNullValue()));
         assertThat(numbers.get(1), is(JSONObject.NULL));

--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiOutputStream.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/AnsiOutputStream.java
@@ -86,6 +86,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 	private static final int SECOND_OSC_CHAR = ']';
 	private static final int BEL = 7;
 	private static final int SECOND_ST_CHAR = '\\';
+	private static final String UTF_8 = "UTF-8";
 	private final ArrayList<Object> options = new ArrayList<Object>();
 	int state = LOOKING_FOR_FIRST_ESC_CHAR;
 	private byte buffer[] = new byte[MAX_ESCAPE_SEQUENCE_LENGTH];
@@ -97,7 +98,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 
     static private byte[] resetCode() {
         try {
-            return new Ansi().reset().toString().getBytes("UTF-8");
+            return new Ansi().reset().toString().getBytes(UTF_8);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -147,7 +148,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_INT_ARG_END:
 			buffer[pos++] = (byte)data;
 			if( !('0' <= data && data <= '9') ) {
-				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				Integer value = new Integer(strValue);
 				options.add(value);
 				if( data == ';' ) {
@@ -161,7 +162,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_STR_ARG_END:
 			buffer[pos++] = (byte)data;
 			if( '"' != data ) {
-				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				options.add(value);
 				if( data == ';' ) {
 					state = LOOKING_FOR_NEXT_ARG;
@@ -184,7 +185,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_OSC_COMMAND_END:
 			buffer[pos++] = (byte)data;
 			if ( ';' == data ) {
-				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String strValue = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				Integer value = new Integer(strValue);
 				options.add(value);
 				startOfValue=pos;
@@ -200,7 +201,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_OSC_PARAM:
 			buffer[pos++] = (byte)data;
 			if ( BEL == data ) {
-				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-1)-startOfValue, UTF_8);
 				options.add(value);
 				reset( processOperatingSystemCommand(options) );
 			} else if ( FIRST_ESC_CHAR == data ) {
@@ -213,7 +214,7 @@ public class AnsiOutputStream extends FilterOutputStream {
 		case LOOKING_FOR_ST:
 			buffer[pos++] = (byte)data;
 			if ( SECOND_ST_CHAR == data ) {
-				String value = new String(buffer, startOfValue, (pos-2)-startOfValue, "UTF-8");
+				String value = new String(buffer, startOfValue, (pos-2)-startOfValue, UTF_8);
 				options.add(value);
 				reset( processOperatingSystemCommand(options) );
 			} else {

--- a/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/groovysupport/GroovyJavaUtils.java
+++ b/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/groovysupport/GroovyJavaUtils.java
@@ -9,29 +9,32 @@ import java.util.function.Supplier;
 
 public class GroovyJavaUtils {
 
+  private static final String WAS_CALLED = "was called";
+  private static final String JAVA_FUNCTION = "Java Function";
+
   private GroovyJavaUtils() {}
 
   public static Consumer<HttpRequest> consumerRequestFilter() {
-    return request -> request.addHeader("Java Consumer", "was called");
+    return request -> request.addHeader("Java Consumer", WAS_CALLED);
   }
 
   public static Function<HttpRequest, HttpRequest> functionRequestFilter() {
     return request -> {
-      request.addHeader("Java Function", "was called");
+      request.addHeader(JAVA_FUNCTION, WAS_CALLED);
       return request;
     };
   }
 
   public static BiFunction<HttpRequest, Object, HttpRequest> function2RequestFilter() {
     return (request, other) -> {
-      request.addHeader("Java Function", "was called");
+      request.addHeader(JAVA_FUNCTION, WAS_CALLED);
       return request;
     };
   }
 
   public static BiFunction<Object, HttpRequest, HttpRequest> function2RequestFilterWithParametersSwapped() {
     return (other, request) -> {
-      request.addHeader("Java Function", "was called");
+      request.addHeader(JAVA_FUNCTION, WAS_CALLED);
       return request;
     };
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 406 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava