### PR TITLE
Implementation of unit style specification for specs2, with only a single run of the mock provider

### DIFF
--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/UnitSpecsSupport.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/UnitSpecsSupport.scala
@@ -1,0 +1,26 @@
+package au.com.dius.pact.consumer
+
+import au.com.dius.pact.consumer.specs2.VerificationResultAsResult
+import au.com.dius.pact.model.{MockProviderConfig, PactFragment, PactSpecVersion}
+import org.specs2.mutable.Specification
+import org.specs2.specification.core.Fragments
+
+trait UnitSpecsSupport extends Specification {
+
+  def pactFragment: PactFragment
+
+  protected lazy val pact = pactFragment.toPact
+  protected val providerConfig = MockProviderConfig.createDefault(PactSpecVersion.V2)
+  protected val server = DefaultMockProvider(providerConfig)
+  protected val consumerPactRunner = new ConsumerPactRunner(server)
+
+  override def map(fragments: => Fragments) = {
+    step(server.start(pact)) ^
+      fragments ^
+      step(server.stop()) ^
+      fragmentFactory.example(
+        "Should match all mock server records",
+        VerificationResultAsResult(consumerPactRunner.writePact(pact, PactSpecVersion.V2))
+      )
+  }
+}

--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/specs2/VerificationResultAsResult.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/specs2/VerificationResultAsResult.scala
@@ -4,8 +4,9 @@ import au.com.dius.pact.consumer._
 import au.com.dius.pact.model.RequestResponseInteraction
 import org.specs2.execute._
 
-case class VerificationResultAsResult() extends AsResult[VerificationResult] {
-  override def asResult(t: => VerificationResult): Result = {
+object VerificationResultAsResult {
+
+  def apply(t: => VerificationResult): Result = {
     t match {
       case PactVerified => Success()
       case PactMismatch(results, error) => Failure(s"""

--- a/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/MultipleExamplesPactSpec.scala
+++ b/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/MultipleExamplesPactSpec.scala
@@ -3,54 +3,40 @@ package au.com.dius.pact.consumer.specs2
 import java.util.concurrent.TimeUnit._
 
 import au.com.dius.pact.consumer._
-import au.com.dius.pact.model.{MockProviderConfig, PactSpecVersion}
 import org.junit.runner.RunWith
-import org.specs2.execute.{AsResult, Result, Success}
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.AroundEach
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 @RunWith(classOf[JUnitRunner])
-class MultipleExamplesPactSpec extends Specification with PactSpec with AroundEach {
+class MultipleExamplesPactSpec extends Specification with PactSpec with UnitSpecsSupport {
   sequential
+
   override val provider: String = "SpecsProvider"
   override val consumer: String = "SpecsConsumer"
 
   val timeout = Duration(5000, MILLISECONDS)
 
-  val pact = uponReceiving("a request for foo")
+  override val pactFragment = uponReceiving("a request for foo")
     .matching(path = "/foo")
     .willRespondWith(maybeBody = Some("{}"))
     .uponReceiving("an option request")
     .matching(path = "/", method = "OPTION")
     .willRespondWith(headers = Map("Option" -> "Value-X"))
     .asPactFragment()
-  val providerConfig = MockProviderConfig.createDefault(PactSpecVersion.V2)
 
-  pact.description >> {
+  pactFragment.description >> {
     "GET returns a 200 status and empty body" >> {
       val simpleGet = ConsumerService(providerConfig.url).simpleGet("/foo")
-      val optionsResult = ConsumerService(providerConfig.url).options("/")
       Await.result(simpleGet, timeout) must be_==(200, "{}")
     }
 
     "OPTION returns a 200 status and the correct headers" >> {
-      val simpleGet = ConsumerService(providerConfig.url).simpleGet("/foo")
       val optionsResult = ConsumerService(providerConfig.url).options("/")
       Await.result(optionsResult, timeout) must be_==(200, "",
         Map("Content-Length" -> "0", "Connection" -> "keep-alive", "Option" -> "Value-X"))
     }
-
   }
-
-  def around[R: AsResult](r: => R): Result = {
-    VerificationResultAsResult().asResult(pact.duringConsumerSpec(providerConfig)(r, (u: R) => u match {
-      case Success => Some(u)
-      case _ => None
-    }))
-  }
-
 }

--- a/pact-jvm-consumer/src/main/scala/au/com/dius/pact/consumer/MockProvider.scala
+++ b/pact-jvm-consumer/src/main/scala/au/com/dius/pact/consumer/MockProvider.scala
@@ -8,7 +8,10 @@ import scala.util.Try
 trait MockProvider {
   def config: MockProviderConfig
   def session: PactSession
+  def start(pact: Pact): Unit
+  def run[T](code: => T): Try[T]
   def runAndClose[T](pact: Pact)(code: => T): Try[(T, PactSessionResults)]
+  def stop(): Unit
 }
 
 object DefaultMockProvider {
@@ -28,21 +31,29 @@ object DefaultMockProvider {
 abstract class StatefulMockProvider extends MockProvider with StrictLogging {
   private var sessionVar = PactSession.empty
   private var pactVar: Option[Pact] = None
-  
+
+  private def waitForRequestsToFinish() = Thread.sleep(100)
+
   def session: PactSession  = sessionVar
   def pact: Option[Pact] = pactVar
   
-  def stop(): Unit
   def start(): Unit
   
-  final def start(pact: Pact): Unit = synchronized {
+  override def start(pact: Pact): Unit = synchronized {
     pactVar = Some(pact)
     sessionVar = PactSession.forPact(pact)
     start()
   }
-  
+
+  override def run[T](code: => T): Try[T] = {
+    Try {
+      val codeResult = code
+      waitForRequestsToFinish()
+      codeResult
+    }
+  }
+
   override def runAndClose[T](pact: Pact)(code: => T): Try[(T, PactSessionResults)] = {
-    def waitForRequestsToFinish() = Thread.sleep(100)
     Try {
       try {
         start(pact)
@@ -54,7 +65,7 @@ abstract class StatefulMockProvider extends MockProvider with StrictLogging {
       }
     }
   }
-  
+
   final def handleRequest(req: Request): Response = synchronized {
     logger.debug("Received request: " + req)
     val (response, newSession) = session.receiveRequest(req)


### PR DESCRIPTION
By blending in `UnitSpecsSupport`, users can write unit style specs2 tests:

```
"some description" >> {
  // call mock provider
  // assert response
}
```