### PR TITLE
Print error when eachLike matcher is used with 0 examples

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -924,6 +924,10 @@ public class PactDslJsonArray extends DslPart {
    * @param numberExamples number of examples to generate
    */
   public PactDslJsonArray eachLike(PactDslJsonRootValue value, int numberExamples) {
+    if (numberExamples == 0) {
+      System.err.println("Testing Zero examples may be unsafe. Please make sure to provide at least one example in the Pact provider implementation. See https://github.com/DiUS/pact-jvm/issues/546");
+    }
+
     matchers.addRule(rootPath + appendArrayIndex(1), matchMin(0));
     PactDslJsonArray parent = new PactDslJsonArray(rootPath, "", this, true);
     parent.setNumberExamples(numberExamples);


### PR DESCRIPTION
Using the eachLike matcher with zero examples may be unsafe. But since this is already in use we shouldn't break backward compatibility. In the JS implementation this isn't even allowed, but in the JWM implementation it was suggested to only print an obnoxious message in case eachLike is called with Zero examples when generating pacts.

See: https://github.com/DiUS/pact-jvm/issues/546