### PR TITLE
Add short 'pact' prefix to maven plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ jsonVersion=20160212
 cglibVersion=3.2.4
 jacksonDatabindVersion=2.8.1
 nettyVersion=4.0.40.Final
+mavenPluginPluginVersion=3.5

--- a/pact-jvm-provider-maven/README.md
+++ b/pact-jvm-provider-maven/README.md
@@ -58,7 +58,7 @@ You define all the providers and consumers within the configuration element of t
 </plugin>
 ```
 
-### 3. Execute `mvn au.com.dius:pact-jvm-provider-maven_2.11:verify`
+### 3. Execute `mvn pact:verify`
 
 You will have to have your provider running for this to pass.
 
@@ -450,7 +450,7 @@ For example:
     </configuration>
 </plugin>
 ```
-You can now execute `mvn au.com.dius:pact-jvm-provider-maven_2.11:publish` to publish the pact files.
+You can now execute `mvn pact:publish` to publish the pact files.
 
 _NOTE:_ The pact broker requires a version for all published pacts. The `publish` task will use the version of the
 project by default, but can be overwritten with the `projectVersion` property. Make sure you have set one otherwise the broker will reject the pact files.

--- a/pact-jvm-provider-maven/build.gradle
+++ b/pact-jvm-provider-maven/build.gradle
@@ -31,6 +31,12 @@ task pluginDescriptor(type: Exec, dependsOn: [":pact-jvm-provider_${project.scal
             def buildNode = asNode().appendNode('build')
             buildNode.appendNode('directory', buildDir)
             buildNode.appendNode('outputDirectory', "$buildDir/classes/main")
+            //add and configure the maven-plugin-plugin so that we can use the shortened 'pact' prefix
+            //https://maven.apache.org/guides/introduction/introduction-to-plugin-prefix-mapping.html
+            def pluginNode = buildNode.appendNode('plugins').appendNode('plugin')
+            pluginNode.appendNode('artifactId', 'maven-plugin-plugin')
+            pluginNode.appendNode('version', project.mavenPluginPluginVersion)
+            pluginNode.appendNode('configuration').appendNode('goalPrefix', 'pact')
         }
         pom.writeTo( pomFile )
     }


### PR DESCRIPTION
Updated pom to enable usage of shorter `pact` prefix using instructions here:
https://maven.apache.org/guides/introduction/introduction-to-plugin-prefix-mapping.html

shortens 
`mvn au.com.dius:pact-jvm-provider-maven_2.11:verify`
to
`mvn pact:verify`