### PR TITLE
Upgrade dependencies for Scala 2.12 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ subprojects {
       if (project.hasProperty('scalaVersion')) {
           compile "org.scala-lang:scala-library:${project.scalaFullVersion}",
             "org.scala-lang:scala-compiler:${project.scalaFullVersion}",
-            "com.typesafe.scala-logging:scala-logging_${project.scalaVersion}:3.4.0"
+            "com.typesafe.scala-logging:scala-logging_${project.scalaVersion}:3.7.2"
 
           testCompile "org.specs2:specs2-core_${project.scalaVersion}:${project.specs2Version}",
             "org.specs2:specs2-junit_${project.scalaVersion}:${project.specs2Version}"

--- a/pact-jvm-provider/build.gradle
+++ b/pact-jvm-provider/build.gradle
@@ -8,7 +8,7 @@ dependencies {
         "org.apache.httpcomponents:httpclient:${project.httpClientVersion}",
         'org.reflections:reflections:0.9.10',
         "net.databinder:unfiltered-netty-server_${project.scalaVersion}:0.8.4",
-        "net.databinder.dispatch:dispatch-core_${project.scalaVersion}:0.11.3"
+        "net.databinder.dispatch:dispatch-core_${project.scalaVersion}:0.12.3"
 
     testCompile project(":pact-jvm-consumer-groovy_${project.scalaVersion}")
     testCompile "ch.qos.logback:logback-classic:${project.logbackVersion}"


### PR DESCRIPTION
Prepare scala 2.12 support: Update the scala-logging and `dispatch-core` dependencies to versions that provide Scala 2.12 support. See #445.