### PR TITLE
fix(provider-junit): fixes #527

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
@@ -67,8 +67,7 @@ public class PactBrokerLoader implements PactLoader {
 
   public List<Pact> load(final String providerName) throws IOException {
     List<Pact> pacts = new ArrayList<>();
-    if (pactBrokerTags == null || pactBrokerTags.isEmpty() || pactBrokerTags.size() == 1 &&
-      pactBrokerTags.contains(LATEST)) {
+    if (pactBrokerTags == null || pactBrokerTags.isEmpty()) {
       pacts.addAll(loadPactsForProvider(providerName, null));
     } else {
       for (String tag : pactBrokerTags) {

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
@@ -106,7 +106,7 @@ public class PactBrokerLoader implements PactLoader {
     try {
       List<ConsumerInfo> consumers;
       PactBrokerClient pactBrokerClient = newPactBrokerClient(uriBuilder.build());
-      if (StringUtils.isEmpty(tag)) {
+      if (StringUtils.isEmpty(tag) || tag.equals(LATEST)) {
         consumers = pactBrokerClient.fetchConsumers(providerName).stream()
           .map(ConsumerInfo::from).collect(toList());
       } else {

--- a/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -154,17 +154,32 @@ class PactBrokerLoaderSpec extends Specification {
 
   def 'Loads pacts for each provided tag'() {
     given:
-    tags = ['latest', 'a', 'b', 'c']
+    tags = ['a', 'b', 'c']
 
     when:
     def result = pactBrokerLoader().load('test')
 
     then:
-    1 * brokerClient.fetchConsumersWithTag('test', 'latest') >> [ new PactBrokerConsumer('test', 'latest', '', []) ]
     1 * brokerClient.fetchConsumersWithTag('test', 'a') >> [ new PactBrokerConsumer('test', 'a', '', []) ]
     1 * brokerClient.fetchConsumersWithTag('test', 'b') >> [ new PactBrokerConsumer('test', 'b', '', []) ]
     1 * brokerClient.fetchConsumersWithTag('test', 'c') >> [ new PactBrokerConsumer('test', 'c', '', []) ]
-    result.size() == 4
+    0 * _
+    result.size() == 3
+  }
+
+  def 'Loads latest pacts together with other tags'() {
+    given:
+    tags = ['a', 'latest', 'b']
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    1 * brokerClient.fetchConsumersWithTag('test', 'a') >> [ new PactBrokerConsumer('test', 'a', '', []) ]
+    1 * brokerClient.fetchConsumers('test') >> [ new PactBrokerConsumer('test', 'latest', '', []) ]
+    1 * brokerClient.fetchConsumersWithTag('test', 'b') >> [ new PactBrokerConsumer('test', 'b', '', []) ]
+    0 * _
+    result.size() == 3
   }
 
   @RestoreSystemProperties


### PR DESCRIPTION
if tags contain 'latest', latest pact with consumer is fetched for 'latest', not a pact tagged 'latest'