### PR TITLE
Marcpa00 readme fixes

### DIFF
--- a/pact-jvm-consumer-groovy/README.md
+++ b/pact-jvm-consumer-groovy/README.md
@@ -3,7 +3,7 @@ pact-jvm-consumer-groovy
 
 Groovy DSL for Pact JVM
 
-##Dependency
+## Dependency
 
 The library is available on maven central using:
 
@@ -11,7 +11,7 @@ The library is available on maven central using:
 * artifact-id = `pact-jvm-consumer-groovy_2.11`
 * version-id = `2.4.x` or `3.3.x`
 
-##Usage
+## Usage
 
 Add the `pact-jvm-consumer-groovy` library to your test class path. This provides a `PactBuilder` class for you to use
 to define your pacts. For a full example, have a look at the example JUnit `ExampleGroovyConsumerPactTest`.

--- a/pact-jvm-consumer-groovy/README.md
+++ b/pact-jvm-consumer-groovy/README.md
@@ -9,7 +9,7 @@ The library is available on maven central using:
 
 * group-id = `au.com.dius`
 * artifact-id = `pact-jvm-consumer-groovy_2.11`
-* version-id = `2.4.x` or `3.3.x`
+* version-id = `2.4.x` or `3.4.x`
 
 ## Usage
 
@@ -19,7 +19,7 @@ to define your pacts. For a full example, have a look at the example JUnit `Exam
 If you are using gradle for your build, add it to your `build.gradle`:
 
     dependencies {
-        testCompile 'au.com.dius:pact-jvm-consumer-groovy_2.11:3.3.8'
+        testCompile 'au.com.dius:pact-jvm-consumer-groovy_2.11:3.4.0'
     }
 
 Then create an instance of the `PactBuilder` in your test.

--- a/pact-jvm-consumer-groovy/README.md
+++ b/pact-jvm-consumer-groovy/README.md
@@ -25,40 +25,48 @@ If you are using gradle for your build, add it to your `build.gradle`:
 Then create an instance of the `PactBuilder` in your test.
 
 ```groovy
-    @Test
-    void "A service consumer side of a pact goes a little something like this"() {
+    import au.com.dius.pact.consumer.PactVerificationResult
+    import au.com.dius.pact.consumer.groovy.PactBuilder
+    import groovyx.net.http.RESTClient
+    import org.junit.Test
 
-        def alice_service = new PactBuilder() // Create a new PactBuilder
-        alice_service {
-            serviceConsumer "Consumer" 	// Define the service consumer by name
-            hasPactWith "Alice Service"   // Define the service provider that it has a pact with
-            port 1234                       // The port number for the service. It is optional, leave it out to
-                                            // to use a random one
+    class AliceServiceConsumerPactTest {
 
-            given('there is some good mallory') // defines a provider state. It is optional.
-            uponReceiving('a retrieve Mallory request') // upon_receiving starts a new interaction
-            withAttributes(method: 'get', path: '/mallory')		// define the request, a GET request to '/mallory'
-            willRespondWith(						// define the response we want returned
-                status: 200,
-                headers: ['Content-Type': 'text/html'],
-                body: '"That is some good Mallory."'
-            )
+        @Test
+        void "A service consumer side of a pact goes a little something like this"() {
+
+            def alice_service = new PactBuilder() // Create a new PactBuilder
+            alice_service {
+                serviceConsumer "Consumer" 	// Define the service consumer by name
+                hasPactWith "Alice Service"   // Define the service provider that it has a pact with
+                port 1234                       // The port number for the service. It is optional, leave it out to
+                                                // to use a random one
+
+                given('there is some good mallory') // defines a provider state. It is optional.
+                uponReceiving('a retrieve Mallory request') // upon_receiving starts a new interaction
+                withAttributes(method: 'get', path: '/mallory')		// define the request, a GET request to '/mallory'
+                willRespondWith(						// define the response we want returned
+                    status: 200,
+                    headers: ['Content-Type': 'text/html'],
+                    body: '"That is some good Mallory."'
+                )
+            }
+
+            // Execute the run method to have the mock server run.
+            // It takes a closure to execute your requests and returns a PactVerificationResult.
+            PactVerificationResult result = alice_service.runTest {
+                def client = new RESTClient('http://localhost:1234/')
+                def alice_response = client.get(path: '/mallory')
+
+                assert alice_response.status == 200
+                assert alice_response.contentType == 'text/html'
+
+                def data = alice_response.data.text()
+                assert data == '"That is some good Mallory."'
+            }
+            assert result == PactVerificationResult.Ok.INSTANCE  // This means it is all good
+
         }
-
-	      // Execute the run method to have the mock server run.
-	      // It takes a closure to execute your requests and returns a Pact VerificationResult.
-	      PactVerificationResult result = alice_service.runTest {
-            def client = new RESTClient('http://localhost:1234/')
-            def alice_response = client.get(path: '/mallory')
-
-            assert alice_response.status == 200
-            assert alice_response.contentType == 'text/html'
-
-            def data = alice_response.data.text()
-            assert data == '"That is some good Mallory."'
-        }
-        assert result == PactVerificationResult.Ok.INSTANCE  // This means it is all good
-
     }
 ```
 

--- a/pact-jvm-consumer-groovy/README.md
+++ b/pact-jvm-consumer-groovy/README.md
@@ -455,7 +455,7 @@ and [#97](https://github.com/DiUS/pact-jvm/issues/97) for information on what th
 
 ## Generating V3 spec pact files (3.1.0+, 2.3.0+)
 
-To have your consumer tests generate V3 format pacts, you can pass an option into the `run` method. For example:
+To have your consumer tests generate V3 format pacts, you can pass an option into the `runTest` method. For example:
 
 ```groovy
 PactVerificationResult result = service.runTest(specificationVersion: PactSpecVersion.V3) { config ->


### PR DESCRIPTION
If one follows instructions in README.md of pact-jvm-consumer-groovy, the code does not compile because PactVerificationResult is not found in the version mentionned (3.3.8).  
These commits tell to use 3.4.0 and include a complete test class (with imports and class declaration).