### PR TITLE
Update PactBrokerLoader to accept tags from system properties.

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
@@ -15,6 +15,7 @@ import java.net.URISyntaxException;
 import java.util.*;
 
 import static au.com.dius.pact.provider.junit.sysprops.PactRunnerExpressionParser.parseExpressions;
+import static au.com.dius.pact.provider.junit.sysprops.PactRunnerTagListExpressionParser.parseTagListExpressions;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -40,7 +41,7 @@ public class PactBrokerLoader implements PactLoader {
     this.pactBrokerHost = pactBrokerHost;
     this.pactBrokerPort = pactBrokerPort;
     this.pactBrokerProtocol = pactBrokerProtocol;
-    this.pactBrokerTags = tags;
+    this.pactBrokerTags = parseTagListExpressions(tags);
     this.failIfNoPactsFound = true;
   }
 

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/sysprops/PactRunnerTagListExpressionParser.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/sysprops/PactRunnerTagListExpressionParser.java
@@ -1,0 +1,34 @@
+package au.com.dius.pact.provider.junit.sysprops;
+
+import com.google.common.base.Strings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static au.com.dius.pact.provider.junit.sysprops.PactRunnerExpressionParser.START_EXPRESSION;
+
+public class PactRunnerTagListExpressionParser {
+
+
+    public static List<String> parseTagListExpressions(final List<String> values) {
+        return parseTagListExpressions(values, new SystemPropertyResolver());
+    }
+
+    public static List<String> parseTagListExpressions(final List<String> values, ValueResolver valueResolver) {
+        return values.stream()
+                .flatMap(value -> substituteIfExpression(value, valueResolver))
+                .collect(Collectors.toList());
+    }
+
+    private static Stream<String> substituteIfExpression(String value, ValueResolver valueResolver) {
+        if (value.contains(START_EXPRESSION)) {
+            String[] split = valueResolver.resolveValue(value).split(",");
+            return Arrays.stream(split)
+                    .filter(str -> ! Strings.isNullOrEmpty(str));
+        }
+        return Stream.of(value);
+
+    }
+}

--- a/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/sysprops/PactRunnerTagListExpressionParserTest.groovy
+++ b/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/sysprops/PactRunnerTagListExpressionParserTest.groovy
@@ -1,0 +1,61 @@
+package au.com.dius.pact.provider.junit.sysprops
+
+import org.junit.Test
+
+import static au.com.dius.pact.provider.junit.sysprops.PactRunnerTagListExpressionParser.parseTagListExpressions
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.MatcherAssert.assertThat
+
+@SuppressWarnings('GStringExpressionWithinString')
+class PactRunnerTagListExpressionParserTest {
+
+    private final Map mappings = [
+            '${empty}': '',
+            '${single}': 'one',
+            '${double}': 'one,two'
+    ]
+
+    private final ValueResolver valueResolver = [
+            resolveValue: { expression -> mappings[expression] }
+    ] as ValueResolver
+
+    @Test
+    void 'Does not modify Strings with no expressions'() {
+        assertThat(parseTagListExpressions([]), is(equalTo([])))
+        assertThat(parseTagListExpressions(['hello']), is(equalTo(['hello'])))
+        assertThat(parseTagListExpressions(['one', 'weird$', '']), is(equalTo(['one', 'weird$', ''])))
+    }
+
+    @Test(expected = RuntimeException)
+    void 'Throws An Exception On Unterminated Expressions'() {
+        parseTagListExpressions(['${value'])
+    }
+
+    @Test
+    void 'omits empty tags'() {
+        assertThat(parseTagListExpressions(['${empty}'], valueResolver), is(equalTo([])))
+        assertThat(parseTagListExpressions(['a', '${empty}', 'b'], valueResolver), is(equalTo(['a', 'b'])))
+    }
+
+    @Test
+    void 'converts single values'() {
+        assertThat(parseTagListExpressions(['${single}'], valueResolver), is(equalTo(['one'])))
+        assertThat(parseTagListExpressions(['a', '${single}', 'b'], valueResolver), is(equalTo(['a', 'one', 'b'])))
+    }
+
+    @Test
+    void 'converts double values'() {
+        assertThat(parseTagListExpressions(['${double}'], valueResolver), is(equalTo(['one', 'two'])))
+        assertThat(parseTagListExpressions(['a', '${double}', 'b'], valueResolver),
+                is(equalTo(['a', 'one', 'two', 'b'])))
+        assertThat(parseTagListExpressions(['${double}', '${double}'], valueResolver),
+                is(equalTo(['one', 'two', 'one', 'two'])))
+    }
+
+    @Test
+    void 'converts mixed values'() {
+        assertThat(parseTagListExpressions(['${single}', '${empty}', '${double}'], valueResolver),
+                is(equalTo(['one', 'one', 'two'])))
+    }
+}


### PR DESCRIPTION
Currently there is no way to modify the list of tags which are pulled from the broker at runtime.  This commit makes the PactBrokerLoader honor system property expressions in a manner similar to the way it is handled for other parameters. If multiple tags are included in a system parameter they must be comma separated.