### PR TITLE
Add a Groovy boolean matcher

### DIFF
--- a/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/Matchers.groovy
+++ b/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/Matchers.groovy
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.RandomStringUtils
 import org.apache.commons.lang3.time.DateUtils
 
 import java.text.ParseException
+import java.util.concurrent.ThreadLocalRandom
 import java.util.regex.Pattern
 
 /**
@@ -118,6 +119,10 @@ class Matchers {
     new TypeMatcher(values: [TYPE, (value != null) ? value : RandomStringUtils.randomAlphanumeric(TEN)])
   }
 
+  static bool(boolean value = null) {
+    new TypeMatcher(values: [TYPE, (value != null) ? value : ThreadLocalRandom.current().nextBoolean()])
+  }
+
   /**
    * Array with maximum size and each element like the following object
    * @param max The maximum size of the array
@@ -151,5 +156,4 @@ class Matchers {
   static eachLike(Integer numberExamples = 1, def arg) {
     new EachLikeMatcher(values: [null,  arg], numberExamples: numberExamples)
   }
-
 }

--- a/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
+++ b/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/MatchersSpec.groovy
@@ -24,7 +24,7 @@ class MatchersSpec extends Specification {
     'timestamp'   | 'yyyy-mm-dd' | [match: 'timestamp', timestamp: 'yyyy-mm-dd']
     'date'        | 'yyyy-mm-dd' | [match: 'date', date: 'yyyy-mm-dd']
     'time'        | 'yyyy-mm-dd' | [match: 'time', time: 'yyyy-mm-dd']
-
+    'bool'        | true         | [match: 'type']
   }
 
   @Unroll
@@ -39,5 +39,10 @@ class MatchersSpec extends Specification {
   def 'string matcher should generate value when not provided'() {
     expect:
     !Matchers.string().value.isEmpty()
+  }
+
+  def 'bool matcher should generate value when not provided'() {
+    expect:
+    Matchers.bool().value instanceof Boolean
   }
 }


### PR DESCRIPTION
I've added a boolean type matcher. I checked the spec and I think I did correctly?

Ideally I would've called it `boolean` but that's reserved. `bool` seemed like a somewhat reasonable alternative, but it's not a term used much in the JVM-world (I have no strong feelings about the name being changed). 