### PR TITLE
Updating URL matching regex to apply to file URLs

### DIFF
--- a/pact-jvm-model/src/main/groovy/au/com/dius/pact/model/PactReader.groovy
+++ b/pact-jvm-model/src/main/groovy/au/com/dius/pact/model/PactReader.groovy
@@ -174,7 +174,7 @@ class PactReader {
         new JsonSlurper().parse(source)
       } else if (source instanceof URL || source instanceof UrlPactSource) {
         loadPactFromUrl(source instanceof URL ? new UrlSource(source.toString()) : source, options)
-      } else if (source instanceof String && source.toLowerCase() ==~ '(https?|file)://.*') {
+      } else if (source instanceof String && source.toLowerCase() ==~ '(https?|file)://?.*') {
         loadPactFromUrl(new UrlSource(source), options)
       } else if (source instanceof String && source.toLowerCase() ==~ 's3://.*') {
         loadPactFromS3Bucket(source, options)


### PR DESCRIPTION
Fixes an issue matching on file:/ URLs. Before the change, this usage of the junit `@PactUrl` caused PactReader to throw confusing exception when it tried to interpret the URL value as a json directly on line 185. This change resolved the issue.

e.g.
`@PactUrl(urls = {"file:/path/to/pact.json"})`