### PR TITLE
Fix logic for default port in case of https url passed to HttpTarget

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/HttpTarget.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/HttpTarget.java
@@ -97,7 +97,7 @@ public class HttpTarget extends BaseTarget {
     public HttpTarget(final URL url, final boolean insecure) {
         this(url.getProtocol() == null ? "http" : url.getProtocol(),
                 url.getHost(),
-                url.getPort() == -1 ? 8080 : url.getPort(),
+                url.getPort() == -1 && url.getProtocol().equalsIgnoreCase("http") ? 8080 : url.getPort() == -1 && url.getProtocol().equalsIgnoreCase("https") ? 443 : url.getPort(),
                 url.getPath() == null ? "/" : url.getPath(),
                 insecure);
 


### PR DESCRIPTION
Currently if https URL is passed to HttpTarget, the port defaults to 8080 instead of 443