### PR TITLE
Add the $.body prefix to DslPart matchers

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactBuilder.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactBuilder.java
@@ -127,11 +127,7 @@ public class MessagePactBuilder {
     }
 
     message.setContents(OptionalBody.body(body.toString()));
-    Map<String, Map<String, Object>> matchingRules = new HashMap<String, Map<String, Object>>();
-    for (String matcherName : body.getMatchers().keySet()) {
-      matchingRules.put("$.body" + matcherName, body.getMatchers().get(matcherName));
-    }
-    message.setMatchingRules(matchingRules);
+    message.setMatchingRules(body.getMatchers());
 
     return this;
   }

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/DslPart.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/DslPart.java
@@ -160,7 +160,11 @@ public abstract class DslPart {
     public abstract DslPart closeObject();
 
     public Map<String, Map<String, Object>> getMatchers() {
-        return matchers;
+        Map<String, Map<String, Object>> matchersWithPrefix = new HashMap<String, Map<String, Object>>();
+        for (String matcherName : matchers.keySet()) {
+            matchersWithPrefix.put("$.body" + matcherName, matchers.get(matcherName));
+        }
+        return matchersWithPrefix;
     }
 
     public void setMatchers(Map<String, Map<String, Object>> matchers) {

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonArrayMatcherSpec.groovy
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonArrayMatcherSpec.groovy
@@ -50,10 +50,10 @@ class PactDslJsonArrayMatcherSpec extends Specification {
           [amount: 100, clearedDate: date.format('mm/dd/yyyy'), status: 'STATUS']
         ]
         subject.matchers == [
-          '': [min: 0, match: 'type'],
-          '[*].amount': [match: 'decimal'],
-          '[*].clearedDate': [date: 'mm/dd/yyyy'],
-          '[*].status': [match: 'type']
+          '$.body': [min: 0, match: 'type'],
+          '$.body[*].amount': [match: 'decimal'],
+          '$.body[*].clearedDate': [date: 'mm/dd/yyyy'],
+          '$.body[*].status': [match: 'type']
         ]
     }
 
@@ -71,10 +71,10 @@ class PactDslJsonArrayMatcherSpec extends Specification {
           [amount: 100, clearedDate: date.format('mm/dd/yyyy'), status: 'STATUS']
         ]
         subject.matchers == [
-          '': [min: 1, match: 'type'],
-          '[*].amount': [match: 'decimal'],
-          '[*].clearedDate': [date: 'mm/dd/yyyy'],
-          '[*].status': [match: 'type']
+          '$.body': [min: 1, match: 'type'],
+          '$.body[*].amount': [match: 'decimal'],
+          '$.body[*].clearedDate': [date: 'mm/dd/yyyy'],
+          '$.body[*].status': [match: 'type']
         ]
     }
 
@@ -92,10 +92,10 @@ class PactDslJsonArrayMatcherSpec extends Specification {
           [amount: 100, clearedDate: date.format('mm/dd/yyyy'), status: 'STATUS']
         ]
         subject.matchers == [
-          '': [max: 10, match: 'type'],
-          '[*].amount': [match: 'decimal'],
-          '[*].clearedDate': [date: 'mm/dd/yyyy'],
-          '[*].status': [match: 'type']
+          '$.body': [max: 10, match: 'type'],
+          '$.body[*].amount': [match: 'decimal'],
+          '$.body[*].clearedDate': [date: 'mm/dd/yyyy'],
+          '$.body[*].status': [match: 'type']
         ]
     }
 

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyMatcherSpec.groovy
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/PactDslJsonBodyMatcherSpec.groovy
@@ -104,10 +104,10 @@ class PactDslJsonBodyMatcherSpec extends Specification {
     result.keySet() == keys
     result.types == ['abc', 'abc']
     subject.matchers == [
-      '.types': [min: 0, match: 'type'],
-      '.subscriptionId': [match: 'type'],
-      '.types[*]': [match: 'type'],
-      '.preference': [match: 'type']
+      '$.body.types': [min: 0, match: 'type'],
+      '$.body.subscriptionId': [match: 'type'],
+      '$.body.types[*]': [match: 'type'],
+      '$.body.preference': [match: 'type']
     ]
   }
 
@@ -127,10 +127,10 @@ class PactDslJsonBodyMatcherSpec extends Specification {
     result.keySet() == keys
     result.types == ['abc', 'abc']
     subject.matchers == [
-      '.types': [min: 2, match: 'type'],
-      '.subscriptionId': [match: 'type'],
-      '.types[*]': [match: 'type'],
-      '.preference': [match: 'type']
+      '$.body.types': [min: 2, match: 'type'],
+      '$.body.subscriptionId': [match: 'type'],
+      '$.body.types[*]': [match: 'type'],
+      '$.body.preference': [match: 'type']
     ]
   }
 
@@ -150,10 +150,10 @@ class PactDslJsonBodyMatcherSpec extends Specification {
     result.keySet() == keys
     result.types == ['abc', 'abc']
     subject.matchers == [
-      '.types': [max: 10, match: 'type'],
-      '.subscriptionId': [match: 'type'],
-      '.types[*]': [match: 'type'],
-      '.preference': [match: 'type']
+      '$.body.types': [max: 10, match: 'type'],
+      '$.body.subscriptionId': [match: 'type'],
+      '$.body.types[*]': [match: 'type'],
+      '$.body.preference': [match: 'type']
     ]
   }
 }

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -52,14 +52,14 @@ public class PactDslJsonBodyTest {
             .closeArray();
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-                ".id",
-                "['2'].id",
-                ".numbers[3]",
-                ".numbers[0]",
-                ".numbers[4].timestamp",
-                ".numbers[4].dob",
-                ".numbers[4].id",
-                ".numbers[4]['10k-depreciation-bips'].id"
+                "$.body.id",
+                "$.body['2'].id",
+                "$.body.numbers[3]",
+                "$.body.numbers[0]",
+                "$.body.numbers[4].timestamp",
+                "$.body.numbers[4].dob",
+                "$.body.numbers[4].id",
+                "$.body.numbers[4]['10k-depreciation-bips'].id"
         ));
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
@@ -76,7 +76,7 @@ public class PactDslJsonBodyTest {
                 .integerType(K_DEPRECIATION_BIPS);
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-                "['200']", "['1']", "['@field']", "['10k-depreciation-bips']"
+                "$.body['200']", "$.body['1']", "$.body['@field']", "$.body['10k-depreciation-bips']"
         ));
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
@@ -93,8 +93,8 @@ public class PactDslJsonBodyTest {
                 .closeArray();
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-                ".ids",
-                ".ids[*].id"
+                "$.body.ids",
+                "$.body.ids[*].id"
         ));
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
 
@@ -120,11 +120,11 @@ public class PactDslJsonBodyTest {
                 .closeObject();
 
         Set<String> expectedMatchers = new HashSet<>(Arrays.asList(
-                ".first.second['@third'].fourth.level4",
-                ".first.second['@third'].level3",
-                ".first.second.level2",
-                ".first.level1",
-                ".first['@level1']"
+                "$.body.first.second['@third'].fourth.level4",
+                "$.body.first.second['@third'].level3",
+                "$.body.first.second.level2",
+                "$.body.first.level1",
+                "$.body.first['@level1']"
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
@@ -163,8 +163,8 @@ public class PactDslJsonBodyTest {
                 .closeArray();
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-                ".first[0]",
-                ".first[1][0]"
+                "$.body.first[0]",
+                "$.body.first[1][0]"
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));
@@ -196,10 +196,10 @@ public class PactDslJsonBodyTest {
                 .closeObject();
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-                ".first.level1",
-                ".first.second[1].level2",
-                ".first.second[0]",
-                ".first.second[1].third[0]"
+                "$.body.first.level1",
+                "$.body.first.second[1].level2",
+                "$.body.first.second[0]",
+                "$.body.first.second[1].third[0]"
         ));
 
         assertThat(body.getMatchers().keySet(), is(equalTo(expectedMatchers)));


### PR DESCRIPTION
Fixes #300 

I'm not entirely sure that this is the right solution. I had to alter some unit tests to make this pass, but perhaps I got it wrong, so please review this.

This change actually limits `DslPart` to only be used for creating matchers for `body`. Perhaps we need to generalize it so it can also be used for `header` and other HTTP parts (see [V2 specs](https://github.com/pact-foundation/pact-specification/tree/version-2#matcher-path-expressions)).