### PR TITLE
Future proof task names for gradle 5.0

### DIFF
--- a/pact-jvm-provider-gradle/build.gradle
+++ b/pact-jvm-provider-gradle/build.gradle
@@ -7,6 +7,9 @@ apply plugin: 'maven-publish'
 
 dependencies {
   compile project(":pact-jvm-provider_${project.scalaVersion}")
+  testCompile 'org.powermock:powermock-module-junit4:1.7.3'
+  testCompile 'org.powermock:powermock-api-mockito2:1.7.3'
+  testCompile 'org.mockito:mockito-core:2.8.0'
   compile "org.fusesource.jansi:jansi:${project.jansiVersion}"
 }
 

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -4,6 +4,7 @@ import au.com.dius.pact.provider.ProviderInfo
 import org.gradle.api.GradleScriptException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.util.NameValidator
 
 /**
  * Main plugin class
@@ -38,7 +39,7 @@ class PactPlugin implements Plugin<Project> {
             }
 
             it.pact.serviceProviders.all { ProviderInfo provider ->
-                def providerTask = project.task("pactVerify_${provider.name}",
+                def providerTask = project.task(NameValidator.asValidName("pactVerify_${provider.name}"),
                     description: "Verify the pacts against ${provider.name}", type: PactVerificationTask,
                     group: GROUP) {
                     providerToVerify = provider

--- a/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/pact-jvm-provider-gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -15,7 +15,6 @@ class PactPlugin implements Plugin<Project> {
   private static final String PACT_VERIFY = 'pactVerify'
   private static final String TEST_CLASSES = 'testClasses'
 
-  @SuppressWarnings(['EmptyCatchBlock'])
   @Override
     void apply(Project project) {
 
@@ -40,14 +39,18 @@ class PactPlugin implements Plugin<Project> {
             }
 
             it.pact.serviceProviders.all { ProviderInfo provider ->
-                def taskName = "pactVerify_${provider.name}"
-                try {
-                  def nameValidator = this.getClass().classLoader.loadClass('org.gradle.util.NameValidator').newInstance()
-                  taskName = nameValidator.asValidName(taskName)
-                } catch (ClassNotFoundException e) {
-                  // Earlier versions of Gradle don't have NameValidator
-                  // Without it, we just don't change the task name
-                }
+                def taskName = {
+                  def defaultName = "pactVerify_${provider.name}"
+                  try {
+                    def nameValidator =
+                      this.getClass().classLoader.loadClass('org.gradle.util.NameValidator').newInstance()
+                    return nameValidator.asValidName(defaultName)
+                  } catch (ClassNotFoundException e) {
+                    // Earlier versions of Gradle don't have NameValidator
+                    // Without it, we just don't change the task name
+                    return defaultName
+                  }
+                } ()
 
                 def providerTask = project.task(taskName,
                     description: "Verify the pacts against ${provider.name}", type: PactVerificationTask,

--- a/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginTest.groovy
+++ b/pact-jvm-provider-gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPluginTest.groovy
@@ -5,9 +5,17 @@ import au.com.dius.pact.provider.PactVerification
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.NameValidator
+import org.powermock.api.mockito.PowerMockito
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import org.mockito.Mockito
 
+@RunWith(PowerMockRunner)
+@PrepareForTest(NameValidator)
 class PactPluginTest {
 
     private PactPlugin plugin
@@ -48,6 +56,23 @@ class PactPluginTest {
 
         assert project.tasks.pactVerify_provider1
         assert project.tasks.pactVerify_provider2
+    }
+
+    @Test
+    void 'uses the valid name provided by Gradle\'s NameValidator'() {
+        PowerMockito.mockStatic(NameValidator)
+        Mockito.when(NameValidator.asValidName('pactVerify_invalidName')).thenReturn('pactVerify_validName')
+
+        project.pact {
+            serviceProviders {
+                invalidName {
+
+                }
+            }
+        }
+        project.evaluate()
+
+        assert project.tasks.pactVerify_validName
     }
 
     @Test


### PR DESCRIPTION
This is a fix for the cause of #614.

Gradle's `NameValidator` class exposes an `asValidName()` method which converts names to valid names. However, currently it doesn't do anything (the [comments](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/util/NameValidator.java#L48) say that it will convert task names once the deprecated task names are actually forbidden).

This means that this PR doesn't fix the deprecation warning, but should fix the problem when the deprecation actually happens.

Possible improvements to this PR:

* Suppress the warning
* If that is not possible, generate an additional warning informing users that they can ignore the warning

Alternatives:

* Provide our own implementation of `asValidName` to suppress the warning. I don't like this, as it means that we're not robust to gradle's definition of a valid name changing.