### PR TITLE
Add matchQuery with List as example

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslRequestWithPath.java
@@ -340,24 +340,39 @@ public class PactDslRequestWithPath {
         return new PactDslResponse(consumerPactBuilder, this);
     }
 
-  /**
-  * Match a query parameter with a regex. A random query parameter value will be generated from the regex.
-  * @param parameter Query parameter
-  * @param regex Regular expression to match with
-  */
-  public PactDslRequestWithPath matchQuery(String parameter, String regex) {
-    return matchQuery(parameter, regex, new Generex(regex).random());
-  }
+    /**
+     * Match a query parameter with a regex. A random query parameter value will be generated from the regex.
+     *
+     * @param parameter Query parameter
+     * @param regex     Regular expression to match with
+     */
+    public PactDslRequestWithPath matchQuery(String parameter, String regex) {
+        return matchQuery(parameter, regex, new Generex(regex).random());
+    }
 
-  /**
-   * Match a query parameter with a regex.
-   * @param parameter Query parameter
-   * @param regex Regular expression to match with
-   * @param example Example value to use for the query parameter (unencoded)
-   */
-  public PactDslRequestWithPath matchQuery(String parameter, String regex, String example) {
-    requestMatchers.addCategory("query").addRule(parameter, new RegexMatcher(regex));
-    query.put(parameter, Collections.singletonList(example));
-    return this;
-  }
+    /**
+     * Match a query parameter with a regex.
+     *
+     * @param parameter Query parameter
+     * @param regex     Regular expression to match with
+     * @param example   Example value to use for the query parameter (unencoded)
+     */
+    public PactDslRequestWithPath matchQuery(String parameter, String regex, String example) {
+        requestMatchers.addCategory("query").addRule(parameter, new RegexMatcher(regex));
+        query.put(parameter, Collections.singletonList(example));
+        return this;
+    }
+
+    /**
+     * Match a repeating query parameter with a regex.
+     *
+     * @param parameter Query parameter
+     * @param regex     Regular expression to match with each element
+     * @param example   Example value list to use for the query parameter (unencoded)
+     */
+    public PactDslRequestWithPath matchQuery(String parameter, String regex, List<String> example) {
+        requestMatchers.addCategory("query").addRule(parameter, new RegexMatcher(regex));
+        query.put(parameter, example);
+        return this;
+    }
 }


### PR DESCRIPTION
As discussed in #509 pact-jvm should be able to allow lists of examples for query param definitions. This commit adds no new functionality, just enables the API to use the existing one. This method will create requests that look like this: /path?param=A&param=B

Also fixed some formatting

Fix #509