### PR TITLE
Fix double-decoding of query parameters

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerClient.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/exampleclients/ConsumerClient.java
@@ -45,7 +45,7 @@ public class ConsumerClient{
 
     private List<NameValuePair> parseQueryString(String queryString) {
         return Arrays.stream(queryString.split("&")).map(s -> s.split("="))
-          .map(p -> new BasicNameValuePair(p[0], UrlEscapers.urlFormParameterEscaper().escape(p[1])))
+          .map(p -> new BasicNameValuePair(p[0], p[1]))
           .collect(Collectors.toList());
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -343,7 +343,7 @@ public class PactDslRequestWithPath {
    * Match a query parameter with a regex.
    * @param parameter Query parameter
    * @param regex Regular expression to match with
-   * @param example Example value to use for the query parameter
+   * @param example Example value to use for the query parameter (unencoded)
    */
   public PactDslRequestWithPath matchQuery(String parameter, String regex, String example) {
     requestMatchers.addCategory("query").addRule(parameter, new RegexMatcher(regex));

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -129,6 +129,16 @@ public class PactDslRequestWithPath {
     }
 
     /**
+     * The encoded query string for the request
+     *
+     * @param query query string
+     */
+    public PactDslRequestWithPath encodedQuery(String query) {
+        this.query = PactReader.queryStringToMap(query, true);
+        return this;
+    }
+
+    /**
      * The body of the request
      *
      * @param body Request body in string form

--- a/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MockHttpServer.kt
+++ b/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MockHttpServer.kt
@@ -128,7 +128,7 @@ abstract class BaseMockServer(val pact: RequestResponsePact,
       OptionalBody.body(bodyContents)
     }
     return Request(exchange.requestMethod, exchange.requestURI.path,
-      PactReader.queryStringToMap(exchange.requestURI.query), headers, body)
+      PactReader.queryStringToMap(exchange.requestURI.rawQuery), headers, body)
   }
 
   private fun initServer() {

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactQueryParameterTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactQueryParameterTest.java
@@ -1,0 +1,95 @@
+package au.com.dius.pact.consumer;
+
+import au.com.dius.pact.model.MockProviderConfig;
+import au.com.dius.pact.model.RequestResponsePact;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static au.com.dius.pact.consumer.ConsumerPactRunnerKt.runConsumerTest;
+import static org.junit.Assert.assertEquals;
+
+public class PactQueryParameterTest {
+    @Test
+    public void testMatchQueryWithSimpleQueryParameter() throws Throwable {
+        // Given a pact expecting GET /hello?q=simple created using the .matchQuery(...) method
+        String path = "/hello";
+        String parameterName = "q";
+        String decodedValue = "simple";
+        String encodedValue = "simple";
+        String encodedFullPath = path + "?" + parameterName + "=" + encodedValue;
+
+        RequestResponsePact pact = ConsumerPactBuilder
+            .consumer("Some Consumer")
+            .hasPactWith("Some Provider")
+            .uponReceiving(encodedFullPath)
+            .path(path)
+            .matchQuery(parameterName, ".+", decodedValue)
+            .method("GET")
+            .willRespondWith()
+            .status(200)
+            .toPact();
+
+        // When sending the request, we expect no errors
+        verifyRequestMatches(pact, encodedFullPath);
+    }
+
+    @Test
+    public void testMatchQueryWithComplexQueryParameter() throws Throwable {
+        // Given a pact expecting GET /hello?q=query%20containing%20%26%20and%20%3F%20characters
+        // created using the .matchQuery(...) method
+        String path = "/hello";
+        String parameterName = "q";
+        String decodedValue = "query containing & and ? characters";
+        String encodedValue = "query%20containing%20%26%20and%20%3F%20characters";
+        String encodedFullPath = path + "?" + parameterName + "=" + encodedValue;
+
+        RequestResponsePact pact = ConsumerPactBuilder
+            .consumer("Some Consumer")
+            .hasPactWith("Some Provider")
+            .uponReceiving(encodedFullPath)
+            .path(path)
+            .matchQuery(parameterName, ".+", decodedValue)
+            .method("GET")
+            .willRespondWith()
+            .status(200)
+            .toPact();
+
+        // When sending the request, we expect no errors
+        verifyRequestMatches(pact, encodedFullPath);
+    }
+
+    private void verifyRequestMatches(RequestResponsePact pact, String fullPath) {
+        MockProviderConfig config = MockProviderConfig.createDefault();
+        PactVerificationResult result = runConsumerTest(pact, config, new PactTestRun() {
+            @Override
+            public void run(@NotNull MockServer mockServer) throws IOException {
+                String uri = mockServer.getUrl() + "/" + fullPath;
+
+                Request.Get(uri).execute().handleResponse(httpResponse -> {
+                    String content = EntityUtils.toString(httpResponse.getEntity());
+                    if (httpResponse.getStatusLine().getStatusCode() == 500) {
+                        Map map = new ObjectMapper().readValue(content, Map.class);
+                        Assert.fail((String) map.get("error"));
+                    }
+                    return null;
+                });
+            }
+        });
+        if (result instanceof PactVerificationResult.Error) {
+            Throwable error = ((PactVerificationResult.Error) result).getError();
+            if (error instanceof RuntimeException) {
+                throw (RuntimeException) error;
+            } else {
+                throw new RuntimeException(error);
+            }
+        }
+        assertEquals(PactVerificationResult.Ok.INSTANCE, result);
+    }
+}

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactQueryParameterTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactQueryParameterTest.java
@@ -65,6 +65,55 @@ public class PactQueryParameterTest {
         verifyRequestMatches(pact, encodedFullPath);
     }
 
+    @Test
+    public void testEncodedQueryWithSimpleQueryParameter() throws Throwable {
+        // Given a pact expecting GET /hello?q=simple, created using the .query(...) method
+        String path = "/hello";
+        String parameterName = "q";
+        String encodedValue = "simple";
+        String encodedQuery = parameterName + "=" + encodedValue;
+        String encodedFullPath = path + "?" + encodedQuery;
+
+        RequestResponsePact pact = ConsumerPactBuilder
+            .consumer("Some Consumer")
+            .hasPactWith("Some Provider")
+            .uponReceiving(encodedFullPath)
+            .path(path)
+            .encodedQuery(encodedQuery)
+            .method("GET")
+            .willRespondWith()
+            .status(200)
+            .toPact();
+
+        // When sending the request, we expect no errors
+        verifyRequestMatches(pact, encodedFullPath);
+    }
+
+    @Test
+    public void testEncodedQueryWithComplexQueryParameter() throws Throwable {
+        // Given a pact expecting GET /hello?q=query%20containing%20%26%20and%20%3F%20characters,
+        // created using the .query(...) method
+        String path = "/hello";
+        String parameterName = "q";
+        String encodedValue = "query%20containing%20%26%20and%20%3F%20characters";
+        String encodedQuery = parameterName + "=" + encodedValue;
+        String encodedFullPath = path + "?" + encodedQuery;
+
+        RequestResponsePact pact = ConsumerPactBuilder
+            .consumer("Some Consumer")
+            .hasPactWith("Some Provider")
+            .uponReceiving(encodedFullPath)
+            .path(path)
+            .encodedQuery(encodedQuery)
+            .method("GET")
+            .willRespondWith()
+            .status(200)
+            .toPact();
+
+        // When sending the request, we expect no errors
+        verifyRequestMatches(pact, encodedFullPath);
+    }
+
     private void verifyRequestMatches(RequestResponsePact pact, String fullPath) {
         MockProviderConfig config = MockProviderConfig.createDefault();
         PactVerificationResult result = runConsumerTest(pact, config, new PactTestRun() {


### PR DESCRIPTION
As mentioned in issue #567, the MockHttpServer was double-decoding query parameters. This PR fixes this, adds some more tests and fixes an existing test that was double-encoding parameters before sending.

Furthermore, to keep the existing API, this PR does not change the behavior of the `.query(...)` DSL method which expects a *unencoded* query string. Instead it adds a `.encodedQuery(...)` method that is expected to be encoded. This allows for it to contain `&` and `=` characters.

Fixes: #567