### PR TITLE
Fix to build pact-jvm-maven plugin #662

### DIFF
--- a/pact-jvm-provider-maven/build.gradle
+++ b/pact-jvm-provider-maven/build.gradle
@@ -14,7 +14,8 @@ def isWindows() {
 
 task pluginDescriptor(type: Exec, dependsOn: [":pact-jvm-provider_${project.scalaVersion}:install",
                                               ':pact-jvm-model:install',
-                                              ":pact-jvm-matchers_${project.scalaVersion}:install"]) {
+                                              ":pact-jvm-matchers_${project.scalaVersion}:install",
+                                              ":pact-jvm-logging_${project.scalaVersion}:install"]) {
     String mvn = 'mvn'
     if (isWindows()) {
         mvn = 'mvn.bat'


### PR DESCRIPTION
I opened an issue https://github.com/DiUS/pact-jvm/issues/662. There were several changes and I had to test if the changes do work. 
I could not test because the pact-jvm-maven-plugin could not be build due to this error:
![image](https://user-images.githubusercontent.com/15687935/38732026-f23f7252-3f1c-11e8-81f6-32069cbf4d99.png)

After this fix the gradle build is successful.