### PR TITLE
Moved getting provider and consumer names to seperate method

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -132,7 +132,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         return consumerInfo != null ? consumerInfo.value() : null;
     }
 
-    private String getProviderName(Class<?> clazz) throws InitializationError {
+    protected String getProviderName(Class<?> clazz) throws InitializationError {
         final Provider providerInfo = clazz.getAnnotation(Provider.class);
 
         if (providerInfo == null) {

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -62,8 +62,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         }
         final String serviceName = providerInfo.value();
 
-        final Consumer consumerInfo = clazz.getAnnotation(Consumer.class);
-        final String consumerName = consumerInfo != null ? consumerInfo.value() : null;
+        final String consumerName = getConsumerName(clazz);
 
         final TestClass testClass = new TestClass(clazz);
 
@@ -130,5 +129,10 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
             LOGGER.error("Error while creating pact source", e);
             throw new InitializationError(e);
         }
+    }
+
+    protected String getConsumerName(final Class<?> clazz) {
+        final Consumer consumerInfo = clazz.getAnnotation(Consumer.class);
+        return consumerInfo != null ? consumerInfo.value() : null;
     }
 }

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -56,11 +56,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
     public PactRunner(final Class<?> clazz) throws InitializationError {
         super(clazz);
 
-        final Provider providerInfo = clazz.getAnnotation(Provider.class);
-        if (providerInfo == null) {
-            throw new InitializationError("Provider name should be specified by using " + Provider.class.getName() + " annotation");
-        }
-        final String serviceName = providerInfo.value();
+        final String providerName = getProviderName(clazz);
 
         final String consumerName = getConsumerName(clazz);
 
@@ -69,7 +65,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         this.child = new ArrayList<>();
         final List<Pact> pacts;
         try {
-            pacts = getPactSource(testClass).load(serviceName).stream()
+            pacts = getPactSource(testClass).load(providerName).stream()
                   .filter(p -> consumerName == null || p.getConsumer().getName().equals(consumerName))
                   .collect(Collectors.toList());
         } catch (final IOException e) {
@@ -77,7 +73,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         }
 
         if (pacts == null || pacts.isEmpty()) {
-          throw new InitializationError("Did not find any pact files for provider " + providerInfo.value());
+          throw new InitializationError("Did not find any pact files for provider " + providerName);
         }
 
         for (final Pact pact : pacts) {
@@ -134,5 +130,15 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
     protected String getConsumerName(final Class<?> clazz) {
         final Consumer consumerInfo = clazz.getAnnotation(Consumer.class);
         return consumerInfo != null ? consumerInfo.value() : null;
+    }
+
+    private String getProviderName(Class<?> clazz) throws InitializationError {
+        final Provider providerInfo = clazz.getAnnotation(Provider.class);
+
+        if (providerInfo == null) {
+            throw new InitializationError("Provider name should be specified by using " + Provider.class.getName() + " annotation");
+        }
+
+        return providerInfo.value();
     }
 }


### PR DESCRIPTION
For running Pact tests on CI we use system properties for passing in the consumer/providername/tags/etc. Our current implementation touches the private internals of this package, I'm trying to improve it by extending the PactRunner class instead. 

For tags this is easy because I can just override the ```getPactSource``` method but the consumer and provider system props are a bit harder because they are retrieved in the constructor and not a seperate method. To fix this I've moved getting the provider and consumer name to a seperate method which would allow me to override those methods for our runner.