### PR TITLE
Boolean to control pactVerify.dependsOn a provider task

### DIFF
--- a/pact-jvm-provider-gradle/README.md
+++ b/pact-jvm-provider-gradle/README.md
@@ -164,6 +164,37 @@ pact {
 Following typical Gradle behaviour, you can set the provider task properties to the actual tasks, or to the task names
 as a string (for the case when they haven't been defined yet).
 
+## Preventing the chaining of provider verify task to `pactVerify` [version 3.4.1+]
+
+Normally a gradle task named `pactVerify_${provider.name}` is created and added as a task dependency for `pactVerify`.  You 
+can disable this dependency on a provider by setting `isDependencyForPactVerify` to `false` (defaults to `true`).
+
+```groovy
+pact {
+
+    serviceProviders {
+
+        provider1 {
+
+            isDependencyForPactVerify = false
+
+            hasPactWith('consumer1') {
+                pactFile = file('path/to/provider1-consumer1-pact.json')
+            }
+
+        }
+
+    }
+
+}
+```
+
+To run this task, you would then have to explicitly name it as in ```gradle pactVerify_provider1```, a normal ```gradle pactVerify``` 
+would skip it.  This can be useful when you want to define two providers, one with `startProviderTask`/`terminateProviderTask` 
+and as second without, so you can manually start your provider (to debug it from your IDE, for example) but still want a `pactVerify` 
+ to run normally from your CI build.
+
+
 ## Enabling insecure SSL [version 2.2.8+]
 
 For providers that are running on SSL with self-signed certificates, you need to enable insecure SSL mode by setting

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -51,7 +51,9 @@ class PactPlugin implements Plugin<Project> {
                     providerTask.finalizedBy(provider.terminateProviderTask)
                 }
 
-                it.pactVerify.dependsOn(providerTask)
+                if (provider.isDependencyForPactVerify) {
+                    it.pactVerify.dependsOn(providerTask)
+                }
             }
         }
     }

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderInfo.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderInfo.groovy
@@ -31,6 +31,8 @@ class ProviderInfo {
     boolean stateChangeUsesBody = true
     boolean stateChangeTeardown = false
 
+    boolean isDependencyForPactVerify = true
+
     PactVerification verificationType
     List packagesToScan = []
     List<ConsumerInfo> consumers = []


### PR DESCRIPTION
Every provider task defined becomes a dependency on `pactVerify`.  

Now suppose that your provider task defines start/stop provider, but the new provider version fails to verify : would be nice to be able to start manually the provider (under a debugger, for example) and simply re-execute the pacts defined.  Right now, to do this, one would have to change the build.gradle file to put the definition of `startProviderTask` and `terminateProviderTask` in comments, then re-run `pactVerify` (and remember not to commit this change... otherwise the CI build previously assuming the provider is automatically started by `pactVerify` will fail).

With this PR, boolean `isDependencyForPactVerify` is added to provider definition and the dependency chaining between `pactVerify` and the new provider task is done only if this is true (the default) and skipped if false.  This way, one can duplicate a provider definition, give it another name (lets say "dev"), remove start/stop provider properties, set `isDependencyForPactVerify` to false to have best of both worlds : `gradle pactVerify` will start the provider, verify, kill the provider as usual, and `gradle pactVerify_dev` can be used after having manually started the provider to run the pacts against it.