### PR TITLE
Allow setting of a custom MockMvc for provider states

### DIFF
--- a/pact-jvm-provider-spring/src/main/java/au/com/dius/pact/provider/spring/target/MockMvcTarget.java
+++ b/pact-jvm-provider-spring/src/main/java/au/com/dius/pact/provider/spring/target/MockMvcTarget.java
@@ -32,6 +32,7 @@ public class MockMvcTarget extends BaseTarget {
     private List<Object> controllerAdvice;
     private boolean printRequestResponse;
     private int runTimes;
+    private MockMvc mockMvc;
 
     public MockMvcTarget() {
         this(Collections.emptyList());
@@ -74,7 +75,11 @@ public class MockMvcTarget extends BaseTarget {
         this.controllerAdvice = Arrays.asList(Optional.ofNullable(controllerAdvice).orElse(new Object[0]));
     }
 
-    /**
+    public void setMockMvc(MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+  /**
      * {@inheritDoc}
      */
     @Override
@@ -83,9 +88,7 @@ public class MockMvcTarget extends BaseTarget {
         ConsumerInfo consumer = new ConsumerInfo(consumerName);
         provider.setVerificationType(PactVerification.ANNOTATED_METHOD);
 
-        MockMvc mockMvc = standaloneSetup(controllers.toArray())
-                .setControllerAdvice(controllerAdvice.toArray())
-                .build();
+        MockMvc mockMvc = buildMockMvc();
 
         MvcProviderVerifier verifier = (MvcProviderVerifier)setupVerifier(interaction, provider, consumer);
 
@@ -103,6 +106,15 @@ public class MockMvcTarget extends BaseTarget {
         } finally {
             verifier.finialiseReports();
         }
+    }
+
+    private MockMvc buildMockMvc() {
+        if (mockMvc != null) {
+            return mockMvc;
+        }
+
+        return standaloneSetup(controllers.toArray())
+            .setControllerAdvice(controllerAdvice.toArray()).build();
     }
 
     private URL[] getClassPathUrls() {

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookController.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookController.java
@@ -42,4 +42,9 @@ public class BookController {
             return new ResponseEntity(bookLogic.getBooks(bestSeller), HttpStatus.OK);
         }
     }
+
+    @RequestMapping(value = {"/books"}, params = "type", method = RequestMethod.GET)
+    ResponseEntity<List<Book>> getAllForType(BookType bookType) throws Exception {
+        return new ResponseEntity(bookLogic.getBooks(bookType), HttpStatus.OK);
+    }
 }

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookLogic.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookLogic.java
@@ -1,11 +1,8 @@
 package au.com.dius.pact.provider.spring;
 
-import org.joda.time.DateTime;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,6 +18,10 @@ public class BookLogic {
 
     public List<Book> getBooks(Boolean bestSellers) {
         return new ArrayList<Book>();
+    }
+
+    public List<Book> getBooks(BookType bookType) {
+      return new ArrayList<Book>();
     }
 
     public Book createBook(Book book) {

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookType.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookType.java
@@ -1,0 +1,14 @@
+package au.com.dius.pact.provider.spring;
+
+public class BookType {
+
+  private final String type;
+
+  public BookType(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+}

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookType.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookType.java
@@ -2,13 +2,13 @@ package au.com.dius.pact.provider.spring;
 
 public class BookType {
 
-  private final String type;
+    private final String type;
 
-  public BookType(String type) {
-    this.type = type;
-  }
+    public BookType(String type) {
+        this.type = type;
+    }
 
-  public String getType() {
-    return type;
-  }
+    public String getType() {
+        return type;
+    }
 }

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookTypeArgumentResolver.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookTypeArgumentResolver.java
@@ -1,0 +1,26 @@
+package au.com.dius.pact.provider.spring;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class BookTypeArgumentResolver implements HandlerMethodArgumentResolver {
+
+	public BookTypeArgumentResolver() {
+	}
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getGenericParameterType().equals(BookType.class);
+  }
+
+  @Override
+  public BookType resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		String type = webRequest.getParameter("type");
+		return new BookType(type);
+	}
+}

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookTypeArgumentResolver.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BookTypeArgumentResolver.java
@@ -8,19 +8,18 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class BookTypeArgumentResolver implements HandlerMethodArgumentResolver {
 
-	public BookTypeArgumentResolver() {
-	}
+    public BookTypeArgumentResolver() {}
 
-  @Override
-  public boolean supportsParameter(MethodParameter parameter) {
-    return parameter.getGenericParameterType().equals(BookType.class);
-  }
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getGenericParameterType().equals(BookType.class);
+    }
 
-  @Override
-  public BookType resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    @Override
+    public BookType resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
-		String type = webRequest.getParameter("type");
-		return new BookType(type);
-	}
+		    String type = webRequest.getParameter("type");
+		    return new BookType(type);
+	  }
 }

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,6 +92,21 @@ public class BooksPactProviderTest {
     @State("update-book-no-content-type")
     public void updateBookNoContentType() {
         // no setup needed
+    }
+
+    @State("get-books-for-page")
+    public void getBooksForPage() {
+        // Prove that we can provide MockMvcTarget with our own pre-build MockMvc for situations where we need greater control over
+        // how MockMvc is configured; in this instance the request needs a custom argum
+        target.setMockMvc(MockMvcBuilders.standaloneSetup(bookController)
+                                         .setCustomArgumentResolvers(new BookTypeArgumentResolver())
+                                         .build());
+
+        List<Book> bookList = new ArrayList<>();
+        bookList.add(new Book(UUID.randomUUID(), "Bob Jones", true));
+        bookList.add(new Book(UUID.randomUUID(), "Eric Reynolds", true));
+
+        when(bookLogic.getBooks(any(BookType.class))).thenReturn(bookList);
     }
 
     @State("get-books")

--- a/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
+++ b/pact-jvm-provider-spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java
@@ -94,8 +94,8 @@ public class BooksPactProviderTest {
         // no setup needed
     }
 
-    @State("get-books-for-page")
-    public void getBooksForPage() {
+    @State("get-books-by-type")
+    public void getBooksByType() {
         // Prove that we can provide MockMvcTarget with our own pre-build MockMvc for situations where we need greater control over
         // how MockMvc is configured; in this instance the request needs a custom argum
         target.setMockMvc(MockMvcBuilders.standaloneSetup(bookController)

--- a/pact-jvm-provider-spring/src/test/resources/pacts/library-contract.json
+++ b/pact-jvm-provider-spring/src/test/resources/pacts/library-contract.json
@@ -35,6 +35,37 @@
         }
       }
     }
+  },{
+    "provider_state": "get-books-for-page",
+    "description" : "Get all books for page",
+    "request" : {
+      "method" : "GET",
+      "path" : "/books",
+      "query": "type=fiction",
+    },
+    "response" : {
+      "status" : 200,
+      "body": [{
+        "id": "90f1787e-9f39-4e42-b897-b59d29",
+        "author": "Ray Barrowman",
+        "bestSeller": true
+      }],
+      "matchingRules": {
+        "$.body": {
+          "min": 2,
+          "match": "type"
+        },
+        "$.body[*].id": {
+          "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        },
+        "$.body[*].author": {
+          "match": "type"
+        },
+        "$.body[*].bestSeller": {
+          "match": "type"
+        }
+      }
+    }
   }, {
     "provider_state": "get-best-selling-books",
     "description" : "Get best selling books",

--- a/pact-jvm-provider-spring/src/test/resources/pacts/library-contract.json
+++ b/pact-jvm-provider-spring/src/test/resources/pacts/library-contract.json
@@ -36,8 +36,8 @@
       }
     }
   },{
-    "provider_state": "get-books-for-page",
-    "description" : "Get all books for page",
+    "provider_state": "get-books-by-type",
+    "description" : "Get all books by type",
     "request" : {
       "method" : "GET",
       "path" : "/books",


### PR DESCRIPTION
Hi,

I've made this change to the **pact-jvm-provider-spring** library to allow a provider state to provide it's own MockMvc that will be used during the test interaction. This is useful in situations where more control is required over the Spring test context.

The example test that I've added to exercise the new behaviour demonstrates a scenario where a Spring controller needs a custom argument resolver to process a "rich" request parameter.

Let me know if you have any questions or comments.

Thanks,
Dave