### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
@@ -11,6 +11,8 @@ import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Date;
@@ -18,6 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class MatchingTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MatchingTest.class);
+
     private static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
 
     @Test
@@ -106,6 +110,7 @@ public class MatchingTest {
                 try {
                     Assert.assertEquals(new ConsumerClient(config.url()).post(path, body, ContentType.APPLICATION_JSON), expectedResponse);
                 } catch (IOException e) {
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         });

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MimeTypeTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MimeTypeTest.java
@@ -9,6 +9,8 @@ import au.com.dius.pact.model.PactSpecVersion;
 import org.apache.http.entity.ContentType;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -17,6 +19,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class MimeTypeTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MimeTypeTest.class);
 
     private static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
 
@@ -66,7 +70,9 @@ public class MimeTypeTest {
             public void run(MockProviderConfig config) {
                 try {
                     assertEquals(new ConsumerClient(config.url()).postBody("/hello", body, mimeType), expectedResponse);
-                } catch (IOException e) {}
+                } catch (IOException e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
             }
         });
 

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -14,6 +14,8 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.TestClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -48,6 +50,8 @@ import static java.util.stream.Collectors.toList;
  * all methods annotated by {@link State} with appropriate state listed will be invoked
  */
 public class PactRunner extends ParentRunner<InteractionRunner> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PactRunner.class);
+
     private final List<InteractionRunner> child;
 
     public PactRunner(final Class<?> clazz) throws InitializationError {
@@ -115,6 +119,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
                     contructorWithClass.setAccessible(true);
                     return contructorWithClass.newInstance(clazz.getJavaClass());
                 } catch(NoSuchMethodException e) {
+                    LOGGER.error(e.getMessage(), e);
                     return pactLoaderClass.newInstance();
                 }
             } else {
@@ -123,6 +128,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
                   .getConstructor(annotation.annotationType()).newInstance(annotation);
             }
         } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            LOGGER.error(e.getMessage(), e);
             throw new InitializationError("Error while creating pact source");
         }
     }

--- a/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/Ansi.java
+++ b/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/org/fusesource/jansi/Ansi.java
@@ -16,6 +16,9 @@
  */
 package au.com.dius.pact.provider.org.fusesource.jansi;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 
@@ -27,9 +30,11 @@ import java.util.concurrent.Callable;
  */
 public class Ansi {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Ansi.class);
+
     public static final String DISABLE = au.com.dius.pact.provider.org.fusesource.jansi.Ansi.class.getName() + ".disable";
     private static final char FIRST_ESC_CHAR = 27;
-	private static final char SECOND_ESC_CHAR = '[';;
+    private static final char SECOND_ESC_CHAR = '[';;
     private static Callable<Boolean> detector = new Callable<Boolean>() {
         public Boolean call() throws Exception {
             return !Boolean.getBoolean(DISABLE);
@@ -72,6 +77,7 @@ public class Ansi {
             return detector.call();
         }
         catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
             return true;
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava