### PR TITLE
Add support for character class shortcuts in Xeger

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect215Test.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/Defect215Test.java
@@ -51,7 +51,7 @@ public class Defect215Test {
         .matchHeader(CONTENT_TYPE, APPLICATION_JSON, APPLICATION_JSON_CHARSET_UTF_8)
       .willRespondWith()
         .status(201)
-        .matchHeader("Location", "http(s)?://\\S+:\\d+//some-service/user/\\S{36}$")
+        .matchHeader("Location", "http(s)?://\\w+:\\d+//some-service/user/\\w{36}$")
       .given("An automation user with id: " + EXPECTED_USER_ID)
       .uponReceiving("existing user lookup")
         .path(SOME_SERVICE_USER + EXPECTED_USER_ID)

--- a/pact-jvm-consumer/src/main/java/nl/flotsam/xeger/Xeger.java
+++ b/pact-jvm-consumer/src/main/java/nl/flotsam/xeger/Xeger.java
@@ -20,8 +20,7 @@ import dk.brics.automaton.RegExp;
 import dk.brics.automaton.State;
 import dk.brics.automaton.Transition;
 
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 /**
  * An object that will generate text from a regular expression. In a way, it's the opposite of a regular expression
@@ -33,6 +32,24 @@ public class Xeger {
     private final Random random;
 
     /**
+     * The predefined character classes supported.
+     * <p>
+     * An immutable map containing as keys the character classes and values the equivalent regular expression syntax.
+     */
+    private static final Map<String, String> PREDEFINED_CHARACTER_CLASSES;
+
+    static {
+        Map<String, String> characterClasses = new HashMap<String, String>();
+        characterClasses.put("\\\\d", "[0-9]");
+        characterClasses.put("\\\\D", "[^0-9]");
+        characterClasses.put("\\\\s", "[ \t\n\f\r]");
+        characterClasses.put("\\\\S", "[^ \t\n\f\r]");
+        characterClasses.put("\\\\w", "[a-zA-Z_0-9]");
+        characterClasses.put("\\\\W", "[^a-zA-Z_0-9]");
+        PREDEFINED_CHARACTER_CLASSES = Collections.unmodifiableMap(characterClasses);
+    }
+
+    /**
      * Constructs a new instance, accepting the regular expression and the randomizer.
      *
      * @param regex  The regular expression. (Not <code>null</code>.)
@@ -42,7 +59,13 @@ public class Xeger {
     public Xeger(String regex, Random random) {
         assert regex != null;
         assert random != null;
-        this.automaton = new RegExp(regex).toAutomaton();
+
+        String finalRegex = regex;
+        for (Map.Entry<String, String> charClass : PREDEFINED_CHARACTER_CLASSES.entrySet()) {
+            finalRegex = finalRegex.replaceAll(charClass.getKey(), charClass.getValue());
+        }
+
+        this.automaton = new RegExp(finalRegex).toAutomaton();
         this.random = random;
     }
 

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MatchingTest.java
@@ -6,6 +6,7 @@ import au.com.dius.pact.model.MockProviderConfig;
 import au.com.dius.pact.model.MockProviderConfig$;
 import au.com.dius.pact.model.PactConfig;
 import au.com.dius.pact.model.PactSpecVersion;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
@@ -104,6 +105,17 @@ public class MatchingTest {
                     .matchHeader("Location", ".*/hello/[0-9]+", "/hello/1234");
         Map expectedResponse = new HashMap();
         runTest(fragment, "{}", expectedResponse, HELLO);
+    }
+
+    @Test
+    public void testRegexCharClassStringGenerator() {
+        PactDslJsonBody numeric = new PactDslJsonBody()
+                .stringMatcher("x", "\\d+");
+        Assert.assertTrue(NumberUtils.isNumber(new JSONObject(numeric.getBody().toString()).getString("x")));
+
+        PactDslJsonBody numericWithLimitedRep = new PactDslJsonBody()
+                .stringMatcher("x", "\\d{9}");
+        Assert.assertTrue(NumberUtils.isNumber(new JSONObject(numericWithLimitedRep.getBody().toString()).getString("x")));
     }
 
     private void runTest(PactDslResponse pactFragment, final String body, final Map expectedResponse, final String path) {


### PR DESCRIPTION
Fixes #288 

Code shamelessly copied from [Generex](https://github.com/mifmif/Generex/blob/master/src/main/java/com/mifmif/common/regex/Generex.java#L62-L71).

I've decided to just copy the relevant code from Generex, instead of introducing a new dependency in the Build. If you prefer otherwise, I have a branch for that which uses Generex instead of Xeger: https://github.com/alonpeer/pact-jvm/tree/alt-regex-gen

Also notice the last commit in this PR which deals with this issue I've found: https://github.com/mifmif/Generex/issues/26
This is reproducible with both Xeger and Generex. I couldn't find a way to resolve it so far. In any case, this has nothing to do with the character class shortcuts, which weren't supported correctly so far anyway.