### PR TITLE
Update io.gatling:jsonpath dependency to 0.6.9

### DIFF
--- a/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/PactBodyBuilderSpec.groovy
+++ b/pact-jvm-consumer-groovy/src/test/groovy/au/com/dius/pact/consumer/groovy/PactBodyBuilderSpec.groovy
@@ -417,7 +417,7 @@ class PactBodyBuilderSpec extends Specification {
     response.body.value == '{"name":"harry"}'
   }
 
-  def 'Guard Against Field Names That Don\'t Conform To Gatling Fields'() {
+  def 'No Special Handling For Field Names Formerly Not Conforming Gatling Fields'() {
     given:
     service {
       uponReceiving('a request with invalid gatling fields')
@@ -445,14 +445,14 @@ class PactBodyBuilderSpec extends Specification {
     then:
     service.interactions.size() == 1
     service.interactions[0].request.matchingRules.rulesForCategory('body').matchingRules == [
-      $/$['2']/$: new MatchingRuleGroup([new MaxTypeMatcher(10)]),
-      $/$['2'][*].id/$: new MatchingRuleGroup([new NumberTypeMatcher(INTEGER)]),
-      $/$['2'][*].lineItems/$: new MatchingRuleGroup([new MinTypeMatcher(1)]),
-      $/$['2'][*].lineItems[*].id/$: new MatchingRuleGroup([new NumberTypeMatcher(INTEGER)]),
-      $/$['2'][*].lineItems[*]['10k-depreciation-bips']/$: new MatchingRuleGroup([
+      $/$.2/$: new MatchingRuleGroup([new MaxTypeMatcher(10)]),
+      $/$.2[*].id/$: new MatchingRuleGroup([new NumberTypeMatcher(INTEGER)]),
+      $/$.2[*].lineItems/$: new MatchingRuleGroup([new MinTypeMatcher(1)]),
+      $/$.2[*].lineItems[*].id/$: new MatchingRuleGroup([new NumberTypeMatcher(INTEGER)]),
+      $/$.2[*].lineItems[*].10k-depreciation-bips/$: new MatchingRuleGroup([
         new NumberTypeMatcher(INTEGER)]),
-      $/$['2'][*].lineItems[*].productCodes/$: new MatchingRuleGroup([TypeMatcher.INSTANCE]),
-      $/$['2'][*].lineItems[*].productCodes[*].code/$: new MatchingRuleGroup([TypeMatcher.INSTANCE])
+      $/$.2[*].lineItems[*].productCodes/$: new MatchingRuleGroup([TypeMatcher.INSTANCE]),
+      $/$.2[*].lineItems[*].productCodes[*].code/$: new MatchingRuleGroup([TypeMatcher.INSTANCE])
     ]
 
     keys == [

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/junit/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/junit/PactDslJsonBodyTest.java
@@ -50,8 +50,8 @@ public class PactDslJsonBodyTest extends ConsumerPactTestMk2 {
 
         MatcherTestUtils.assertResponseMatcherKeysEqualTo(pact, "body",
             "$.id",
-            "$['2'].id",
-            "$['2'].v1",
+            "$.2.id",
+            "$.2.v1",
             "$.numbers[0]",
             "$.numbers[3]",
             "$.numbers[4].id",

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -28,7 +28,7 @@ public class PactDslJsonBodyTest {
     private static final String THIRD = "@third";
 
     @Test
-    public void guardAgainstObjectNamesThatDontConformToGatlingFields() {
+    public void noSpecialHandlingForObjectNamesFormerlyNotConformingToGatling() {
         DslPart body = new PactDslJsonBody()
             .id()
             .object("2")
@@ -53,13 +53,13 @@ public class PactDslJsonBodyTest {
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
           ".id",
-          "['2'].id",
+          ".2.id",
           ".numbers[3]",
           ".numbers[0]",
           ".numbers[4].timestamp",
           ".numbers[4].dob",
           ".numbers[4].id",
-          ".numbers[4]['10k-depreciation-bips'].id"
+          ".numbers[4].10k-depreciation-bips.id"
         ));
         assertThat(body.getMatchers().getMatchingRules().keySet(), is(equalTo(expectedMatchers)));
 
@@ -76,7 +76,7 @@ public class PactDslJsonBodyTest {
           .integerType(K_DEPRECIATION_BIPS);
 
         Set<String> expectedMatchers = new HashSet<String>(Arrays.asList(
-          "['200']", "['1']", "['@field']", "['10k-depreciation-bips']"
+          ".200", ".1", "['@field']", ".10k-depreciation-bips"
         ));
         assertThat(body.getMatchers().getMatchingRules().keySet(), is(equalTo(expectedMatchers)));
 

--- a/pact-jvm-matchers/build.gradle
+++ b/pact-jvm-matchers/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(":pact-jvm-model"),
     "org.apache.commons:commons-lang3:${project.commonsLang3Version}",
-    "io.gatling:jsonpath_${project.scalaVersion}:0.6.4",
+    "io.gatling:jsonpath_${project.scalaVersion}:0.6.9",
     'com.googlecode.java-diff-utils:diffutils:1.3.0'
 
   testCompile "ch.qos.logback:logback-classic:${project.logbackVersion}"


### PR DESCRIPTION
This is one of several necessary version upgrades to be able to provide Scala 2.12 support. (See #445)

[Since version 0.6.7](https://github.com/gatling/jsonpath/compare/bbced508133...404eee2e95#diff-ae7d7c0ef89d66c7f95b5f359b182c90R52), Gatling's Json parser allows Json field names starting with digits, which is why the corresponding tests are updated alongside the version upgrade.