### PR TITLE
Fix error message shown when @Pact is used incorrectly

### DIFF
--- a/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactProviderRule.java
+++ b/pact-jvm-consumer-junit/src/main/java/au/com/dius/pact/consumer/MessagePactProviderRule.java
@@ -211,7 +211,7 @@ public class MessagePactProviderRule extends ExternalResource {
 
         if (!conforms && pact != null) {
             throw new UnsupportedOperationException("Method " + m.getName() +
-                " does not conform required method signature 'public PactFragment xxx(PactDslWithProvider builder)'");
+                " does not conform required method signature 'public MessagePact xxx(MessagePactBuilder builder)'");
         }
         return conforms;
     }


### PR DESCRIPTION
When a method annotated with @Pact doesn't have the correct method signature, an error message is shown.

This corrects the error message