### PR TITLE
Add scalatest ProviderSpec support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ httpBuilderVersion=0.7.1
 commonsLang3Version=3.3.2
 httpClientVersion=4.5.1
 specs2Version=3.8.4
+scalatestVersion=2.2.6

--- a/pact-jvm-provider-scalatest/README.md
+++ b/pact-jvm-provider-scalatest/README.md
@@ -1,0 +1,8 @@
+pact-jvm-provider-scalatest
+========================
+
+Provides an extension to scalatest to validate pact files against a running provider. See
+[examples](pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest)
+for details.
+
+*Note:* The Pact ProviderSpec requires scalatest 2.2.x

--- a/pact-jvm-provider-scalatest/build.gradle
+++ b/pact-jvm-provider-scalatest/build.gradle
@@ -1,0 +1,5 @@
+
+dependencies {
+    compile project(":pact-jvm-provider_${project.scalaVersion}"),
+      "org.scalatest:scalatest_${project.scalaVersion}:${project.scalatestVersion}"
+}

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderDsl.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderDsl.scala
@@ -1,0 +1,65 @@
+package au.com.dius.pact.provider.scalatest
+
+import java.net.URI
+
+import au.com.dius.pact.provider.ConsumerInfo
+
+/**
+  * DSL extension on top of the default verify method
+  */
+trait ProviderDsl {
+
+  case class Provider(provider: String) {
+    def complying(consumer: Consumer): PactBetween = PactBetween(provider, consumer)
+  }
+
+  case class PactBetween(provider: String, consumer: Consumer) {
+    def pacts(from: from): LocationHandler = LocationHandler(this, from.uri)
+  }
+
+  case class LocationHandler(pactBetween: PactBetween, uri: URI) {
+    def testing(serverStarter: ServerStarter): ServerHandler = ServerHandler(pactBetween, uri, serverStarter)
+  }
+
+  case class ServerHandler(pactBetween: PactBetween, uri: URI, serverStarter: ServerStarter) {
+    def withoutRestart() = VerificationConfig(Pact(pactBetween.provider, pactBetween.consumer, uri), ServerConfig(serverStarter))
+
+    def withRestart() = VerificationConfig(Pact(pactBetween.provider, pactBetween.consumer, uri), ServerConfig(serverStarter, true))
+  }
+
+  /**
+    * Support string provider in the DSL
+    *
+    * @param provider
+    * @return
+    */
+  implicit def strToProvider(provider: String) = Provider(provider)
+
+  /**
+    * Allows every pacts to be run against the provider
+    */
+  case object all extends Consumer {
+    override val filter = (consumerInfo: ConsumerInfo) => true
+  }
+
+  /**
+    * Defines the resource uri where the pacts can be found
+    *
+    * @param uri
+    */
+  case class from(uri: URI)
+
+  implicit def defaultPactDirectoryToUri(default: defaultPactDirectory.type): URI = stringToUri(default.directory)
+
+  implicit def stringToUri(default: String): URI = this.getClass.getClassLoader.getResource(default).toURI
+
+  /**
+    * pacts-dependents is the default directory for pacts
+    */
+  object defaultPactDirectory {
+    val directory = "pacts-dependents"
+  }
+
+}
+
+object ProviderDsl extends ProviderDsl

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderSpec.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.Executors
 import au.com.dius.pact.model
 import au.com.dius.pact.model.{FullResponseMatch, RequestResponseInteraction, ResponseMatching, Pact => PactForConsumer}
 import au.com.dius.pact.provider.sbtsupport.HttpClient
+import au.com.dius.pact.provider.scalatest.ProviderDsl.defaultPactDirectory
 import au.com.dius.pact.provider.scalatest.Tags.ProviderTest
 import au.com.dius.pact.provider.{ConsumerInfo, ProviderUtils, ProviderVerifier}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
@@ -85,26 +86,30 @@ trait ProviderSpec extends FlatSpec with BeforeAndAfterAll with ProviderDsl with
 }
 
 /**
-  * Convenient abstract class to run pacts from a given directory against a defined provider and all the consumer.
-  * Provider will be restarted and state will be set before every iteration.
+  * Convenient abstract class to run pacts from a given directory against a defined provider and consumer.
+  * Provider will be restarted and state will be set before every interaction.
+  *
   * @param provider
+  * @param directory
   * @param consumer
   */
-abstract class PactProviderRestartDslSpec(provider: String, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
+abstract class PactProviderRestartDslSpec(provider: String, directory: String = defaultPactDirectory.directory, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
   def serverStarter: ServerStarter
 
-  verify(provider complying consumer pacts from(defaultPactDirectory) testing (serverStarter) withRestart)
+  verify(provider complying consumer pacts from(directory) testing (serverStarter) withRestart)
 }
 
 /**
-  * Convenient abstract class to run pacts from a given directory against a defined provider and all the consumer.
-  * Provider won't be restarted just the state handler server method will be called before every iteration.
+  * Convenient abstract class to run pacts from a given directory against a defined provider and consumer.
+  * Provider won't be restarted just the state handler server method will be called before every interaction.
+  *
   * @param provider
+  * @param directory
   * @param consumer
   */
-abstract class PactProviderStatefulDslSpec(provider: String, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
+abstract class PactProviderStatefulDslSpec(provider: String, directory: String = defaultPactDirectory.directory, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
   def serverStarter: ServerStarter
 
-  verify(provider complying consumer pacts from(defaultPactDirectory) testing (serverStarter) withoutRestart)
+  verify(provider complying consumer pacts from(directory) testing (serverStarter) withoutRestart)
 }
 

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ProviderSpec.scala
@@ -1,0 +1,110 @@
+package au.com.dius.pact.provider.scalatest
+
+import java.io.File
+import java.net.URL
+import java.util.concurrent.Executors
+
+import au.com.dius.pact.model
+import au.com.dius.pact.model.{FullResponseMatch, RequestResponseInteraction, ResponseMatching, Pact => PactForConsumer}
+import au.com.dius.pact.provider.sbtsupport.HttpClient
+import au.com.dius.pact.provider.scalatest.Tags.ProviderTest
+import au.com.dius.pact.provider.{ConsumerInfo, ProviderUtils, ProviderVerifier}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+
+/**
+  * Trait to run consumer pacts against the provider
+  */
+trait ProviderSpec extends FlatSpec with BeforeAndAfterAll with ProviderDsl with Matchers {
+
+  private var handler: Option[ServerStarterWithUrl] = None
+
+  /**
+    * Verifies pacts with a given configuration.
+    * Every item will be run as a standalone {@link org.scalatest.FlatSpec}
+    *
+    * @param verificationConfig
+    */
+  def verify(verificationConfig: VerificationConfig): Unit = {
+
+    import verificationConfig.pact._
+    import verificationConfig.serverConfig._
+
+    val verifier = new ProviderVerifier
+    ProviderUtils.loadPactFiles(new model.Provider(provider), new File(uri)).asInstanceOf[java.util.List[ConsumerInfo]]
+      .filter(consumer.filter)
+      .flatMap(c => verifier.loadPactFileForConsumer(c).asInstanceOf[PactForConsumer].getInteractions.map(i => (c.getName, i.asInstanceOf[RequestResponseInteraction])))
+      .foreach { case (consumerName, interaction) =>
+        val description = new StringBuilder(s"${interaction.getDescription} for '$consumerName'")
+        if (interaction.getProviderState != null) description.append(s" given ${interaction.getProviderState}")
+        provider should description.toString() taggedAs ProviderTest in {
+          startServerWithState(serverStarter, interaction.getProviderState)
+          implicit val executionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+          val request = interaction.getRequest.copy
+          handler.foreach(h => request.setPath(s"${h.url.toString}${interaction.getRequest.getPath}"))
+          val actualResponseFuture = HttpClient.run(request)
+          val actualResponse = Await.result(actualResponseFuture, 5 seconds)
+          if (restartServer) stopServer()
+          ResponseMatching.matchRules(interaction.getResponse, actualResponse) shouldBe (FullResponseMatch)
+        }
+      }
+  }
+
+  override def afterAll() = {
+    super.afterAll()
+    stopServer()
+  }
+
+  private def startServerWithState(serverStarter: ServerStarter, state: String) {
+    handler = handler.orElse {
+      Some(ServerStarterWithUrl(serverStarter))
+    }.map { h =>
+      h.initState(state)
+      h
+    }
+  }
+
+  private def stopServer() {
+    handler.foreach { h =>
+      h.stopServer()
+      handler = None
+    }
+  }
+
+  private case class ServerStarterWithUrl(serverStarter: ServerStarter) {
+    val url: URL = serverStarter.startServer()
+
+    def initState(state: String) = serverStarter.initState(state)
+
+    def stopServer() = serverStarter.stopServer()
+  }
+
+}
+
+/**
+  * Convenient abstract class to run pacts from a given directory against a defined provider and all the consumer.
+  * Provider will be restarted and state will be set before every iteration.
+  * @param provider
+  * @param consumer
+  */
+abstract class PactProviderRestartDslSpec(provider: String, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
+  def serverStarter: ServerStarter
+
+  verify(provider complying consumer pacts from(defaultPactDirectory) testing (serverStarter) withRestart)
+}
+
+/**
+  * Convenient abstract class to run pacts from a given directory against a defined provider and all the consumer.
+  * Provider won't be restarted just the state handler server method will be called before every iteration.
+  * @param provider
+  * @param consumer
+  */
+abstract class PactProviderStatefulDslSpec(provider: String, consumer: Consumer = ProviderDsl.all) extends ProviderSpec {
+  def serverStarter: ServerStarter
+
+  verify(provider complying consumer pacts from(defaultPactDirectory) testing (serverStarter) withoutRestart)
+}
+

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ServerStarter.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/ServerStarter.scala
@@ -1,0 +1,29 @@
+package au.com.dius.pact.provider.scalatest
+
+import java.net.URL
+
+/**
+  * This trait provides a link between your server implementation and scalatest
+  */
+trait ServerStarter {
+
+  /**
+    * method to start the underlying server implementation
+    *
+    * @return URL for the server
+    */
+  def startServer(): URL
+
+  /**
+    * This method is called before each and every interaction test
+    *
+    * @param state is the 'provider_state' attribute from the pact
+    */
+  def initState(state: String): Unit
+
+
+  /**
+    * method to stop the underlying server implementation
+    */
+  def stopServer(): Unit
+}

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/Tags.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/Tags.scala
@@ -1,0 +1,12 @@
+package au.com.dius.pact.provider.scalatest
+
+import org.scalatest.Tag
+
+object Tags {
+
+  /**
+    * Provider pact tests are annotated with this tag by default. Can be excluded or included in the build process.
+    */
+  object ProviderTest extends Tag("au.com.dius.pact.provider.scalatest.Tags.ProviderTest")
+
+}

--- a/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/package.scala
+++ b/pact-jvm-provider-scalatest/src/main/scala/au/com/dius/pact/provider/scalatest/package.scala
@@ -1,0 +1,32 @@
+package au.com.dius.pact.provider
+
+import java.net.URI
+
+package object scalatest {
+
+  trait Consumer {
+    val filter: ConsumerInfo => Boolean
+  }
+
+  /**
+    * Matching consumer pacts will be allowed to run against the provider
+    *
+    * @param consumer
+    * @return
+    */
+  implicit def strToConsumer(consumer: String) = new Consumer {
+    override val filter = (consumerInfo: ConsumerInfo) => consumerInfo.getName == consumer
+  }
+
+  /**
+    * @param provider which provider pact should be tested
+    * @param consumer which consumer pact should be tested
+    * @param uri      where is the pact
+    */
+  case class Pact(provider: String, consumer: Consumer, uri: URI)
+
+  case class ServerConfig(serverStarter: ServerStarter, restartServer: Boolean = false)
+
+  case class VerificationConfig(pact: Pact, serverConfig: ServerConfig)
+
+}

--- a/pact-jvm-provider-scalatest/src/test/resources/pacts-dependents/test_provider-test_consumer.json
+++ b/pact-jvm-provider-scalatest/src/test/resources/pacts-dependents/test_provider-test_consumer.json
@@ -1,0 +1,31 @@
+{
+    "provider" : {
+        "name" : "test_provider"
+    },
+    "consumer" : {
+        "name" : "test_consumer"
+    },
+    "interactions" : [ {
+        "provider_state" : "state1",
+        "description" : "test interaction1",
+        "request" : {
+            "method" : "GET",
+            "path" : "/"
+        },
+        "response" : {
+            "status" : 200,
+            "body" : ["All Done state1"]
+        }
+    },{
+        "provider_state" : "state2",
+        "description" : "test interaction2",
+        "request" : {
+            "method" : "GET",
+            "path" : "/"
+        },
+        "response" : {
+            "status" : 200,
+            "body" : ["All Done state2"]
+        }
+    } ]
+}

--- a/pact-jvm-provider-scalatest/src/test/resources/pacts-dependents/test_provider-test_consumer2.json
+++ b/pact-jvm-provider-scalatest/src/test/resources/pacts-dependents/test_provider-test_consumer2.json
@@ -1,0 +1,31 @@
+{
+    "provider" : {
+        "name" : "test_provider"
+    },
+    "consumer" : {
+        "name" : "test_consumer2"
+    },
+    "interactions" : [ {
+        "provider_state" : "state1",
+        "description" : "test interaction1",
+        "request" : {
+            "method" : "GET",
+            "path" : "/"
+        },
+        "response" : {
+            "status" : 200,
+            "body" : ["All Done state1"]
+        }
+    },{
+        "provider_state" : "state2",
+        "description" : "test interaction2",
+        "request" : {
+            "method" : "GET",
+            "path" : "/"
+        },
+        "response" : {
+            "status" : 200,
+            "body" : ["All Done state2"]
+        }
+    } ]
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleConfigProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleConfigProviderSpec.scala
@@ -1,0 +1,13 @@
+package au.com.dius.pact.provider.scalatest
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ExampleConfigProviderSpec extends ProviderSpec {
+
+  /**
+    * Runs 'test_provider' pact verifications from 'pacts-dependents' directory with server restart just against 'test_consumer' pacts
+    */
+  verify(VerificationConfig(Pact(provider = "test_provider", consumer = "test_consumer", uri = "pacts-dependents"), ServerConfig(serverStarter = new ProviderServerStarter, restartServer = true)))
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleDslProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleDslProviderSpec.scala
@@ -1,0 +1,13 @@
+package au.com.dius.pact.provider.scalatest
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ExampleDslProviderSpec extends ProviderSpec {
+
+  /**
+    * Runs 'test_provider' pact verifications from default 'pacts-dependents' directory with server restart just against 'test_consumer2' pacts
+    */
+  verify("test_provider" complying "test_consumer2" pacts from(defaultPactDirectory) testing (new ProviderServerStarter) withRestart)
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleRestartProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleRestartProviderSpec.scala
@@ -1,0 +1,15 @@
+package au.com.dius.pact.provider.scalatest
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+/**
+  * Provider will be tested against all the defined consumers in the configured default directory.
+  * Before each and every interactions the tested provider will be restarted.
+  * A freshly started provider will be initialised with the state before verification take place.
+  */
+@RunWith(classOf[JUnitRunner])
+class ExampleRestartProviderSpec extends PactProviderRestartDslSpec("test_provider") {
+
+  lazy val serverStarter: ServerStarter = new ProviderServerStarter
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleStatefulProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleStatefulProviderSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.junit.JUnitRunner
 
 /**
   * Provider will be tested against all the defined consumers in the configured default directory.
-  * The provider is not restarted before a new interaction is tested.
+  * The provider won't be restarted during the test suite.
   * Every interactions tests a provider which was started at the very beginning of the suite.
   * State will be initialised before a new interaction is tested.
   */

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleStatefulProviderSpec.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ExampleStatefulProviderSpec.scala
@@ -1,0 +1,16 @@
+package au.com.dius.pact.provider.scalatest
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+/**
+  * Provider will be tested against all the defined consumers in the configured default directory.
+  * The provider is not restarted before a new interaction is tested.
+  * Every interactions tests a provider which was started at the very beginning of the suite.
+  * State will be initialised before a new interaction is tested.
+  */
+@RunWith(classOf[JUnitRunner])
+class ExampleStatefulProviderSpec extends PactProviderStatefulDslSpec("test_provider") {
+
+  lazy val serverStarter: ServerStarter = new ProviderServerStarter
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ProviderServerStarter.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/ProviderServerStarter.scala
@@ -1,0 +1,19 @@
+package au.com.dius.pact.provider.scalatest
+
+import java.net.URL
+
+class ProviderServerStarter extends ServerStarter {
+  var server: TestServer = _
+
+  override def startServer(): URL = {
+    server = new TestServer()
+    server.startServer()
+    server.url
+  }
+
+  override def initState(state: String): Unit = server.state = state
+
+  override def stopServer(): Unit = {
+    server.stopServer()
+  }
+}

--- a/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/TestServer.scala
+++ b/pact-jvm-provider-scalatest/src/test/scala/au/com/dius/pact/provider/scalatest/TestServer.scala
@@ -1,0 +1,37 @@
+package au.com.dius.pact.provider.scalatest
+
+import java.net.URL
+
+import au.com.dius.pact.model.{MockProviderConfig, PactConfig, PactSpecVersion}
+import unfiltered.netty.cycle.{Plan, SynchronousExecution}
+import unfiltered.netty.{Server, ServerErrorResponse}
+import unfiltered.response.ResponseString
+
+/**
+  * This is not really part of the example, it's just a fake server instead of building a real provider
+  */
+class TestServer {
+
+  private var server: Server = _
+  var url: URL = _
+  var state: String = _
+
+  def startServer(): Unit = {
+
+    val config = MockProviderConfig.createDefault(PactConfig(PactSpecVersion.V2))
+    val server = Server.http(config.port, config.hostname).handler(new Plan with SynchronousExecution with ServerErrorResponse {
+      def intent: Plan.Intent = {
+        case req => {
+          ResponseString(s"""["All Done $state"]""")
+        }
+      }
+    })
+
+    this.url = new URL(s"http://${config.hostname}:${config.port}")
+    this.server = server.start()
+  }
+
+  def stopServer() = server.stop()
+
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ def crossCompileModules = [
   'pact-jvm-model',
   'pact-jvm-provider',
   'pact-jvm-provider-specs2',
+  'pact-jvm-provider-scalatest',
   'pact-jvm-server',
   'pact-specification-test',
   'pact-jvm-provider-gradle',


### PR DESCRIPTION
Hi,
I have added a scalatest ProviderSpec support to be able to test pacts in scalatest. 
pact-jvm-provider-specs2 project was used as an example but this scalatest version has a bit wider DSL and functionality support.
Tests and documentation clearly explains how it works.
I hope you will like it. Feel free to comment or suggest.
Krisztian 