### PR TITLE
Allow an empty string to be specified when using the Groovy string matcher

### DIFF
--- a/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/Matchers.groovy
+++ b/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/Matchers.groovy
@@ -115,7 +115,7 @@ class Matchers {
   }
 
   static string(String value = null) {
-    new TypeMatcher(values: [TYPE, value ?: RandomStringUtils.randomAlphanumeric(TEN)])
+    new TypeMatcher(values: [TYPE, (value != null) ? value : RandomStringUtils.randomAlphanumeric(TEN)])
   }
 
   /**

--- a/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
+++ b/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
@@ -33,7 +33,7 @@ class MatchersSpec extends Specification {
     Matchers.string(value).value == value
 
     where:
-    value << [ "", " ", "example" ]
+    value << ['', ' ', 'example']
   }
 
   def 'string matcher should generate value when not provided'() {

--- a/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
+++ b/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
@@ -27,4 +27,17 @@ class MatchersSpec extends Specification {
 
   }
 
+  @Unroll
+  def 'string matcher should use provided value - `#value`'() {
+    expect:
+    Matchers.string(value).value == value
+
+    where:
+    value << [ "", " ", "example" ]
+  }
+
+  def 'string matcher should generate value when not provided'() {
+    expect:
+    !Matchers.string().value.isEmpty()
+  }
 }


### PR DESCRIPTION
When using the string matcher with a non-null value you expect to see that example value in the Pact file. This is not the case with an empty string, a generated value would be present in the Pact instead. My pull request addresses this situation.

Before my change `Matchers.string()` was equivalent to `Matchers.string('')`. Now it is possible to use an empty string as an example value.

This change also makes the matcher's behaviour consistent with the equivalent Java matcher ([`PactDslJsonBody#stringType(...)`][0]).


[0]: https://github.com/DiUS/pact-jvm/blob/master/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java#L130-L139
