### PR TITLE
Fix issue 455

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/PactRunner.java
@@ -78,7 +78,7 @@ public class PactRunner extends ParentRunner<InteractionRunner> {
         throw new InitializationError(e);
       }
 
-      if (pacts == null || pacts.isEmpty()) {
+      if (pacts == null) {
         throw new InitializationError("Did not find any pact files for provider " + providerInfo.value());
       }
 


### PR DESCRIPTION
Commit 468429677703620469a7fc13684882db70341edd introduced a feature
regression (see https://github.com/DiUS/pact-jvm/issues/455): it is not
possible anymore to write provider tests before having developed any
consumer expectations.
@PactRunner should accept having no pacts to execute for that matter.