### PR TITLE
Making state comparison case-insensitive

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/InteractionRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/InteractionRunner.java
@@ -193,8 +193,11 @@ class InteractionRunner extends Runner {
             final String state = interaction.getProviderState();
             final List<FrameworkMethod> onStateChange = new ArrayList<FrameworkMethod>();
             for (FrameworkMethod ann: testClass.getAnnotatedMethods(State.class)) {
-                if (ArrayUtils.contains(ann.getAnnotation(State.class).value(), state)) {
+                for(String annotationState : ann.getAnnotation(State.class).value()) {
+                  if(annotationState.equalsIgnoreCase(state)) {
                     onStateChange.add(ann);
+                    break;
+                  }
                 }
             }
             if (onStateChange.isEmpty()) {


### PR DESCRIPTION
Sometimes consumers use different casing for their provider states which causes problems when the provider tries to run its pact tests because it performs a case-sensitive comparison when determining which method annotated with @State corresponds to the pact.

This problem is magnified when using the Pact Broker since the it changes the casing of the provider state when it renders the pact through the web ui. If a developer writes provider contract tests based on the provider state they see on the Pact Broker, the casing may end up not matching the casing of the actual pact. 

It took me a while to troubleshoot the cause and I think this PR can help some folks.