### PR TITLE
Better specs2 states support

### DIFF
--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
@@ -13,8 +13,8 @@ trait PactSpec extends FragmentsFactory {
 
   def uponReceiving(description: String) = {
     val pact = PactFragment.consumer(consumer).hasPactWith(provider)
-    if (providerState.isDefined) pact.given(providerState.get)
-    pact.uponReceiving(description)
+    if (providerState.isDefined) pact.given(providerState.get).uponReceiving(description)
+    else pact.uponReceiving(description)
   }
 
   implicit def liftFragmentBuilder(builder: PactWithAtLeastOneRequest): ReadyForTest = {

--- a/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/DifferentStatesPactSpec.scala
+++ b/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/DifferentStatesPactSpec.scala
@@ -3,6 +3,7 @@ package au.com.dius.pact.consumer.specs2
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import au.com.dius.pact.consumer.PactSpec
+import au.com.dius.pact.model.PactFragment
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -11,26 +12,34 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 @RunWith(classOf[JUnitRunner])
-class ExamplePactSpec extends Specification with PactSpec {
+class DifferentStatesPactSpec extends Specification with PactSpec {
 
   val consumer = "My Consumer"
   val provider = "My Provider"
-  override val providerState = Some("foo_state")
 
   val timeout = Duration(5000, MILLISECONDS)
 
-  override def is = uponReceiving("a request for foo")
+  override def is = PactFragment.consumer(consumer).hasPactWith(provider)
+    .given("foo_state")
+    .uponReceiving("a request for foo")
       .matching(path = "/foo")
       .willRespondWith(body = "{}")
-    .uponReceiving("an option request")
+    .given("bar_state")
+    .uponReceiving("an option request for bar")
       .matching(path = "/", method = "OPTION")
       .willRespondWith(headers = Map("Option" -> "Value-X"))
+    .given()
+    .uponReceiving("a stateless request for foobar")
+      .matching(path = "/foobar")
+      .willRespondWith(body = "{}")
     .withConsumerTest(providerConfig => {
       val optionsResult = ConsumerService(providerConfig.url).options("/")
       val simpleGet = ConsumerService(providerConfig.url).simpleGet("/foo")
+      val simpleStatelessGet = ConsumerService(providerConfig.url).simpleGet("/foobar")
       Await.result(optionsResult, timeout) must be_==(200, "",
         Map("Content-Length" -> "0", "Connection" -> "keep-alive", "Option" -> "Value-X")) and
-        (Await.result(simpleGet, timeout) must be_==(200, "{}"))
+        (Await.result(simpleGet, timeout) must be_==(200, "{}")) and
+        (Await.result(simpleStatelessGet, timeout) must be_==(200, "{}"))
     })
 
 }

--- a/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/PactFragmentBuilder.scala
+++ b/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/PactFragmentBuilder.scala
@@ -81,12 +81,26 @@ object PactFragmentBuilder {
   }
 
   case class PactWithAtLeastOneRequest(consumer: Consumer, provider:Provider, state: Option[String], interactions: Seq[RequestResponseInteraction]) {
+    def given() = {
+      InState(None, this)
+    }
+
+    def given(newState: String) = {
+      InState(Some(newState), this)
+    }
+
     def uponReceiving(description: String) = {
       DescribingRequest(consumer, provider, state, description, CanBuildPactFragment.additionalBuild(this))
     }
 
     def duringConsumerSpec[T](config: MockProviderConfig)(test: => T, verification: ConsumerTestVerification[T]): VerificationResult = {
       PactFragment(consumer, provider, interactions).duringConsumerSpec(config)(test, verification)
+    }
+
+    case class InState(newState: Option[String], pactWithAtLeastOneRequest: PactWithAtLeastOneRequest) {
+      def uponReceiving(description: String) = {
+        DescribingRequest(consumer, provider, newState, description, CanBuildPactFragment.additionalBuild(pactWithAtLeastOneRequest))
+      }
     }
   }
 


### PR DESCRIPTION
This PR:

- Adds support for switching between states for different provider requests.
- Fixes a bug where the value `providerState` in `PactSpec` was not applied.
