### PR TITLE
Simplifying line separator logic

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -2,6 +2,7 @@ package au.com.dius.pact.consumer.dsl;
 
 import au.com.dius.pact.consumer.InvalidMatcherException;
 import com.mifmif.common.regex.Generex;
+import groovy.json.JsonSlurper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
@@ -170,7 +171,11 @@ public class PactDslJsonArray extends DslPart {
           matchers.put(rootPath + appendArrayIndex(1) + matcherName, object.matchers.get(matcherName));
       }
       for (int i = 0; i < getNumberExamples(); i++) {
-        body.put(object.getBody());
+        Object objBody = object.getBody();
+        if (objBody instanceof String)
+            body.put(new JsonSlurper().parseText((String)objBody));
+        else
+            body.put(object.getBody());
       }
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -2,7 +2,6 @@ package au.com.dius.pact.consumer.dsl;
 
 import au.com.dius.pact.consumer.InvalidMatcherException;
 import com.mifmif.common.regex.Generex;
-import groovy.json.JsonSlurper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
@@ -171,11 +170,7 @@ public class PactDslJsonArray extends DslPart {
           matchers.put(rootPath + appendArrayIndex(1) + matcherName, object.matchers.get(matcherName));
       }
       for (int i = 0; i < getNumberExamples(); i++) {
-        Object objBody = object.getBody();
-        if (objBody instanceof String)
-            body.put(new JsonSlurper().parseText((String)objBody));
-        else
-            body.put(object.getBody());
+        body.put(object.getBody());
       }
     }
 

--- a/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
+++ b/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
@@ -63,12 +63,12 @@ object Conversions extends StrictLogging {
   def toPath(uri: String) = new URI(uri).getPath
 
   def toBody(request: HttpRequest[ReceivedMessage], charset: String = "UTF-8") = {
-    val br = if (request.headers(ContentEncoding.GZip.name).contains("gzip")) {
-      new BufferedReader(new InputStreamReader(new GZIPInputStream(request.inputStream)))
+    val is = if (request.headers(ContentEncoding.GZip.name).contains("gzip")) {
+      new GZIPInputStream(request.inputStream)
     } else {
-      new BufferedReader(request.reader)
+      request.inputStream
     }
-    Stream.continually(br.readLine()).takeWhile(_ != null).mkString(System.lineSeparator())
+    scala.io.Source.fromInputStream(is).mkString
   }
 
   implicit def unfilteredRequestToPactRequest(request: HttpRequest[ReceivedMessage]): Request = {

--- a/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
+++ b/pact-jvm-consumer/src/main/scala/au/com/dius/pact/model/unfiltered/Conversions.scala
@@ -68,7 +68,7 @@ object Conversions extends StrictLogging {
     } else {
       request.inputStream
     }
-    scala.io.Source.fromInputStream(is).mkString
+    if(is == null) "" else scala.io.Source.fromInputStream(is).mkString
   }
 
   implicit def unfilteredRequestToPactRequest(request: HttpRequest[ReceivedMessage]): Request = {


### PR DESCRIPTION
This change directly converts stream to string w/o having to read line by line and then concat by System dependent line separator. As a result whatever line separator comes from user data is retained as it is.

Reason for this change is as follows:

I was creating tests for multipart-formdata in which file content is sent. Despite proper line separator ("\n") on linux, my tests were failing. reason being as per the RFC

Extract:

**The message body is itself a protocol element and MUST therefore use only CRLF to represent line breaks between body-parts**

I was unable to generate requests having CRLF with existing code on Linux machine. This current fix will remove totally the complexity of deciding on line separator and retain whatever is sent as part of body

> Sorry for the last 2 commits, They were not intended to be part of pull request