### PR TITLE
An alternative set of helpers for building a PactFragment in Unit Spec mode

### DIFF
--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/PactSpec.scala
@@ -1,7 +1,7 @@
 package au.com.dius.pact.consumer
 
 import au.com.dius.pact.model.PactFragmentBuilder.PactWithAtLeastOneRequest
-import au.com.dius.pact.model.{MockProviderConfig, PactFragment, PactSpecVersion}
+import au.com.dius.pact.model._
 import org.specs2.execute.{AsResult, Failure, Result, Success}
 import org.specs2.specification.create.FragmentsFactory
 
@@ -46,14 +46,13 @@ trait PactSpec extends FragmentsFactory {
     }
   }
 
-  case class ConsumerTestFailed(r:Result) extends RuntimeException
+  case class ConsumerTestFailed(r: Result) extends RuntimeException
 
   def verify: ConsumerTestVerification[Result] = { r: Result =>
-    if(r.isSuccess) {
+    if (r.isSuccess) {
       None
     } else {
       Some(r)
     }
   }
-
 }

--- a/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/UnitSpecsSupport.scala
+++ b/pact-jvm-consumer-specs2/src/main/scala/au/com/dius/pact/consumer/UnitSpecsSupport.scala
@@ -1,9 +1,12 @@
 package au.com.dius.pact.consumer
 
+import au.com.dius.pact.consumer.dsl.DslPart
 import au.com.dius.pact.consumer.specs2.VerificationResultAsResult
-import au.com.dius.pact.model.{MockProviderConfig, PactFragment, PactSpecVersion}
+import au.com.dius.pact.model._
 import org.specs2.mutable.Specification
 import org.specs2.specification.core.Fragments
+
+import scala.collection.JavaConverters._
 
 trait UnitSpecsSupport extends Specification {
 
@@ -23,4 +26,35 @@ trait UnitSpecsSupport extends Specification {
         VerificationResultAsResult(consumerPactRunner.writePact(pact, PactSpecVersion.V2))
       )
   }
+
+  def buildRequest(path: String,
+                   method: String = "GET",
+                   query: String = "",
+                   headers: Map[String, String] = Map(),
+                   body: String = "",
+                   matchers: Map[String, Map[String, String]] = Map()): Request =
+    new Request(method, path, PactReader.queryStringToMap(query), headers.asJava, OptionalBody.body(body), CollectionUtils.scalaMMapToJavaMMap(matchers))
+
+  def buildResponse(status: Int = 200,
+                    headers: Map[String, String] = Map(),
+                    maybeBody: Option[String] = None,
+                    matchers: Map[String, Map[String, String]] = Map()): Response = {
+    val optionalBody = maybeBody match {
+      case Some(body) => OptionalBody.body(body)
+      case None => OptionalBody.missing()
+    }
+
+    new Response(status, headers.asJava, optionalBody, CollectionUtils.scalaMMapToJavaMMap(matchers))
+  }
+
+  def buildResponse(status: Int,
+                    headers: Map[String, String],
+                    bodyAndMatchers: DslPart): Response =
+    new Response(status, headers.asJava, OptionalBody.body(bodyAndMatchers.toString), bodyAndMatchers.getMatchers)
+
+  def buildInteraction(description: String, maybeState: Option[String], request: Request, response: Response): RequestResponseInteraction =
+    new RequestResponseInteraction(description, maybeState.orNull, request, response)
+
+  def buildPactFragment(consumer: String, provider: String, interactions: List[RequestResponseInteraction]): PactFragment =
+    new PactFragment(new Consumer(consumer), new Provider(provider), interactions)
 }

--- a/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/AltPactWithUnitSupportSpec.scala
+++ b/pact-jvm-consumer-specs2/src/test/scala/au/com/dius/pact/consumer/specs2/AltPactWithUnitSupportSpec.scala
@@ -1,0 +1,48 @@
+package au.com.dius.pact.consumer.specs2
+
+import java.util.concurrent.TimeUnit._
+
+import au.com.dius.pact.consumer._
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+@RunWith(classOf[JUnitRunner])
+class AltPactWithUnitSupportSpec extends Specification with PactSpec with UnitSpecsSupport {
+  sequential
+
+  override val provider: String = "AltSpecsProvider"
+  override val consumer: String = "AltSpecsConsumer"
+
+  val timeout = Duration(5000, MILLISECONDS)
+
+  val fooRequest = buildRequest(path = "/foo")
+  val fooResponse = buildResponse(maybeBody = Some("{}"))
+  val optionRequest = buildRequest(path = "/", method = "OPTION")
+  val optionResponse = buildResponse(headers = Map("Option" -> "Value-X"))
+
+  override val pactFragment = buildPactFragment(
+    consumer = consumer,
+    provider = provider,
+    interactions = List(
+      buildInteraction("a request for foo", None, fooRequest, fooResponse),
+      buildInteraction("an option request", None, optionRequest, optionResponse)
+    )
+  )
+
+  pactFragment.description >> {
+    "GET returns a 200 status and empty body" >> {
+      val simpleGet = ConsumerService(providerConfig.url).simpleGet("/foo")
+      Await.result(simpleGet, timeout) must be_==(200, "{}")
+    }
+
+    "OPTION returns a 200 status and the correct headers" >> {
+      val optionsResult = ConsumerService(providerConfig.url).options("/")
+      Await.result(optionsResult, timeout) must be_==(200, "",
+        Map("Content-Length" -> "0", "Connection" -> "keep-alive", "Option" -> "Value-X"))
+    }
+  }
+}


### PR DESCRIPTION
This is an alternative method for building a `PactFragment` when writing specs in Unit Spec mode.
We find this method useful in my team when the provider has many endpoints with which the consumer interacts, in which case the other method of defining the `PactFragment` generates a very unreadable code. Using this method, we can divide our code into smaller pieces and merge them all together in a more readable manner.