### PR TITLE
Added method to PactFolderLoader to provide files along with pacts to…

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/MessagePactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/MessagePactRunner.java
@@ -1,0 +1,23 @@
+package au.com.dius.pact.provider.junit;
+
+import au.com.dius.pact.model.Pact;
+import au.com.dius.pact.model.RequestResponsePact;
+import au.com.dius.pact.model.v3.messaging.Message;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.runners.model.InitializationError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MessagePactRunner extends PactRunner {
+    public MessagePactRunner(final Class<?> clazz) throws InitializationError {
+        super(clazz);
+    }
+
+    @Override
+    protected List<Pact> filterPacts(List<Pact> pacts) {
+        return pacts.stream()
+                .filter(pact -> pact.getClass() == MessagePact.class)
+                .collect(Collectors.toList());
+    }
+}

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -81,9 +81,13 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
           throw new InitializationError("Did not find any pact files for provider " + providerInfo.value());
         }
 
-        for (final Pact pact : pacts) {
+        for (final Pact pact : filterPacts(pacts)) {
             this.child.add(new InteractionRunner(testClass, pact));
         }
+    }
+
+    protected List<Pact> filterPacts(List<Pact> pacts){
+        return pacts;
     }
 
     @Override

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/RestPactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/RestPactRunner.java
@@ -1,0 +1,23 @@
+package au.com.dius.pact.provider.junit;
+
+import au.com.dius.pact.model.Pact;
+import au.com.dius.pact.model.RequestResponseInteraction;
+import au.com.dius.pact.model.RequestResponsePact;
+import au.com.dius.pact.model.v3.messaging.Message;
+import org.junit.runners.model.InitializationError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RestPactRunner extends PactRunner {
+    public RestPactRunner(final Class<?> clazz) throws InitializationError {
+        super(clazz);
+    }
+
+    @Override
+    protected List<Pact> filterPacts(List<Pact> pacts) {
+        return pacts.stream()
+                .filter(pact -> pact.getClass() == RequestResponsePact.class)
+                .collect(Collectors.toList());
+    }
+}

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactFolderLoader.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactFolderLoader.java
@@ -8,7 +8,9 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Out-of-the-box implementation of {@link PactLoader}
@@ -52,6 +54,26 @@ public class PactFolderLoader implements PactLoader {
                 Pact pact = PactReader.loadPact(file);
                 if (pact.getProvider().getName().equals(providerName)) {
                     pacts.add(pact);
+                }
+            }
+        }
+        return pacts;
+    }
+
+    public Map<Pact, File> loadPactsWithFiles(final String providerName) throws IOException {
+        Map<Pact, File> pacts = new HashMap<Pact, File>();
+        File pactFolder = resolvePath();
+        File[] files = pactFolder.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".json");
+            }
+        });
+        if (files != null) {
+            for (File file : files) {
+                Pact pact = PactReader.loadPact(file);
+                if (pact.getProvider().getName().equals(providerName)) {
+                    pacts.put(pact, file);
                 }
             }
         }

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/AmqpTarget.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/target/AmqpTarget.java
@@ -1,19 +1,26 @@
 package au.com.dius.pact.provider.junit.target;
 
 import au.com.dius.pact.model.Interaction;
+import au.com.dius.pact.model.Pact;
 import au.com.dius.pact.provider.ConsumerInfo;
 import au.com.dius.pact.provider.PactVerification;
 import au.com.dius.pact.provider.ProviderInfo;
 import au.com.dius.pact.provider.ProviderVerifier;
 import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit.loader.PactFolderLoader;
 import org.codehaus.groovy.runtime.MethodClosure;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Out-of-the-box implementation of {@link Target},
@@ -83,6 +90,23 @@ public class AmqpTarget extends BaseTarget {
     ProviderInfo providerInfo = new ProviderInfo(provider.value());
     providerInfo.setVerificationType(PactVerification.ANNOTATED_METHOD);
     providerInfo.setPackagesToScan(packagesToScan);
+    PactBroker annotation = testClass.getAnnotation(PactBroker.class);
+    PactFolder folder = testClass.getAnnotation(PactFolder.class);
+    if(annotation != null && annotation.host() != null) {
+      List list = providerInfo.hasPactsFromPactBroker(annotation.protocol() + "://" + annotation.host() + (annotation.port() != null ? ":" + annotation.port() : ""));
+      providerInfo.setConsumers(list);
+    } else if (folder != null && folder.value() != null) {
+      try {
+        PactFolderLoader folderLoader = new PactFolderLoader(folder);
+        Map<Pact, File> pactFileMap = folderLoader.loadPactsWithFiles(providerInfo.getName());
+        providerInfo.setConsumers(pactFileMap.entrySet().stream()
+          .map(e -> new ConsumerInfo(e.getKey().getConsumer().getName(), e.getValue()))
+          .collect(Collectors.toList()));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
     return providerInfo;
   }
 }


### PR DESCRIPTION
… fix the ConsumerInfo instantiation.

We found that AmqpTarget does not handle @PactFolder annotation well as something deep into the framework chokes when ConsumerInfo is missing the File version of the pact.  This felt somewhat hacky to do, but a new method in PactFolderLoader to return both the pact and the file, then creation of ConsumerInfo in AmqpTarget using the Consumer name and the pact File fixes the issue.