### PR TITLE
squid:S00100 - Method names should comply with a naming convention

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerHttpsClient.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerHttpsClient.java
@@ -5,7 +5,6 @@ import com.google.common.net.UrlEscapers;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.fluent.InsecureHttpsRequest;
-import org.apache.http.client.fluent.Request;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicNameValuePair;
@@ -36,7 +35,7 @@ public class ConsumerHttpsClient {
       if (StringUtils.isNotEmpty(queryString)) {
           uriBuilder.setParameters(parseQueryString(queryString));
       }
-      return jsonToMap(InsecureHttpsRequest.Get(uriBuilder.toString())
+      return jsonToMap(InsecureHttpsRequest.get(uriBuilder.toString())
               .addHeader("testreqheader", "testreqheadervalue")
               .execute().returnContent().asString());
   }
@@ -52,13 +51,13 @@ public class ConsumerHttpsClient {
     }
 
   public List getAsList(String path) throws IOException {
-    return jsonToList(InsecureHttpsRequest.Get(url + encodePath(path))
+    return jsonToList(InsecureHttpsRequest.get(url + encodePath(path))
                 .addHeader("testreqheader", "testreqheadervalue")
                 .execute().returnContent().asString());
   }
 
   public Map post(String path, String body, ContentType mimeType) throws IOException {
-      String respBody = InsecureHttpsRequest.Post(url + encodePath(path))
+      String respBody = InsecureHttpsRequest.post(url + encodePath(path))
               .addHeader("testreqheader", "testreqheadervalue")
               .bodyString(body, mimeType)
               .execute().returnContent().asString();
@@ -74,19 +73,19 @@ public class ConsumerHttpsClient {
 	}
 
   public int options(String path) throws IOException {
-      return InsecureHttpsRequest.Options(url + encodePath(path))
+      return InsecureHttpsRequest.options(url + encodePath(path))
               .addHeader("testreqheader", "testreqheadervalue")
               .execute().returnResponse().getStatusLine().getStatusCode();
   }
 
   public String postBody(String path, String body, ContentType mimeType) throws IOException {
-      return InsecureHttpsRequest.Post(url + encodePath(path))
+      return InsecureHttpsRequest.post(url + encodePath(path))
           .bodyString(body, mimeType)
           .execute().returnContent().asString();
   }
 
   public Map putAsMap(String path, String body) throws IOException {
-      String respBody = InsecureHttpsRequest.Put(url + encodePath(path))
+      String respBody = InsecureHttpsRequest.put(url + encodePath(path))
               .addHeader("testreqheader", "testreqheadervalue")
               .bodyString(body, ContentType.APPLICATION_JSON)
               .execute().returnContent().asString();

--- a/pact-jvm-consumer-junit/src/test/java/org/apache/http/client/fluent/InsecureHttpsRequest.java
+++ b/pact-jvm-consumer-junit/src/test/java/org/apache/http/client/fluent/InsecureHttpsRequest.java
@@ -75,35 +75,35 @@ public class InsecureHttpsRequest extends Request {
     return new Response(internalExecute(httpclient, null));
   }
 
-  public static Request Options(final URI uri) {
+  public static Request options(final URI uri) {
     return new InsecureHttpsRequest(new InternalHttpRequest(HttpOptions.METHOD_NAME, uri));
   }
 
-  public static Request Options(final String uri) {
+  public static Request options(final String uri) {
     return new InsecureHttpsRequest(new InternalHttpRequest(HttpOptions.METHOD_NAME, URI.create(uri)));
   }
 
-  public static Request Post(final URI uri) {
+  public static Request post(final URI uri) {
     return new InsecureHttpsRequest(new InternalEntityEnclosingHttpRequest(HttpPost.METHOD_NAME, uri));
   }
 
-  public static Request Post(final String uri) {
+  public static Request post(final String uri) {
     return new InsecureHttpsRequest(new InternalEntityEnclosingHttpRequest(HttpPost.METHOD_NAME, URI.create(uri)));
   }
 
-  public static Request Put(final URI uri) {
+  public static Request put(final URI uri) {
     return new InsecureHttpsRequest(new InternalEntityEnclosingHttpRequest(HttpPut.METHOD_NAME, uri));
   }
 
-  public static Request Put(final String uri) {
+  public static Request put(final String uri) {
     return new InsecureHttpsRequest(new InternalEntityEnclosingHttpRequest(HttpPut.METHOD_NAME, URI.create(uri)));
   }
 
-  public static Request Get(final URI uri) {
+  public static Request get(final URI uri) {
     return new InsecureHttpsRequest(new InternalHttpRequest(HttpGet.METHOD_NAME, uri));
   }
 
-  public static Request Get(final String uri) {
+  public static Request get(final String uri) {
     return new InsecureHttpsRequest(new InternalHttpRequest(HttpGet.METHOD_NAME, URI.create(uri)));
   }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00100 - Method names should comply with a naming convention.
This pull request removes 40 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00100
Please let me know if you have any questions.
George Kankava