### PR TITLE
Use UTF-8 as a default charset in MockServer

### DIFF
--- a/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MockHttpServer.kt
+++ b/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MockHttpServer.kt
@@ -200,7 +200,7 @@ open class MockHttpsServer(pact: RequestResponsePact, config: MockProviderConfig
 
 fun calculateCharset(headers: Map<String, String>): Charset {
   val contentType = headers.entries.find { it.key.toUpperCase() == "CONTENT-TYPE" }
-  val default = Charset.forName("ISO-8859-1")
+  val default = Charset.forName("UTF-8")
   if (contentType != null) {
     try {
       return ContentType.parse(contentType.value)?.charset ?: default


### PR DESCRIPTION
Use UTF-8 instead of ISO-8859-1 to parse bodies if no charset has been provided from the client.
If a client sends a request using Content-Type: application/json, the behaviour should be identical to a client requesting using Content-Typre: application/json, Charset=UTF-8.