### PR TITLE
Upgrade provider sbt plugin to 3.x, Scala 2.12, SBT 1.x

### DIFF
--- a/pact-jvm-provider-sbt/build.sbt
+++ b/pact-jvm-provider-sbt/build.sbt
@@ -1,9 +1,15 @@
 sbtPlugin := true
 isSnapshot := true
 
+scalaVersion := "2.12.4"
+organization := "au.com.dius"
+
+val currentVersion = "3.5.11"
+version := currentVersion
+
 libraryDependencies ++= Seq(
-  "au.com.dius" %% "pact-jvm-provider-sbtsupport" % Common.version,
-  "ch.qos.logback" % "logback-classic" % "1.1.7"
+  "au.com.dius" %% "pact-jvm-provider-scalasupport" % currentVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3"
 )
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/pact-jvm-provider-sbt/project/build.properties
+++ b/pact-jvm-provider-sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.3

--- a/pact-jvm-provider-sbt/src/main/scala/PactJvmPlugin.scala
+++ b/pact-jvm-provider-sbt/src/main/scala/PactJvmPlugin.scala
@@ -2,21 +2,24 @@ import au.com.dius.pact.provider.sbtsupport.Main
 import sbt.Keys.TaskStreams
 import sbt._
 
-object PactJvmPlugin extends Plugin {
-  val verifyPacts = taskKey[Unit]("**DEPRECATED** Verify this provider adheres to the pacts provided by its consumers.")
+object PactJvmPlugin extends AutoPlugin {
 
-  val pactConfig = settingKey[File]("json file containing configuration for the provider test server.")
-  val pactRoot = settingKey[File]("root folder for pact files, all .json files in root and sub folders are assumed to be pacts.")
+  object autoImport {
+    lazy val verifyPacts = taskKey[Unit]("**DEPRECATED** Verify this provider adheres to the pacts provided by its consumers.")
 
-  val pactSettings = Seq(
-    pactConfig := file("pact-config.json"),
-    pactRoot := file("pacts"),
-    verifyPacts := {
-      implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
-      val s: TaskStreams = Keys.streams.value
-      s.log.warn("=== WARNING: verifyPacts is deprecated and is being replaced with an updated task (pactVerify). ===")
-      import Main._
-      runPacts(loadFiles(pactRoot.value, pactConfig.value))
-    }
-  )
+    lazy val pactConfig = settingKey[File]("json file containing configuration for the provider test server.")
+    lazy val pactRoot = settingKey[File]("root folder for pact files, all .json files in root and sub folders are assumed to be pacts.")
+
+    lazy val pactSettings = Seq(
+      pactConfig := file("pact-config.json"),
+      pactRoot := file("pacts"),
+      verifyPacts := {
+        implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+        val s: TaskStreams = Keys.streams.value
+        s.log.warn("=== WARNING: verifyPacts is deprecated and is being replaced with an updated task (pactVerify). ===")
+        import Main._
+        runPacts(loadFiles(pactRoot.value, pactConfig.value))
+      }
+    )
+  }
 }


### PR DESCRIPTION
  - Updates `pact-jvm-provider-sbt` plugin to support SBT 1.x, Scala
  2.12.
  - Migrates to [auto plugin](http://www.scala-sbt.org/1.0/docs/Plugins.html) API.
  - See https://github.com/DiUS/pact-jvm/issues/618