### PR TITLE
Added RestPactRunner and MessagePactRunner

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/MessagePactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/MessagePactRunner.java
@@ -1,0 +1,23 @@
+package au.com.dius.pact.provider.junit;
+
+import au.com.dius.pact.model.Pact;
+import au.com.dius.pact.model.RequestResponsePact;
+import au.com.dius.pact.model.v3.messaging.Message;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import org.junit.runners.model.InitializationError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MessagePactRunner extends PactRunner {
+    public MessagePactRunner(final Class<?> clazz) throws InitializationError {
+        super(clazz);
+    }
+
+    @Override
+    protected List<Pact> filterPacts(List<Pact> pacts) {
+        return pacts.stream()
+                .filter(pact -> pact.getClass() == MessagePact.class)
+                .collect(Collectors.toList());
+    }
+}

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -81,9 +81,13 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
           throw new InitializationError("Did not find any pact files for provider " + providerInfo.value());
         }
 
-        for (final Pact pact : pacts) {
+        for (final Pact pact : filterPacts(pacts)) {
             this.child.add(new InteractionRunner(testClass, pact));
         }
+    }
+
+    protected List<Pact> filterPacts(List<Pact> pacts){
+        return pacts;
     }
 
     @Override

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/RestPactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/RestPactRunner.java
@@ -1,0 +1,23 @@
+package au.com.dius.pact.provider.junit;
+
+import au.com.dius.pact.model.Pact;
+import au.com.dius.pact.model.RequestResponseInteraction;
+import au.com.dius.pact.model.RequestResponsePact;
+import au.com.dius.pact.model.v3.messaging.Message;
+import org.junit.runners.model.InitializationError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RestPactRunner extends PactRunner {
+    public RestPactRunner(final Class<?> clazz) throws InitializationError {
+        super(clazz);
+    }
+
+    @Override
+    protected List<Pact> filterPacts(List<Pact> pacts) {
+        return pacts.stream()
+                .filter(pact -> pact.getClass() == RequestResponsePact.class)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
When a microservice is a provider of both a REST API and Messages, the PactRunner cannot differentiate between HTTP/AMQP pacts and thus attempts to play both types against the respective test type.  This provides differentiation via inheritance and filters to only play certain Pact types against a provider.

We didn't update docs yet, so feel free to either reject or I can follow up with a subsequent PR with doc updates.  The change is not breaking.