### PR TITLE
Add support for multipart/mixed content type

### DIFF
--- a/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/PactBuilder.groovy
+++ b/pact-jvm-consumer-groovy/src/main/groovy/au/com/dius/pact/consumer/groovy/PactBuilder.groovy
@@ -40,7 +40,7 @@ class PactBuilder extends BaseBuilder {
   private static final String BODY = 'body'
   private static final String LOCALHOST = 'localhost'
   public static final String HEADER = 'header'
-  public static final String MULTIPART_HEADER_REGEX = 'multipart/form-data;\\s*boundary=.*'
+  public static final String MULTIPART_HEADER_REGEX = 'multipart/(mixed|form-data);\\s*boundary=.*'
 
   Consumer consumer
   Provider provider

--- a/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MatchingConfig.kt
+++ b/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MatchingConfig.kt
@@ -7,7 +7,8 @@ object MatchingConfig {
     "application/json-rpc" to "au.com.dius.pact.matchers.JsonBodyMatcher",
     "application/jsonrequest" to "au.com.dius.pact.matchers.JsonBodyMatcher",
     "text/plain" to "au.com.dius.pact.matchers.PlainTextBodyMatcher",
-    "multipart/form-data" to "au.com.dius.pact.matchers.MultipartFormBodyMatcher",
+    "multipart/form-data" to "au.com.dius.pact.matchers.MultipartMessageBodyMatcher",
+    "multipart/mixed" to "au.com.dius.pact.matchers.MultipartMessageBodyMatcher",
     "application/x-www-form-urlencoded" to "au.com.dius.pact.matchers.FormPostBodyMatcher"
   )
 

--- a/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MultipartMessageBodyMatcher.kt
+++ b/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MultipartMessageBodyMatcher.kt
@@ -12,7 +12,7 @@ import javax.mail.Header
 import javax.mail.internet.MimeMultipart
 import javax.mail.util.ByteArrayDataSource
 
-class MultipartFormBodyMatcher : BodyMatcher {
+class MultipartMessageBodyMatcher : BodyMatcher {
 
   override fun matchBody(expected: HttpPart, actual: HttpPart, allowUnexpectedKeys: Boolean): List<BodyMismatch> {
     val expectedBody = expected.body

--- a/pact-jvm-matchers/src/test/groovy/au/com/dius/pact/matchers/MultipartMessageBodyMatcherSpec.groovy
+++ b/pact-jvm-matchers/src/test/groovy/au/com/dius/pact/matchers/MultipartMessageBodyMatcherSpec.groovy
@@ -4,13 +4,13 @@ import au.com.dius.pact.model.OptionalBody
 import au.com.dius.pact.model.Request
 import spock.lang.Specification
 
-class MultipartFormBodyMatcherSpec extends Specification {
+class MultipartMessageBodyMatcherSpec extends Specification {
 
-  private MultipartFormBodyMatcher matcher
+  private MultipartMessageBodyMatcher matcher
   private expected, actual
 
   def setup() {
-    matcher = new MultipartFormBodyMatcher()
+    matcher = new MultipartMessageBodyMatcher()
     expected = { body -> new Request('', '', null, ['Content-Type': 'multipart/form-data; boundary=XXX'], body) }
     actual = { body -> new Request('', '', null, ['Content-Type': 'multipart/form-data; boundary=XXX'], body) }
   }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateGeneratorSpec.groovy
@@ -6,7 +6,7 @@ class DateGeneratorSpec extends Specification {
 
   def 'supports timezones'() {
     expect:
-    new DateGenerator('yyyy-MM-ddZ').generate(null) ==~ /\d{4}-\d{2}-\d{2}(-|\\+)\d+/
+    new DateGenerator('yyyy-MM-ddZ').generate(null) ==~ /\d{4}-\d{2}-\d{2}[-+]\d+/
   }
 
 }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateGeneratorSpec.groovy
@@ -6,7 +6,7 @@ class DateGeneratorSpec extends Specification {
 
   def 'supports timezones'() {
     expect:
-    new DateGenerator('yyyy-MM-ddZ').generate(null) ==~ /\d{4}-\d{2}-\d{2}\+\d+/
+    new DateGenerator('yyyy-MM-ddZ').generate(null) ==~ /\d{4}-\d{2}-\d{2}(-|\\+)\d+/
   }
 
 }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateTimeGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateTimeGeneratorSpec.groovy
@@ -7,7 +7,7 @@ class DateTimeGeneratorSpec extends Specification {
   def 'supports timezones'() {
     expect:
     new DateTimeGenerator('yyyy-MM-dd\'T\'HH:mm:ssZ').generate(null) ==~
-      /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\\+)\d+/
+      /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d+/
   }
 
 }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateTimeGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/DateTimeGeneratorSpec.groovy
@@ -7,7 +7,7 @@ class DateTimeGeneratorSpec extends Specification {
   def 'supports timezones'() {
     expect:
     new DateTimeGenerator('yyyy-MM-dd\'T\'HH:mm:ssZ').generate(null) ==~
-      /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d+/
+      /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\\+)\d+/
   }
 
 }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/TimeGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/TimeGeneratorSpec.groovy
@@ -6,7 +6,7 @@ class TimeGeneratorSpec extends Specification {
 
   def 'supports timezones'() {
     expect:
-    new TimeGenerator('HH:mm:ssZ').generate(null) ==~ /\d{2}:\d{2}:\d{2}(-|\\+)\d+/
+    new TimeGenerator('HH:mm:ssZ').generate(null) ==~ /\d{2}:\d{2}:\d{2}[-+]\d+/
   }
 
 }

--- a/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/TimeGeneratorSpec.groovy
+++ b/pact-jvm-model/src/test/groovy/au/com/dius/pact/model/generators/TimeGeneratorSpec.groovy
@@ -6,7 +6,7 @@ class TimeGeneratorSpec extends Specification {
 
   def 'supports timezones'() {
     expect:
-    new TimeGenerator('HH:mm:ssZ').generate(null) ==~ /\d{2}:\d{2}:\d{2}\+\d+/
+    new TimeGenerator('HH:mm:ssZ').generate(null) ==~ /\d{2}:\d{2}:\d{2}(-|\\+)\d+/
   }
 
 }


### PR DESCRIPTION
- Refactored name of Multipart matcher to reflect that it supports more than 1 type of multipart request
- Added a matcher for 'multipart/mixed' request body
- Updated tests to support the other side of the GMT