### PR TITLE
Issue #330 Implementing several minimal features in PactDsl

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -11,6 +11,7 @@ import org.w3c.dom.Document;
 
 import javax.xml.transform.TransformerException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class PactDslRequestWithPath {
@@ -73,6 +74,26 @@ public class PactDslRequestWithPath {
      */
     public PactDslRequestWithPath method(String method) {
         requestMethod = method;
+        return this;
+    }
+
+    /**
+     * Headers to be included in the request
+     *
+     * @param firstHeaderName      The name of the first header
+     * @param firstHeaderValue     The value of the first header
+     * @param headerNameValuePairs Additional headers in name-value pairs.
+     */
+    public PactDslRequestWithPath headers(String firstHeaderName, String firstHeaderValue, String... headerNameValuePairs) {
+        if (headerNameValuePairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Pair key value should be provided, but there is one key without value.");
+        }
+        requestHeaders.put(firstHeaderName, firstHeaderValue);
+
+        for (int i = 0; i < headerNameValuePairs.length; i+=2) {
+            requestHeaders.put(headerNameValuePairs[i], headerNameValuePairs[i+1]);
+        }
+
         return this;
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -178,6 +178,45 @@ public class PactDslRequestWithPath {
     }
 
     /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithPath bodyWithSingleQuotes(String body) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithPath bodyWithSingleQuotes(String body, String mimeType) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body, mimeType);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithPath bodyWithSingleQuotes(String body, ContentType mimeType) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body, mimeType);
+    }
+
+    /**
      * The body of the request
      *
      * @param body Request body in JSON form

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -11,8 +11,8 @@ import org.w3c.dom.Document;
 
 import javax.xml.transform.TransformerException;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class PactDslRequestWithPath {
     private static final String CONTENT_TYPE = "Content-Type";
@@ -144,6 +144,36 @@ public class PactDslRequestWithPath {
      * @param body Request body in string form
      */
     public PactDslRequestWithPath body(String body, ContentType mimeType) {
+        return body(body, mimeType.toString());
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithPath body(Supplier<String> body) {
+        requestBody = OptionalBody.body(body.get());
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithPath body(Supplier<String> body, String mimeType) {
+        requestBody = OptionalBody.body(body.get());
+        requestHeaders.put(CONTENT_TYPE, mimeType);
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithPath body(Supplier<String> body, ContentType mimeType) {
         return body(body, mimeType.toString());
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
@@ -3,13 +3,16 @@ package au.com.dius.pact.consumer.dsl;
 import au.com.dius.pact.consumer.ConsumerPactBuilder;
 import au.com.dius.pact.model.OptionalBody;
 import com.mifmif.common.regex.Generex;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
 import org.w3c.dom.Document;
 
 import javax.xml.transform.TransformerException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static au.com.dius.pact.consumer.ConsumerPactBuilder.xmlToString;
 
@@ -53,6 +56,26 @@ public class PactDslRequestWithoutPath {
      */
     public PactDslRequestWithoutPath headers(Map<String, String> headers) {
         requestHeaders = new HashMap<String, String>(headers);
+        return this;
+    }
+
+    /**
+     * Headers to be included in the request
+     *
+     * @param firstHeaderName      The name of the first header
+     * @param firstHeaderValue     The value of the first header
+     * @param headerNameValuePairs Additional headers in name-value pairs.
+     */
+    public PactDslRequestWithoutPath headers(String firstHeaderName, String firstHeaderValue, String... headerNameValuePairs) {
+        if (headerNameValuePairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Pair key value should be provided, but there is one key without value.");
+        }
+        requestHeaders.put(firstHeaderName, firstHeaderValue);
+
+        for (int i = 0; i < headerNameValuePairs.length; i+=2) {
+            requestHeaders.put(headerNameValuePairs[i], headerNameValuePairs[i+1]);
+        }
+
         return this;
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
@@ -12,6 +12,8 @@ import javax.xml.transform.TransformerException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static au.com.dius.pact.consumer.ConsumerPactBuilder.xmlToString;
@@ -116,6 +118,37 @@ public class PactDslRequestWithoutPath {
      * @param body Request body in string form
      */
     public PactDslRequestWithoutPath body(String body, ContentType mimeType) {
+        return body(body, mimeType.toString());
+    }
+
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithoutPath body(Supplier<String> body) {
+        requestBody = OptionalBody.body(body.get());
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithoutPath body(Supplier<String> body, String mimeType) {
+        requestBody = OptionalBody.body(body.get());
+        requestHeaders.put(CONTENT_TYPE, mimeType);
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Request body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslRequestWithoutPath body(Supplier<String> body, ContentType mimeType) {
         return body(body, mimeType.toString());
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithoutPath.java
@@ -153,6 +153,45 @@ public class PactDslRequestWithoutPath {
     }
 
     /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithoutPath bodyWithSingleQuotes(String body) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithoutPath bodyWithSingleQuotes(String body, String mimeType) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body, mimeType);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslRequestWithoutPath bodyWithSingleQuotes(String body, ContentType mimeType) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body, mimeType);
+    }
+
+    /**
      * The body of the request
      *
      * @param body Request body in JSON form

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -113,6 +113,43 @@ public class PactDslResponse {
         return body(body, mimeType.toString());
     }
 
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslResponse bodyWithSingleQuotes(String body) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslResponse bodyWithSingleQuotes(String body, String mimeType) {
+        if (body != null) {
+            body = QuoteUtil.convert(body);
+        }
+        return body(body, mimeType);
+    }
+
+    /**
+     * The body of the request with possible single quotes as delimiters
+     * and using {@link QuoteUtil} to convert single quotes to double quotes if required.
+     *
+     * @param body Request body in string form
+     */
+    public PactDslResponse bodyWithSingleQuotes(String body, ContentType mimeType) {
+        return body(body, mimeType.toString());
+    }
+
     /**
      * Response body to return
      *

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -16,6 +16,7 @@ import scala.collection.JavaConversions$;
 import javax.xml.transform.TransformerException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class PactDslResponse {
     private static final String CONTENT_TYPE = "Content-Type";
@@ -79,6 +80,36 @@ public class PactDslResponse {
      * @param body body in string form
      */
     public PactDslResponse body(String body, ContentType mimeType) {
+        return body(body, mimeType.toString());
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Response body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslResponse body(Supplier<String> body) {
+        responseBody = OptionalBody.body(body.get());
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Response body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslResponse body(Supplier<String> body, String mimeType) {
+        responseBody = OptionalBody.body(body.get());
+        responseHeaders.put(CONTENT_TYPE, mimeType);
+        return this;
+    }
+
+    /**
+     * The body of the request
+     *
+     * @param body Response body in Java Functional Interface Supplier that must return a string
+     */
+    public PactDslResponse body(Supplier<String> body, ContentType mimeType) {
         return body(body, mimeType.toString());
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/QuoteUtil.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/QuoteUtil.java
@@ -1,0 +1,48 @@
+package au.com.dius.pact.consumer.dsl;
+
+/**
+ * Util class for dealing with Json format
+ */
+public final class QuoteUtil {
+
+    private QuoteUtil() {
+        super();
+    }
+
+    /**
+     * Reads the input text with possible single quotes as delimiters
+     * and returns a String correctly formatted.
+     * <p>For convenience, single quotes as well as double quotes
+     * are allowed to delimit strings. If single quotes are
+     * used, any quotes, single or double, in the string must be
+     * escaped (prepend with a '\').
+     *
+     * @param text the input data
+     * @return String without single quotes
+     */
+    public static String convert(String text) {
+        StringBuilder builder = new StringBuilder();
+        boolean single_context = false;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '\\') {
+                i = i + 1;
+                if (i < text.length()) {
+                    ch = text.charAt(i);
+                    if (!(single_context && ch == '\'')) {
+                        // unescape ' inside single quotes
+                        builder.append('\\');
+                    }
+                }
+            } else if (ch == '\'') {
+                // Turn ' into ", for proper string
+                ch = '"';
+                single_context = ! single_context;
+            }
+            builder.append(ch);
+        }
+
+        return builder.toString();
+    }
+
+}

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/dsl/QuoteUtilTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/dsl/QuoteUtilTest.java
@@ -1,0 +1,21 @@
+package au.com.dius.pact.consumer.dsl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuoteUtilTest {
+
+    @Test
+    public void testSingleQuotes() {
+        final String converted = QuoteUtil.convert("{'name': 'Alex'}");
+        assertEquals("{\"name\": \"Alex\"}", converted);
+    }
+
+    @Test
+    public void testSkipDoubleQuotes() {
+        final String converted = QuoteUtil.convert("{\"name\": \"Alex\"}");
+        assertEquals("{\"name\": \"Alex\"}", converted);
+    }
+
+}


### PR DESCRIPTION
Implementing several minimal features in PactDsl.

- implements a `.headers(String... headers)` so instead of having to create a separate `Map`, you can do something like `.headers("content-type", "application/json")`

- implements a `.body(java.util.Consumer<>)` method. Now users can only use JSONObject, Document or String, but if we create a functional method then users wil be able to use lambda to for example transform Jackson POJO to String or JSR 364 JsonObject.

- implements a `toJson` method that allows users to set Json/xml as string using single quotes, so avoiding having to skip over and over again the (") char. https://github.com/arquillian-testing-microservices/game-service/blob/contract-tests/src/test/java/org/arquillian/microservices/gameservice/AgeCheckerConsumer.java#L82