### PR TITLE
fix the matchingRules generated by eachKeyLike with PactDslJsonRootValue

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/WildcardKeysTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/WildcardKeysTest.java
@@ -49,7 +49,10 @@ public class WildcardKeysTest {
             .closeObject()
           .closeArray()
           .closeObject()
-        .closeArray();
+        .closeArray()
+        .object("foo")
+          .eachKeyLike("001", PactDslJsonRootValue.numberType(42))
+        .closeObject();
 
       RequestResponsePact pact = builder
         .uponReceiving("a request for an article")
@@ -70,7 +73,8 @@ public class WildcardKeysTest {
         "$.body.articles[*].variants[*].*[*].bundles[*].*.description",
         "$.body.articles[*].variants[*].*[*].bundles[*].*.referencedArticles",
         "$.body.articles[*].variants[*].*[*].bundles[*].*.referencedArticles[*].*",
-        "$.body.articles[*].variants[*].*[*].bundles[*].*.referencedArticles[*].bundleId"
+        "$.body.articles[*].variants[*].*[*].bundles[*].*.referencedArticles[*].bundleId",
+        "$.body.foo.*"
       );
 
       return pact;
@@ -84,6 +88,10 @@ public class WildcardKeysTest {
         .execute().returnContent().asString();
       Map<String, Object> body = (Map<String, Object>) new JsonSlurper().parseText(result);
 
+      assertThat(body, hasKey("foo"));
+      Map<String, Object> foo = (Map<String, Object>) body.get("foo");
+      assertThat(foo, hasKey("001"));
+      assertThat(foo.get("001"), is(42));
       assertThat(body, hasKey("articles"));
       List articles = (List) body.get("articles");
       assertThat(articles.size(), is(1));

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -972,7 +972,7 @@ public class PactDslJsonBody extends DslPart {
   public PactDslJsonBody eachKeyLike(String exampleKey, PactDslJsonRootValue value) {
     body.put(exampleKey, value.getBody());
     for(String matcherName: value.matchers.keySet()) {
-      matchers.put(matcherName + ".*", value.matchers.get(matcherName));
+      matchers.put(rootPath + "*" + matcherName, value.matchers.get(matcherName));
     }
     return this;
   }


### PR DESCRIPTION
when `eachKeyLike(String exampleKey, PactDslJsonRootValue value)` is called, it generates matchingRules that are mistakenly not namespaced under the rootPath (see issue https://github.com/DiUS/pact-jvm/issues/441 for an example). This commit should fix it, and adds a test for it.

Please review because I am not very familiar with the codebase ;)