### PR TITLE
Make message pact metadata available from MessagePactProviderRule

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/v3/ExampleMessageWithMetadataConsumerTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/v3/ExampleMessageWithMetadataConsumerTest.java
@@ -1,0 +1,49 @@
+package au.com.dius.pact.consumer.v3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import au.com.dius.pact.consumer.MessagePactBuilder;
+import au.com.dius.pact.consumer.MessagePactProviderRule;
+import au.com.dius.pact.consumer.Pact;
+import au.com.dius.pact.consumer.PactVerification;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.v3.messaging.MessagePact;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+public class ExampleMessageWithMetadataConsumerTest {
+
+    @Rule
+    public MessagePactProviderRule mockProvider = new MessagePactProviderRule(this);
+
+    @Pact(provider = "test_provider", consumer = "test_consumer_v3")
+    public MessagePact createPact(MessagePactBuilder builder) {
+        PactDslJsonBody body = new PactDslJsonBody();
+        body.stringValue("testParam1", "value1");
+        body.stringValue("testParam2", "value2");
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("metadata1", "metadataValue1");
+        metadata.put("metadata2", "metadataValue2");
+
+        return builder.given("SomeProviderState")
+                .expectsToReceive("a test message with metadata")
+                .withMetadata(metadata)
+                .withContent(body)
+                .toPact();
+    }
+
+    @Test
+    @PactVerification({"test_provider", "SomeProviderState"})
+    public void test() throws Exception {
+        assertNotNull(mockProvider.getMessage());
+        assertNotNull(mockProvider.getMetadata());
+        assertEquals("metadataValue1", mockProvider.getMetadata().get("metadata1"));
+        assertEquals("metadataValue2", mockProvider.getMetadata().get("metadata2"));
+    }
+
+}


### PR DESCRIPTION
Hi,
I see there is a way of defining metadata in the MessagePact (that is, the return from the @Pact annotated method on the consumer side), but there is now way of retrieving it from the MessagePactProviderRule.
I added code and tests for retrieving it.
If that is something you find needed, PACT then should probably support verifying that metadata in the provider side as well. I can try and find the time for another PR regarding that - no promises :)