### PR TITLE
Disambiguate logback Logger in SBT plugin

### DIFF
--- a/pact-jvm-provider-sbt/src/main/scala/au/com/dius/pact/provider/sbt/SbtProviderPlugin.scala
+++ b/pact-jvm-provider-sbt/src/main/scala/au/com/dius/pact/provider/sbt/SbtProviderPlugin.scala
@@ -5,7 +5,7 @@ import java.util
 import au.com.dius.pact.provider.{ProviderInfo, ConsumerInfo, PactVerification, ProviderVerifier, ProviderUtils}
 import org.apache.http.HttpRequest
 import org.slf4j.LoggerFactory
-import ch.qos.logback.classic.{Logger, Level}
+import ch.qos.logback.classic.{Logger => LogbackLogger, Level}
 import sbt.Keys.TaskStreams
 import sbt._
 
@@ -23,7 +23,7 @@ object SbtProviderPlugin extends AutoPlugin {
         val s: TaskStreams = Keys.streams.value
 
         if (System.getProperty("pact.logLevel") != null) {
-          LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(
+          LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger].setLevel(
             Level.toLevel(System.getProperty("pact.logLevel"))
           )
         }


### PR DESCRIPTION
  - Fixes an issue with abiguous usage of Logger in SBT plugin (`Logger` class is
  defined in both `sbt.Logger` and `ch.qos.logback.classic`).
  - It caused an error when trying to set a custom log level via system
  properties, since `sbt.Logger` does not implement `setLevel`.

```scala
scala> import ch.qos.logback.classic.{Logger, Level}
scala> import sbt._
scala>           LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(
     |             Level.toLevel(System.getProperty("pact.logLevel"))
     |           )
<console>:24: error: reference to Logger is ambiguous;
it is imported twice in the same scope by
import sbt._
and import ch.qos.logback.classic.{Logger, Level}
                 LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger].setLevel(
```