### PR TITLE
Added support for the text/xml content type

### DIFF
--- a/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MatchingConfig.kt
+++ b/pact-jvm-matchers/src/main/kotlin/au/com/dius/pact/matchers/MatchingConfig.kt
@@ -3,6 +3,7 @@ package au.com.dius.pact.matchers
 object MatchingConfig {
   val bodyMatchers = mapOf(
     "application/.*xml" to "au.com.dius.pact.matchers.XmlBodyMatcher",
+    "text/xml" to "au.com.dius.pact.matchers.XmlBodyMatcher",
     "application/.*json" to "au.com.dius.pact.matchers.JsonBodyMatcher",
     "application/json-rpc" to "au.com.dius.pact.matchers.JsonBodyMatcher",
     "application/jsonrequest" to "au.com.dius.pact.matchers.JsonBodyMatcher",


### PR DESCRIPTION
The existing matcher map is not supporting the soap services whose content type is text/xml. So, adding support for text/xml content type.