### PR TITLE
JUnit Support for MessageContract

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ You want to look at: [pact-jvm-provider](pact-jvm-provider)
 
 As part of the V3 pact specification, we have defined a new pact file for interactions with message queues. The Gradle
 pact plugin supports a mechanism where you can verify V3 message pacts, have a look at [pact gradle plugin](pact-jvm-provider-gradle#verifying-a-message-provider).
+The JUnit pact library also supports verification of V3 message pacts, have a look at [pact-jvm-provider-junit](pact-jvm-provider-junit#verifying-a-message-provider).
 
 ### I Use Ruby or Go or something else
 The pact-jvm libraries are pure jvm technologies and do not have any native dependencies.

--- a/pact-jvm-provider-junit/README.md
+++ b/pact-jvm-provider-junit/README.md
@@ -18,7 +18,7 @@ each test of an interaction.
 - **au.com.dius.pact.provider.junit.State** custom annotation - before each interaction that requires a state change,
 all methods annotated by `@State` with appropriate the state listed will be invoked.
 
-## Example of test
+## Example of HTTP test
 
 ```java
     @RunWith(PactRunner.class) // Say JUnit to run tests with custom Runner
@@ -55,6 +55,47 @@ all methods annotated by `@State` with appropriate the state listed will be invo
 
         @TestTarget // Annotation denotes Target that will be used for tests
         public final Target target = new HttpTarget(8332); // Out-of-the-box implementation of Target (for more information take a look at Test Target section)
+    }
+```
+
+## Example of AMQP Message test
+
+```java
+    @RunWith(PactRunner.class) // Say JUnit to run tests with custom Runner
+    @Provider("myAwesomeService") // Set up name of tested provider
+    @PactBroker(host="pactbroker", port = "80") 
+    public class ConfirmationKafkaContractTest {
+
+        @TestTarget // Annotation denotes Target that will be used for tests
+        public final Target target = new AmqpTarget(); // Out-of-the-box implementation of Target (for more information take a look at Test Target section)
+
+        @BeforeClass //Method will be run once: before whole contract test suite
+        public static void setUpService() {
+            //Run DB, create schema
+            //Run service
+            //...
+        }
+
+        @Before //Method will be run before each test of interaction
+        public void before() {
+            // Message data preparation
+            // ...
+        }
+
+        @PactVerifyProvider('an order confirmation message')
+        String verifyMessageForOrder() {
+            Order order = new Order()
+            order.setId(10000004)
+            order.setPrice(BigDecimal.TEN)
+            order.setUnits(15)
+
+            def message = new ConfirmationKafkaMessageBuilder()
+              .withOrder(order)
+              .build()
+
+            JsonOutput.toJson(message)
+        }
+
     }
 ```
 
@@ -149,6 +190,11 @@ will be used for actual Interaction execution and asserting of contract.
 that will play pacts as http request and assert response from service by matching rules from pact.
 
 _Version 3.2.2/2.4.3+_ you can also specify the protocol, defaults to "http".
+
+### AmqpTarget
+
+`au.com.dius.pact.provider.junit.target.AmqpTarget` - out-of-the-box implementation of `au.com.dius.pact.provider.junit.target.Target`
+that will play pacts as an AMQP message and assert response from service by matching rules from pact.
 
 #### Modifying the requests before they are sent [Version 3.2.3/2.4.5+]
 

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -1,7 +1,6 @@
 package au.com.dius.pact.provider.junit;
 
 import au.com.dius.pact.model.Pact;
-import au.com.dius.pact.model.RequestResponsePact;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
 import au.com.dius.pact.provider.junit.loader.PactFolder;
 import au.com.dius.pact.provider.junit.loader.PactLoader;
@@ -83,7 +82,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         }
 
         for (final Pact pact : pacts) {
-            this.child.add(new InteractionRunner(testClass, (RequestResponsePact) pact));
+            this.child.add(new InteractionRunner(testClass, pact));
         }
     }
 

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/AmqpTarget.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/AmqpTarget.java
@@ -1,0 +1,93 @@
+package au.com.dius.pact.provider.junit.target;
+
+import au.com.dius.pact.model.Interaction;
+import au.com.dius.pact.provider.ConsumerInfo;
+import au.com.dius.pact.provider.PactVerification;
+import au.com.dius.pact.provider.ProviderInfo;
+import au.com.dius.pact.provider.ProviderVerifier;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit.loader.PactFolderLoader;
+import org.codehaus.groovy.runtime.MethodClosure;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Out-of-the-box implementation of {@link Target},
+ * that run {@link Interaction} against message pact and verify response
+ */
+public class AmqpTarget extends BaseTarget {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void testInteraction(final String consumerName, final Interaction interaction) {
+      ProviderInfo provider = getProviderInfo();
+      ConsumerInfo consumer = new ConsumerInfo(consumerName);
+      ProviderVerifier verifier = setupVerifier(interaction, provider, consumer);
+
+      Map<String, Object> failures = new HashMap<>();
+      failures = verifier.verifyProvider(provider);
+
+      try {
+        if (!failures.isEmpty()) {
+          verifier.displayFailures(failures);
+          throw getAssertionError(failures);
+        }
+      } finally {
+        verifier.finialiseReports();
+      }
+    }
+
+  ProviderVerifier setupVerifier(Interaction interaction, ProviderInfo provider,
+                                         ConsumerInfo consumer) {
+    ProviderVerifier verifier = new ProviderVerifier();
+    verifier.setProjectClasspath(new MethodClosure(this, "getClassPathUrls"));
+
+    setupReporters(verifier, provider.getName(), interaction.getDescription());
+
+    verifier.initialiseReporters(provider);
+    verifier.reportVerificationForConsumer(consumer, provider);
+
+    if (interaction.getProviderState() != null) {
+      verifier.reportStateForInteraction(interaction.getProviderState(), provider, consumer, true);
+    }
+
+    verifier.reportInteractionDescription(interaction);
+
+    return verifier;
+  }
+
+  private URL[] getClassPathUrls() {
+    return ((URLClassLoader)ClassLoader.getSystemClassLoader()).getURLs();
+  }
+
+  ProviderInfo getProviderInfo() {
+      Provider provider = testClass.getAnnotation(Provider.class);
+      final ProviderInfo providerInfo = new ProviderInfo(provider.value());
+      providerInfo.setVerificationType(PactVerification.ANNOTATED_METHOD);
+
+      PactBroker annotation = testClass.getAnnotation(PactBroker.class);
+      PactFolder folder = testClass.getAnnotation(PactFolder.class);
+      if(annotation != null && annotation.host() != null) {
+        List list = providerInfo.hasPactsFromPactBroker(annotation.protocol() + "://" + annotation.host() + (annotation.port() != null ? ":" + annotation.port() : ""));
+        providerInfo.setConsumers(list);
+      } else if (folder != null && folder.value() != null) {
+        try {
+          PactFolderLoader folderLoader = new PactFolderLoader(folder);
+          providerInfo.setConsumers(folderLoader.load(providerInfo.getName()).stream().map(pact -> new ConsumerInfo(pact.getConsumer().getName())).collect(Collectors.toList()));
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+
+    return providerInfo;
+  }
+}

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/BaseTarget.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/BaseTarget.java
@@ -1,0 +1,135 @@
+package au.com.dius.pact.provider.junit.target;
+
+import au.com.dius.pact.model.Interaction;
+import au.com.dius.pact.provider.ConsumerInfo;
+import au.com.dius.pact.provider.ProviderInfo;
+import au.com.dius.pact.provider.ProviderVerifier;
+import au.com.dius.pact.provider.junit.VerificationReports;
+import au.com.dius.pact.provider.junit.sysprops.SystemPropertyResolver;
+import au.com.dius.pact.provider.junit.sysprops.ValueResolver;
+import au.com.dius.pact.provider.reporters.ReporterManager;
+import au.com.dius.pact.provider.reporters.VerifierReporter;
+import org.apache.commons.lang3.StringUtils;
+import org.jooq.lambda.Seq;
+import org.jooq.lambda.tuple.Tuple2;
+import org.junit.runners.model.TestClass;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Out-of-the-box implementation of {@link Target},
+ * that run {@link Interaction} against message pact and verify response
+ */
+public abstract class BaseTarget implements TestClassAwareTarget {
+    protected TestClass testClass;
+  protected Object testTarget;
+  protected ValueResolver valueResolver = new SystemPropertyResolver();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public abstract void testInteraction(final String consumerName, final Interaction interaction);
+
+  abstract ProviderInfo getProviderInfo();
+
+  abstract ProviderVerifier setupVerifier(Interaction interaction, ProviderInfo provider,
+                                         ConsumerInfo consumer);
+
+  void setupReporters(ProviderVerifier verifier, String name, String description) {
+    String reportDirectory = "target/pact/reports";
+    String[] reports = new String[]{};
+    boolean reportingEnabled = false;
+
+    VerificationReports verificationReports = testClass.getAnnotation(VerificationReports.class);
+    if (verificationReports != null) {
+      reportingEnabled = true;
+      reportDirectory = verificationReports.reportDir();
+      reports = verificationReports.value();
+    } else if (valueResolver.propertyDefined("pact.verification.reports")) {
+      reportingEnabled = true;
+      reportDirectory = valueResolver.resolveValue("pact.verification.reportDir:" + reportDirectory);
+      reports = valueResolver.resolveValue("pact.verification.reports:").split(",");
+    }
+
+    if (reportingEnabled) {
+      File reportDir = new File(reportDirectory);
+      reportDir.mkdirs();
+      verifier.setReporters(Seq.of(reports)
+        .filter(r -> !r.isEmpty())
+        .map(r -> {
+          VerifierReporter reporter = ReporterManager.createReporter(r.trim());
+          reporter.setReportDir(reportDir);
+          reporter.setReportFile(new File(reportDir, name + " - " + description + reporter.getExt()));
+          return reporter;
+        }).toList());
+    }
+  }
+
+  AssertionError getAssertionError(final Map<String, Object> mismatches) {
+    String error = System.lineSeparator() + Seq.seq(mismatches.values()).zipWithIndex()
+      .map(i -> {
+        String errPrefix = String.valueOf(i.v2) + " - ";
+        if (i.v1 instanceof Throwable) {
+          return errPrefix + exceptionMessage((Throwable) i.v1, errPrefix.length());
+        } else if (i.v1 instanceof Map) {
+          return errPrefix + convertMapToErrorString((Map) i.v1);
+        } else {
+          return errPrefix + i.v1.toString();
+        }
+      }).toString(System.lineSeparator());
+    return new AssertionError(error);
+  }
+
+  private String exceptionMessage(Throwable err, int prefixLength) {
+    String message = err.getMessage();
+    if (message.contains("\n")) {
+      String padString = StringUtils.leftPad("", prefixLength);
+      Tuple2<Optional<String>, Seq<String>> lines = Seq.of(message.split("\n")).splitAtHead();
+      return lines.v1.orElse("") + System.lineSeparator() + lines.v2.map(line -> padString + line)
+        .toString(System.lineSeparator());
+    } else {
+      return message;
+    }
+  }
+
+  private String convertMapToErrorString(Map mismatches) {
+    if (mismatches.containsKey("comparison")) {
+      Object comparison = mismatches.get("comparison");
+      if (mismatches.containsKey("diff")) {
+        return mapToString((Map) comparison);
+      } else {
+        if (comparison instanceof Map) {
+          return mapToString((Map) comparison);
+        } else {
+          return String.valueOf(comparison);
+        }
+      }
+    } else {
+      return mapToString(mismatches);
+    }
+  }
+
+  private String mapToString(Map comparison) {
+    return comparison.entrySet().stream()
+      .map(e -> String.valueOf(((Map.Entry)e).getKey()) + " -> " + ((Map.Entry)e).getValue())
+      .collect(Collectors.joining(System.lineSeparator())).toString();
+  }
+
+  @Override
+  public void setTestClass(final TestClass testClass, final Object testTarget) {
+    this.testClass = testClass;
+    this.testTarget = testTarget;
+  }
+
+  public ValueResolver getValueResolver() {
+    return valueResolver;
+  }
+
+  public void setValueResolver(ValueResolver valueResolver) {
+    this.valueResolver = valueResolver;
+  }
+}

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/Target.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/Target.java
@@ -1,20 +1,20 @@
 package au.com.dius.pact.provider.junit.target;
 
-import au.com.dius.pact.model.RequestResponseInteraction;
+import au.com.dius.pact.model.Interaction;
 
 /**
- * Run {@link RequestResponseInteraction} and perform response verification
+ * Run {@link Interaction} and perform response verification
  *
  * @see HttpTarget out-of-the-box implementation
  */
 public interface Target {
     /**
-     * Run {@link RequestResponseInteraction} and perform response verification
+     * Run {@link Interaction} and perform response verification
      * <p>
      * Any exception will be caught by caller and reported as test failure
      *
      * @param consumer consumer name that generated the interaction
      * @param interaction interaction to be tested
      */
-    void testInteraction(String consumer, RequestResponseInteraction interaction);
+    void testInteraction(String consumer, Interaction interaction);
 }


### PR DESCRIPTION
I've added a new OOTB target for AMQP Messages and, in doing so, realized that it was very similar to the HttpTarget.  I abstracted a BaseTarget then implemented AmqpTarget. 

From there I replaced instances of RequestResponseInteraction with the interface Interaction in the InteractionRunner and the cast in PactRunner.  

I'm using JUnit across the board for HTTP and AMQP testing, and this works a treat the same basic pattern.