### PR TITLE
Improve URL encoding in uploadJson URLs

### DIFF
--- a/pact-jvm-pact-broker/src/main/groovy/au/com/dius/pact/provider/broker/PactBrokerClient.groovy
+++ b/pact-jvm-pact-broker/src/main/groovy/au/com/dius/pact/provider/broker/PactBrokerClient.groovy
@@ -94,7 +94,7 @@ class PactBrokerClient extends PactBrokerClientBase {
       } else {
         "FAILED! $status"
       }
-    } as BiFunction<String,String, Object>, false)
+    }, false)
   }
 
   static uploadTags(IHalClient halClient, String consumerName, String version, List<String> tags) {

--- a/pact-jvm-pact-broker/src/test/groovy/au/com/dius/pact/provider/broker/PactBrokerClientSpec.groovy
+++ b/pact-jvm-pact-broker/src/test/groovy/au/com/dius/pact/provider/broker/PactBrokerClientSpec.groovy
@@ -173,12 +173,14 @@ class PactBrokerClientSpec extends Specification {
     def result = client.uploadPactFile(pactFile, '10.0.0')
 
     then:
-    1 * halClient.uploadJson('/pacts/provider/Provider/consumer/Foo%20Consumer/version/10.0.0', pactContents, _) >>
+    1 * halClient.uploadJson(
+      '/pacts/provider/Provider/consumer/Foo%20Consumer/version/10.0.0',
+      pactContents, _, false) >>
       { args -> args[2].apply('Failed', 'Error') }
     result == 'FAILED! Error'
   }
 
-  def 'encode the provider name, consumer name and tags when uploading a pact'() {
+  def 'encode the provider name, consumer name, tags and version when uploading a pact'() {
     given:
     def halClient = Mock(IHalClient)
     def client = Spy(PactBrokerClient, constructorArgs: ['baseUrl']) {
@@ -199,12 +201,12 @@ class PactBrokerClientSpec extends Specification {
     pactFile.write pactContents
 
     when:
-    client.uploadPactFile(pactFile, '10.0.0', [tag])
+    client.uploadPactFile(pactFile, '10.0.0/B', [tag])
 
     then:
-    1 * halClient.uploadJson('/pacts/provider/Provider%2FA/consumer/Foo%20Consumer%2FA/version/10.0.0',
-      pactContents, _) >> { args -> args[2].apply('OK', 'OK') }
-    1 * halClient.uploadJson('/pacticipants/Foo%20Consumer%2FA/versions/10.0.0/tags/A%2FB', '', _, false)
+    1 * halClient.uploadJson('/pacts/provider/Provider%2FA/consumer/Foo%20Consumer%2FA/version/10.0.0%2FB',
+      pactContents, _, false) >> { args -> args[2].apply('OK', 'OK') }
+    1 * halClient.uploadJson('/pacticipants/Foo%20Consumer%2FA/versions/10.0.0%2FB/tags/A%2FB', '', _, false)
   }
 
   @Unroll


### PR DESCRIPTION
Encodes tags, doesn't double encode spaces etc (fixes #599 )

I had some trouble with the pact tests in `pact-jvm-provider_2.12` after making this change - I suspect something is misconfigured on my end, but it's worth confirming I didn't break anything.