### PR TITLE
Fix missing generation of array examples with `eachArray*` methods

### DIFF
--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ArrayExampleTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ArrayExampleTest.java
@@ -1,0 +1,69 @@
+package au.com.dius.pact.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.RequestResponsePact;
+import groovy.json.JsonSlurper;
+import org.apache.http.client.fluent.Request;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+public class ArrayExampleTest {
+
+    private static final String APPLICATION_JSON = "application/json";
+
+    @Rule
+    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("ArrayExampleProvider", "localhost", 8082, this);
+
+    @Pact(consumer = "ArrayExampleConsumer")
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
+        final DslPart body = new PactDslJsonBody()
+                .eachArrayWithMinLike("foo", 3, 2)
+                .object()
+                .id()
+                .stringType("bar")
+                .closeObject()
+                .closeArray()
+                .closeArray();
+
+        return builder.uponReceiving("a request expecting multiple items in an array")
+                      .path("/")
+                      .method("GET")
+                      .willRespondWith()
+                      .status(200)
+                      .body(body)
+                      .toPact();
+    }
+
+    @Test
+    @PactVerification
+    public void examplesAreGeneratedForArray() throws IOException {
+        final String response = Request.Get("http://localhost:8082/")
+                                       .addHeader("Accept", APPLICATION_JSON)
+                                       .execute()
+                                       .returnContent()
+                                       .asString();
+
+        final Map<String, Object> jsonResponse = (Map<String, Object>) new JsonSlurper().parseText(response);
+
+        assertThat(jsonResponse, Matchers.hasKey("foo"));
+        final List<List<Map<String, Object>>> fooArray = (List<List<Map<String, Object>>>) jsonResponse.get("foo");
+        assertThat(fooArray.isEmpty(), is(false));
+        assertThat(fooArray.size(), is(greaterThanOrEqualTo(2)));
+        final List<Map<String, Object>> secondSubArray = fooArray.get(1);
+        assertThat(secondSubArray.size(), is(1));
+        final Map<String, Object> object = secondSubArray.get(0);
+        assertThat(object, hasKey("id"));
+        assertThat(object, hasKey("bar"));
+        System.out.println(response);
+    }
+}

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -24,7 +24,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -198,7 +197,9 @@ public class PactDslJsonArray extends DslPart {
               object.matchers.getMatchingRules().get(matcherName));
         }
         generators.addGenerators(object.generators, rootPath + appendArrayIndex(1));
-        body.put(object.getBody());
+        for (int i = 0; i < getNumberExamples(); i++) {
+            body.put(object.getBody());
+        }
     }
 
     @Override

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/dsl/PactDslJsonBodySpec.groovy
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/dsl/PactDslJsonBodySpec.groovy
@@ -100,7 +100,7 @@ class PactDslJsonBodySpec extends Specification {
       .eachArrayLike('1').closeArray().closeArray()
       .eachArrayWithMaxLike('2', 10).closeArray().closeArray()
       .eachArrayWithMinLike('3', 10).closeArray().closeArray()
-      .close().toString() == '{"0":[],"1":[[]],"2":[[]],"3":[[]],"asdf":"string"}'
+            .close().toString() == '{"0":[],"1":[[]],"2":[[]],"3":[[],[],[],[],[],[],[],[],[],[]],"asdf":"string"}'
   }
 
   def 'generate the correct JSON when the attribute name has a space'() {


### PR DESCRIPTION
Those methods were not properly generating the array examples to be used by
the Pact consumers, resulting in indirect violation of the contract and/or
incorrect handling of the data by the consumer.

The issue was probably never caught as it seems there is no test case for
example array in the spec except for the trivial "at least one element",
which is always satisfied.