### PR TITLE
Fix for #605

### DIFF
--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
@@ -223,8 +223,11 @@ public class LambdaDslJsonArray {
     /**
      * Element that is an array where each item must match the following example
      */
-    public LambdaDslJsonArray eachLike() {
-        pactArray.eachLike();
+    public LambdaDslJsonArray eachLike(Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.eachLike();
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -233,8 +236,11 @@ public class LambdaDslJsonArray {
      *
      * @param numberExamples Number of examples to generate
      */
-    public LambdaDslJsonArray eachLike(int numberExamples) {
-        pactArray.eachLike(numberExamples);
+    public LambdaDslJsonArray eachLike(int numberExamples, Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.eachLike(numberExamples);
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -243,8 +249,11 @@ public class LambdaDslJsonArray {
      *
      * @param size minimum size of the array
      */
-    public LambdaDslJsonArray minArrayLike(Integer size) {
-        pactArray.minArrayLike(size, size);
+    public LambdaDslJsonArray minArrayLike(Integer size, Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.minArrayLike(size);
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -255,8 +264,12 @@ public class LambdaDslJsonArray {
      * @param size           minimum size of the array
      * @param numberExamples number of examples to generate
      */
-    public LambdaDslJsonArray minArrayLike(Integer size, int numberExamples) {
-        pactArray.minArrayLike(size, numberExamples);
+    public LambdaDslJsonArray minArrayLike(Integer size, int numberExamples,
+                                           Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.minArrayLike(size, numberExamples);
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -265,8 +278,11 @@ public class LambdaDslJsonArray {
      *
      * @param size maximum size of the array
      */
-    public LambdaDslJsonArray maxArrayLike(Integer size) {
-        pactArray.maxArrayLike(size);
+    public LambdaDslJsonArray maxArrayLike(Integer size, Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.maxArrayLike(size);
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -277,8 +293,12 @@ public class LambdaDslJsonArray {
      * @param size           maximum size of the array
      * @param numberExamples number of examples to generate
      */
-    public LambdaDslJsonArray maxArrayLike(Integer size, int numberExamples) {
-        pactArray.maxArrayLike(size, numberExamples);
+    public LambdaDslJsonArray maxArrayLike(Integer size, int numberExamples,
+                                           Consumer<LambdaDslJsonBody> nestedObject) {
+        final PactDslJsonBody arrayLike = pactArray.maxArrayLike(size, numberExamples);
+        final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(arrayLike);
+        nestedObject.accept(dslBody);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -290,33 +310,53 @@ public class LambdaDslJsonArray {
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayLike() {
-        pactArray.eachArrayLike();
+    public LambdaDslJsonArray eachArrayLike(Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayLike();
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayLike(int numberExamples) {
-        pactArray.eachArrayLike(numberExamples);
+    public LambdaDslJsonArray eachArrayLike(int numberExamples, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayLike(numberExamples);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayWithMaxLike(Integer size) {
-        pactArray.eachArrayWithMaxLike(size);
+    public LambdaDslJsonArray eachArrayWithMaxLike(Integer size, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayWithMaxLike(size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayWithMaxLike(int numberExamples, Integer size) {
-        pactArray.eachArrayWithMaxLike(numberExamples, size);
+    public LambdaDslJsonArray eachArrayWithMaxLike(int numberExamples, Integer size,
+                                                   Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayWithMaxLike(numberExamples, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayWithMinLike(Integer size) {
-        pactArray.eachArrayWithMinLike(size);
+    public LambdaDslJsonArray eachArrayWithMinLike(Integer size, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayWithMinLike(size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslJsonArray eachArrayWithMinLike(int numberExamples, Integer size) {
-        pactArray.eachArrayWithMinLike(numberExamples, size);
+    public LambdaDslJsonArray eachArrayWithMinLike(int numberExamples, Integer size,
+                                                   Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = pactArray.eachArrayWithMinLike(numberExamples, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 

--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -209,7 +209,7 @@ public class LambdaDslObject {
     /**
      * Attribute that must be an ISO formatted timestamp
      *
-     * @param name
+     * @param name attribute name
      */
     public LambdaDslObject timestamp(String name) {
         object.timestamp(name);
@@ -270,8 +270,11 @@ public class LambdaDslObject {
      *
      * @param name field name
      */
-    public LambdaDslObject eachLike(String name) {
-        object.eachLike(name);
+    public LambdaDslObject eachLike(String name, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody arrayLike = object.eachLike(name);
+        final LambdaDslObject dslObject = new LambdaDslObject(arrayLike);
+        nestedObject.accept(dslObject);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -281,8 +284,11 @@ public class LambdaDslObject {
      * @param name           field name
      * @param numberExamples number of examples to generate
      */
-    public LambdaDslObject eachLike(String name, int numberExamples) {
-        object.eachLike(name, numberExamples);
+    public LambdaDslObject eachLike(String name, int numberExamples, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody arrayLike = object.eachLike(name, numberExamples);
+        final LambdaDslObject dslObject = new LambdaDslObject(arrayLike);
+        nestedObject.accept(dslObject);
+        arrayLike.closeArray();
         return this;
     }
 
@@ -292,8 +298,11 @@ public class LambdaDslObject {
      * @param name field name
      * @param size minimum size of the array
      */
-    public LambdaDslObject minArrayLike(String name, Integer size) {
-        object.minArrayLike(name, size);
+    public LambdaDslObject minArrayLike(String name, Integer size, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody minArrayLike = object.minArrayLike(name, size);
+        final LambdaDslObject dslObject = new LambdaDslObject(minArrayLike);
+        nestedObject.accept(dslObject);
+        minArrayLike.closeArray();
         return this;
     }
 
@@ -304,8 +313,12 @@ public class LambdaDslObject {
      * @param size           minimum size of the array
      * @param numberExamples number of examples to generate
      */
-    public LambdaDslObject minArrayLike(String name, Integer size, int numberExamples) {
-        object.minArrayLike(name, size, numberExamples);
+    public LambdaDslObject minArrayLike(String name, Integer size, int numberExamples,
+                                        Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody minArrayLike = object.minArrayLike(name, size, numberExamples);
+        final LambdaDslObject dslObject = new LambdaDslObject(minArrayLike);
+        nestedObject.accept(dslObject);
+        minArrayLike.closeArray();
         return this;
     }
 
@@ -315,8 +328,11 @@ public class LambdaDslObject {
      * @param name field name
      * @param size maximum size of the array
      */
-    public LambdaDslObject maxArrayLike(String name, Integer size) {
-        object.minArrayLike(name, size);
+    public LambdaDslObject maxArrayLike(String name, Integer size, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody maxArrayLike = object.maxArrayLike(name, size);
+        final LambdaDslObject dslObject = new LambdaDslObject(maxArrayLike);
+        nestedObject.accept(dslObject);
+        maxArrayLike.closeArray();
         return this;
     }
 
@@ -327,8 +343,12 @@ public class LambdaDslObject {
      * @param size           maximum size of the array
      * @param numberExamples number of examples to generate
      */
-    public LambdaDslObject maxArrayLike(String name, Integer size, int numberExamples) {
-        object.maxArrayLike(name, size, numberExamples);
+    public LambdaDslObject maxArrayLike(String name, Integer size, int numberExamples,
+                                        Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody maxArrayLike = object.maxArrayLike(name, size, numberExamples);
+        final LambdaDslObject dslObject = new LambdaDslObject(maxArrayLike);
+        nestedObject.accept(dslObject);
+        maxArrayLike.closeArray();
         return this;
     }
 
@@ -342,36 +362,56 @@ public class LambdaDslObject {
         return this;
     }
 
-    public LambdaDslObject eachArrayLike(String name) {
-        object.eachArrayLike(name);
+    public LambdaDslObject eachArrayLike(String name, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayLike(name);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslObject eachArrayLike(String name, int numberExamples) {
-        object.eachArrayLike(name, numberExamples);
+    public LambdaDslObject eachArrayLike(String name, int numberExamples, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayLike(name, numberExamples);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
-    public LambdaDslObject eachArrayWithMaxLike(String name, Integer size) {
-        object.eachArrayWithMaxLike(name, size);
-        return this;
-    }
-
-
-    public LambdaDslObject eachArrayWithMaxLike(String name, int numberExamples, Integer size) {
-        object.eachArrayWithMaxLike(name, numberExamples, size);
-        return this;
-    }
-
-
-    public LambdaDslObject eachArrayWithMinLike(String name, Integer size) {
-        object.eachArrayWithMinLike(name, size);
+    public LambdaDslObject eachArrayWithMaxLike(String name, Integer size, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayWithMaxLike(name, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 
 
-    public LambdaDslObject eachArrayWithMinLike(String name, int numberExamples, Integer size) {
-        object.eachArrayWithMinLike(name, numberExamples, size);
+    public LambdaDslObject eachArrayWithMaxLike(String name, int numberExamples, Integer size,
+                                                Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayWithMaxLike(name, numberExamples, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
+        return this;
+    }
+
+
+    public LambdaDslObject eachArrayWithMinLike(String name, Integer size, Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayWithMinLike(name, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
+        return this;
+    }
+
+
+    public LambdaDslObject eachArrayWithMinLike(String name, int numberExamples, Integer size,
+                                                Consumer<LambdaDslJsonArray> nestedArray) {
+        final PactDslJsonArray arrayLike = object.eachArrayWithMinLike(name, numberExamples, size);
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(arrayLike);
+        nestedArray.accept(dslArray);
+        arrayLike.closeArray().closeArray();
         return this;
     }
 

--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -420,8 +420,11 @@ public class LambdaDslObject {
      *
      * @param exampleKey Example key to use for generating bodies
      */
-    public LambdaDslObject eachKeyMappedToAnArrayLike(String exampleKey) {
-        object.eachKeyMappedToAnArrayLike(exampleKey);
+    public LambdaDslObject eachKeyMappedToAnArrayLike(String exampleKey, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody objectLike = object.eachKeyMappedToAnArrayLike(exampleKey);
+        final LambdaDslObject dslObject = new LambdaDslObject(objectLike);
+        nestedObject.accept(dslObject);
+        objectLike.closeObject().closeArray();
         return this;
     }
 
@@ -430,8 +433,11 @@ public class LambdaDslObject {
      *
      * @param exampleKey Example key to use for generating bodies
      */
-    public LambdaDslObject eachKeyLike(String exampleKey) {
-        object.eachKeyLike(exampleKey);
+    public LambdaDslObject eachKeyLike(String exampleKey, Consumer<LambdaDslObject> nestedObject) {
+        final PactDslJsonBody objectLike = object.eachKeyLike(exampleKey);
+        final LambdaDslObject dslObject = new LambdaDslObject(objectLike);
+        nestedObject.accept(dslObject);
+        objectLike.closeObject();
         return this;
     }
 

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
@@ -3,7 +3,7 @@ package io.pactfoundation.consumer.dsl;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertThat;
 public class LambdaDslJsonArrayTest {
 
     @Test
-    public void testObjectArray() throws IOException {
+    public void testObjectArray() {
         /*
             [
                 {
@@ -25,25 +25,21 @@ public class LambdaDslJsonArrayTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonArray("", "", null, false)
-            .object()
-            .stringValue("foo", "Foo")
-            .closeObject()
-            .object()
-            .stringType("bar", "Bar")
-            .closeObject()
-            .getBody().toString();
+                .object()
+                .stringValue("foo", "Foo")
+                .closeObject()
+                .object()
+                .stringType("bar", "Bar")
+                .closeObject()
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
         final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
         array
-            .object((o) -> {
-                o.stringValue("foo", "Foo");
-            })
-            .object((o) -> {
-                o.stringValue("bar", "Bar");
-            })
-            .build();
+                .object((o) -> o.stringValue("foo", "Foo"))
+                .object((o) -> o.stringValue("bar", "Bar"))
+                .build();
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
@@ -52,7 +48,7 @@ public class LambdaDslJsonArrayTest {
     }
 
     @Test
-    public void testStringArray() throws IOException {
+    public void testStringArray() {
         /*
             [
                 "Foo",
@@ -62,26 +58,26 @@ public class LambdaDslJsonArrayTest {
          */
         // Old DSL
         final String pactDslJson = new PactDslJsonArray("", "", null, false)
-            .string("Foo")
-            .stringType("Bar")
-            .stringMatcher("[a-z]", "x")
-            .getBody().toString();
+                .string("Foo")
+                .stringType("Bar")
+                .stringMatcher("[a-z]", "x")
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
         final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
         array
-            .stringValue("Foo")
-            .stringType("Bar")
-            .stringMatcher("[a-z]", "x")
-            .build();
+                .stringValue("Foo")
+                .stringType("Bar")
+                .stringMatcher("[a-z]", "x")
+                .build();
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
     }
 
     @Test
-    public void testNumberArray() throws IOException {
+    public void testNumberArray() {
         /*
             [
                 1,
@@ -91,26 +87,26 @@ public class LambdaDslJsonArrayTest {
          */
         // Old DSL
         final String pactDslJson = new PactDslJsonArray("", "", null, false)
-            .numberValue(1)
-            .numberValue(2)
-            .numberValue(3)
-            .getBody().toString();
+                .numberValue(1)
+                .numberValue(2)
+                .numberValue(3)
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
         final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
         array
-            .numberValue(1)
-            .numberValue(2)
-            .numberValue(3)
-            .build();
+                .numberValue(1)
+                .numberValue(2)
+                .numberValue(3)
+                .build();
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
     }
 
     @Test
-    public void testArrayArray() throws IOException {
+    public void testArrayArray() {
         /*
             [
                 ["a1", "a2"],
@@ -120,32 +116,460 @@ public class LambdaDslJsonArrayTest {
          */
         // Old DSL
         final String pactDslJson = new PactDslJsonArray("", "", null, false)
-            .array()
-            .stringValue("a1")
-            .stringValue("a2")
-            .closeArray()
-            .array()
-            .numberValue(1)
-            .numberValue(2)
-            .closeArray()
-            .array()
-            .object()
-            .stringValue("foo", "Foo")
-            .closeObject()
-            .closeArray()
-            .getBody().toString();
+                .array()
+                .stringValue("a1")
+                .stringValue("a2")
+                .closeArray()
+                .array()
+                .numberValue(1)
+                .numberValue(2)
+                .closeArray()
+                .array()
+                .object()
+                .stringValue("foo", "Foo")
+                .closeObject()
+                .closeArray()
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
         final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
         array
-            .array((a) -> a.stringValue("a1").stringValue("a2"))
-            .array((a) -> a.numberValue(1).numberValue(2))
-            .array((a) -> a.object((o) -> o.stringValue("foo", "Foo")))
-            .build();
+                .array((a) -> a.stringValue("a1").stringValue("a2"))
+                .array((a) -> a.numberValue(1).numberValue(2))
+                .array((a) -> a.object((o) -> o.stringValue("foo", "Foo")))
+                .build();
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
     }
 
+    @Test
+    public void testEachArrayLike() {
+        /*
+            [
+                [
+                    ["Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayLike()
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayLike(a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayLikeWithExample() {
+        /*
+            [
+                [
+                    ["Foo", "Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayLike(2)
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayLike(2, a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMinLike() {
+        /*
+            [
+                [
+                    ["Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayWithMinLike(2)
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayWithMinLike(2, a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMinLikeWithExample() {
+        /*
+            [
+                [
+                    ["Foo", "Foo", "Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayWithMinLike(3, 2)
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayWithMinLike(3, 2, a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMaxLike() {
+        /*
+            [
+                [
+                    ["Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayWithMaxLike(2)
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayWithMaxLike(2, a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMaxLikeWithExample() {
+        /*
+            [
+                [
+                    ["Foo", "Foo"]
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachArrayWithMaxLike(2, 3)
+                .stringType("Foo")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachArrayWithMaxLike(2, 3, a -> a.stringType("Foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(3));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachLike() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachLike()
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachLike(o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachLikeWithExample() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    },
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .eachLike(2)
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .eachLike(2, o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMinArrayLike() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    },
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .minArrayLike(2)
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .minArrayLike(2, o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMinArrayLikeWithExample() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    },
+                    {
+                        "foo": "string"
+                    },
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .minArrayLike(2, 3)
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .minArrayLike(2, 3, o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMaxArrayLike() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .maxArrayLike(2)
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .maxArrayLike(2, o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(2));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMaxArrayLikeWithExample() {
+        /*
+            [
+                [
+                    {
+                        "foo": "string"
+                    },
+                    {
+                        "foo": "string"
+                    }
+                ]
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray()
+                .maxArrayLike(3, 2)
+                .stringType("foo")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray();
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .maxArrayLike(3, 2, o -> o.stringType("foo"))
+                .build();
+
+        final String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(3));
+        final Map<String, Object> objectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(objectRule.get("match"), is("type"));
+    }
 }

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
@@ -3,7 +3,6 @@ package io.pactfoundation.consumer.dsl;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -13,7 +12,7 @@ import static org.junit.Assert.assertThat;
 public class LambdaDslObjectTest {
 
     @Test
-    public void testStringValue() throws IOException {
+    public void testStringValue() {
          /*
             {
                 "bar": "Bar",
@@ -23,16 +22,16 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .stringValue("foo", "Foo")
-            .stringValue("bar", "Bar")
-            .getBody().toString();
+                .stringValue("foo", "Foo")
+                .stringValue("bar", "Bar")
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody("", "", null);
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringValue("foo", "Foo")
-            .stringValue("bar", "Bar");
+                .stringValue("foo", "Foo")
+                .stringValue("bar", "Bar");
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
@@ -41,11 +40,11 @@ public class LambdaDslObjectTest {
     }
 
     @Test
-    public void testStringMatcher() throws IOException {
+    public void testStringMatcher() {
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody("", "", null);
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringMatcher("foo", "[a-z][0-9]");
+                .stringMatcher("foo", "[a-z][0-9]");
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString().replace("\"", "'");
@@ -57,7 +56,7 @@ public class LambdaDslObjectTest {
     }
 
     @Test
-    public void testStringMatcherWithExample() throws IOException {
+    public void testStringMatcherWithExample() {
          /*
             {
                 "foo": "a0"
@@ -66,14 +65,14 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .stringMatcher("foo", "[a-z][0-9]", "a0")
-            .getBody().toString();
+                .stringMatcher("foo", "[a-z][0-9]", "a0")
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringMatcher("foo", "[a-z][0-9]", "a0");
+                .stringMatcher("foo", "[a-z][0-9]", "a0");
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
@@ -85,11 +84,11 @@ public class LambdaDslObjectTest {
     }
 
     @Test
-    public void testStringType() throws IOException {
+    public void testStringType() {
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringType("foo");
+                .stringType("foo");
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString().replace("\"", "'");
@@ -100,7 +99,7 @@ public class LambdaDslObjectTest {
     }
 
     @Test
-    public void testStringTypeWithExample() throws IOException {
+    public void testStringTypeWithExample() {
         /*
             {
                 "foo": "Foo"
@@ -109,14 +108,14 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .stringType("foo", "Foo")
-            .getBody().toString();
+                .stringType("foo", "Foo")
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody("", "", null);
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringType("foo", "Foo");
+                .stringType("foo", "Foo");
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
@@ -124,11 +123,10 @@ public class LambdaDslObjectTest {
         assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(1));
         final Map matcher = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
         assertThat(matcher.get("match"), is("type"));
-        System.out.println(actualJson);
     }
 
     @Test
-    public void testStringTypes() throws IOException {
+    public void testStringTypes() {
         /*
             {
                 "foo": [
@@ -141,14 +139,14 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .stringType(new String[]{"foo", "bar"})
-            .getBody().toString();
+                .stringType(new String[]{"foo", "bar"})
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .stringType(new String[]{"foo", "bar"});
+                .stringType(new String[]{"foo", "bar"});
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
@@ -161,11 +159,10 @@ public class LambdaDslObjectTest {
         assertThat(matcher.get("match"), is("type"));
         matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
         assertThat(matcher.get("match"), is("type"));
-        System.out.println(actualJson);
     }
 
     @Test
-    public void testArray() throws IOException {
+    public void testArray() {
         /*
             {
                 "foo": [
@@ -178,22 +175,18 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .array("foo")
-            .object()
-            .stringValue("bar", "Bar")
-            .closeObject()
-            .closeArray()
-            .getBody().toString();
+                .array("foo")
+                .object()
+                .stringValue("bar", "Bar")
+                .closeObject()
+                .closeArray()
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .array("foo", (array) -> {
-                array.object((o) -> {
-                    o.stringValue("bar", "Bar");
-                });
-            });
+                .array("foo", (array) -> array.object((o) -> o.stringValue("bar", "Bar")));
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
@@ -202,7 +195,7 @@ public class LambdaDslObjectTest {
     }
 
     @Test
-    public void testObject() throws IOException {
+    public void testObject() {
         /*
             {
                 "foo": {
@@ -213,23 +206,477 @@ public class LambdaDslObjectTest {
 
         // Old DSL
         final String pactDslJson = new PactDslJsonBody()
-            .object("foo")
-            .stringType("bar", "Bar")
-            .closeObject()
-            .getBody().toString();
+                .object("foo")
+                .stringType("bar", "Bar")
+                .closeObject()
+                .getBody().toString();
 
         // Lambda DSL
         final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
         final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
         object
-            .object("foo", (o) -> {
-                o.stringValue("bar", "Bar");
-            });
+                .object("foo", (o) -> o.stringValue("bar", "Bar"));
         actualPactDsl.close();
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
         assertThat(actualPactDsl.getMatchers().allMatchingRules().isEmpty(), is(true));
 
+    }
+
+    @Test
+    public void testEachArrayLike() {
+        /*
+            {
+                "foo": [
+                    ["Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayLike("foo")
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayLike("foo", a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    ["Bar", "Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayLike("foo", 2)
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        System.out.println(pactDslJson);
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayLike("foo", 2, a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMinLike() {
+        /*
+            {
+                "foo": [
+                    ["Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayWithMinLike("foo", 2)
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayWithMinLike("foo", 2, a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMinLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    ["Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayWithMinLike("foo", 3, 2)
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayWithMinLike("foo", 3, 2, a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMaxLike() {
+        /*
+            {
+                "foo": [
+                    ["Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayWithMaxLike("foo", 2)
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayWithMaxLike("foo", 2, a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(2));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachArrayWithMaxLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    ["Bar"]
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachArrayWithMaxLike("foo", 2, 3)
+                .stringType("Bar")
+                .closeArray()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachArrayWithMaxLike("foo", 2, 3, a -> a.stringType("Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("max"), is(3));
+        final Map<String, Object> subArrayRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(subArrayRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testEachLike() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "string"
+                    }
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachLike("foo")
+                .stringType("bar")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachLike("foo", o -> o.stringType("bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
+
+    }
+
+    @Test
+    public void testEachLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "Bar"
+                    },
+                    {
+                        "bar": "Bar"
+                    }
+                ]
+            }
+
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .eachLike("foo", 2)
+                .stringType("bar", "Bar")
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslJsonBody object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .eachLike("foo", 2, o -> o.stringType("bar", "Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("match"), is("type"));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
+
+    }
+
+    @Test
+    public void testMinArrayLike() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "string"
+                    },
+                    {
+                        "bar": "string"
+                    }
+                ]
+            }
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .minArrayLike("foo", 2)
+                .stringType("bar")
+                .closeObject()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .minArrayLike("foo", 2, o -> o.stringType("bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> arrayRule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(arrayRule.get("min"), is(2));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMinArrayLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "Bar"
+                    },
+                    {
+                        "bar": "Bar"
+                    },
+                    {
+                        "bar": "Bar"
+                    }
+                ]
+            }
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .minArrayLike("foo", 2, 3)
+                .stringType("bar", "Bar")
+                .closeObject()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .minArrayLike("foo", 2, 3, o -> o.stringType("bar", "Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> rule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(rule.get("min"), is(2));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMaxArrayLike() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "string"
+                    }
+                ]
+            }
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .maxArrayLike("foo", 2)
+                .stringType("bar")
+                .closeObject()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .maxArrayLike("foo", 2, o -> o.stringType("bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> rule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(rule.get("max"), is(2));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
+    }
+
+    @Test
+    public void testMaxArrayLikeWithExample() {
+        /*
+            {
+                "foo": [
+                    {
+                        "bar": "Bar"
+                    },
+                    {
+                        "bar": "Bar"
+                    }
+                ]
+            }
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .maxArrayLike("foo", 3, 2)
+                .stringType("bar", "Bar")
+                .closeObject()
+                .closeArray()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object
+                .maxArrayLike("foo", 3, 2, o -> o.stringType("bar", "Bar"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(2));
+        final Map<String, Object> rule = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(rule.get("max"), is(3));
+        final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(arrayObjectRule.get("match"), is("type"));
     }
 }

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
@@ -679,4 +679,51 @@ public class LambdaDslObjectTest {
         final Map<String, Object> arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
         assertThat(arrayObjectRule.get("match"), is("type"));
     }
+
+    @Test
+    public void testEachKeyLike() {
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .object("one")
+                .eachKeyLike("001-A") // key like an id where the value is matched by the following example
+                .stringType("description", "Some Description")
+                .closeObject()
+                .closeObject()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object.object("one",
+                      o -> o.eachKeyLike("001-A",
+                                         nested -> nested.stringType("description", "Some Description")));
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+    }
+
+    @Test
+    public void testEachKeyMappedToAnArrayLike() {
+        // Old DSL
+        final String pactDslJson = new PactDslJsonBody()
+                .object("one")
+                .eachKeyMappedToAnArrayLike("001")
+                .id("someId", 23456L)
+                .closeObject()
+                .closeArray()
+                .closeObject()
+                .getBody()
+                .toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslJsonBody(actualPactDsl);
+        object.object("one",
+                      o -> o.eachKeyMappedToAnArrayLike("001",
+                                                        nested -> nested.id("someId", 23456L)));
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+    }
 }


### PR DESCRIPTION
This fix allow the LambdaDSL to generate Pact spec that are compliant with those generated with the default JVM Pact DSL.

It is a bit rough on the edges (some code duplication) and break the API (by forcing the use of a consumer), but I do consider it as a minor trade-off in order to have a more fluent, less error-prone way to write Pact Specs