### PR TITLE
Update code to have platform specific line separator

### DIFF
--- a/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
+++ b/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
@@ -68,7 +68,7 @@ object Conversions extends StrictLogging {
     } else {
       new BufferedReader(request.reader)
     }
-    Stream.continually(br.readLine()).takeWhile(_ != null).mkString("\n")
+    Stream.continually(br.readLine()).takeWhile(_ != null).mkString(System.lineSeparator())
   }
 
   implicit def unfilteredRequestToPactRequest(request: HttpRequest[ReceivedMessage]): Request = {

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MimeTypeTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/MimeTypeTest.java
@@ -39,8 +39,9 @@ public class MimeTypeTest {
 
     @Test
     public void testMatchingText() {
-        String body = "Define a pact between service consumers and providers, enabling \"consumer driven contract\" testing.\n" +
-            "\nPact provides an RSpec DSL for service consumers to define the HTTP requests they will make to a service" +
+        String newLine = System.lineSeparator();
+        String body = "Define a pact between service consumers and providers, enabling \"consumer driven contract\" testing." + newLine +
+            newLine + "Pact provides an RSpec DSL for service consumers to define the HTTP requests they will make to a service" +
             " provider and the HTTP responses they expect back. These expectations are used in the consumers specs " +
             "to provide a mock service provider. The interactions are recorded, and played back in the service " +
             "provider specs to ensure the service provider actually does provide the response the consumer expects.";


### PR DESCRIPTION
Updated to code to have platform specific line separator as on windows  "\r\n" was getting replaced by just "\n" thus altering the actual request body