### PR TITLE
Add in the capability to register a pact file to be accessible from the main server API.

### DIFF
--- a/pact-jvm-server/README.md
+++ b/pact-jvm-server/README.md
@@ -98,16 +98,21 @@ The following actions are expected to occur
 
 ### /create
 
-The client will need `POST` to `/create` the generated `JSON` interactions, also providing a state as a query parameter.
+The client will need `POST` to `/create` the generated `JSON` interactions, also providing a state as a query parameter
+and a path.
 
 For example:
 
-    POST http://localhost:29999/create?state=NoUsers '{ "provider": { "name": "Animal_Service"}, ... }'
+    POST http://localhost:29999/create?state=NoUsers&path=/sub/ref/path '{ "provider": { "name": "Animal_Service"}, ... }'
 
 This will create a new running mock service provider on a randomly generated port.  The port will be returned in the
 `201` response:
 
     { "port" : 34423 }
+
+But you can also reference the path from `/sub/ref/path` using the server port.  The service will not strip
+the prefix path, but instead will use it as a differentiator.  If your services do not have differences
+in the prefix of their path, then you will have to use the port method.
 
 ### /complete
 

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Complete.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/Complete.scala
@@ -8,9 +8,9 @@ import scala.collection.JavaConversions
 
 object Complete {
 
-  def getPort(j: Any): Option[Int] = j match {
+  def getPort(j: Any): Option[String] = j match {
     case map: Map[AnyRef, AnyRef] => {
-      if (map.contains("port")) Some(map("port").asInstanceOf[Int])
+      if (map.contains("port")) Some(map("port").asInstanceOf[String])
       else None
     }
     case _ => None
@@ -22,7 +22,7 @@ object Complete {
 
   def apply(request: Request, oldState: ServerState): Result = {
     def clientError = Result(new Response(400), oldState)
-    def pactWritten(response: Response, port: Int) = Result(response, oldState - port)
+    def pactWritten(response: Response, port: String) = Result(response, oldState - port)
 
     val result = for {
       port <- getPort(JsonUtils.parseJsonString(request.getBody.getValue))
@@ -31,16 +31,16 @@ object Complete {
       pact <- mockProvider.pact
     } yield {
       mockProvider.stop()
-      
+
       ConsumerPactRunner.writeIfMatching(pact, sessionResults, mockProvider.config.getPactVersion) match {
         case PactVerified => pactWritten(new Response(200, JavaConversions.mapAsJavaMap(ResponseUtils.CrossSiteHeaders)),
-          mockProvider.config.getPort)
+          mockProvider.config.getPort.asInstanceOf[String])
         case error => pactWritten(new Response(400,
           JavaConversions.mapAsJavaMap(Map("Content-Type" -> "application/json")), toJson(error)),
-          mockProvider.config.getPort)
+          mockProvider.config.getPort.asInstanceOf[String])
       }
     }
-    
+
     result getOrElse clientError
   }
 

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/RequestRouter.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/RequestRouter.scala
@@ -2,8 +2,32 @@ package au.com.dius.pact.server
 
 import au.com.dius.pact.model.Request
 import au.com.dius.pact.model.Response
+import au.com.dius.pact.consumer.DefaultMockProvider
+import au.com.dius.pact.consumer.StatefulMockProvider
+import au.com.dius.pact.model._
+
+import scala.collection.JavaConverters._
 
 object RequestRouter {
+  def matchPath(request: Request, oldState: ServerState): Option[StatefulMockProvider[RequestResponseInteraction]] =
+    (for {
+      k <- oldState.keys if (request.getPath.startsWith(k))
+      pact <- oldState.get(k)
+    } yield pact).headOption
+
+  def handlePactRequest(request: Request, oldState: ServerState): Option[Response] =
+    (for {
+      pact <- matchPath(request, oldState)
+    } yield pact.handleRequest(request)).headOption
+
+  def state404(request: Request, oldState: ServerState): String =
+    (oldState + ("path" -> request.getPath)).mkString(",\n")
+
+  def pactDispatch(request: Request, oldState: ServerState): Response =
+    // handlePactRequest(request, oldState) getOrElse new Response(404)
+    handlePactRequest(request, oldState) getOrElse Response.fromMap(
+      Map("status" -> 404, "body" -> state404(request, oldState)).asJava)
+
   def dispatch(request: Request, oldState: ServerState, config: Config): Result = {
     val urlPattern ="/(\\w*)\\?{0,1}.*".r
     val urlPattern(action) = request.getPath
@@ -11,7 +35,7 @@ object RequestRouter {
       case "create" => Create(request, oldState, config)
       case "complete" => Complete(request, oldState)
       case "" => ListServers(oldState)
-      case _ => Result(new Response(404), oldState)
+      case _ => Result(pactDispatch(request, oldState), oldState)
     }
   }
 }

--- a/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
+++ b/pact-jvm-server/src/main/scala/au/com/dius/pact/server/package.scala
@@ -4,5 +4,5 @@ import au.com.dius.pact.consumer.StatefulMockProvider
 import au.com.dius.pact.model.RequestResponseInteraction
 
 package object server {
-  type ServerState = Map[Int, StatefulMockProvider[RequestResponseInteraction]]
+  type ServerState = Map[String, StatefulMockProvider[RequestResponseInteraction]]
 }

--- a/pact-jvm-server/src/test/groovy/au/com/dius/pact/server/CreateSpec.groovy
+++ b/pact-jvm-server/src/test/groovy/au/com/dius/pact/server/CreateSpec.groovy
@@ -13,7 +13,9 @@ class CreateSpec extends Specification {
     def pact = CreateSpec.getResourceAsStream('/create-pact.json').text
 
     when:
-    def result = Create.create('test state', pact, new scala.collection.immutable.HashMap(),
+    def result = Create.create('test state',
+      JavaConversions.asScalaBuffer(['/data']).toList(),
+      pact, new scala.collection.immutable.HashMap(),
       new Config(4444, 'localhost', false, 20000, 40000, true,
               2, '', '', 8444))
 
@@ -22,8 +24,12 @@ class CreateSpec extends Specification {
     result.response().body.value != '{"port": 8444}'
 
     cleanup:
-    JavaConversions.asJavaCollection(result.newState().values()).each {
-      it.stop()
+    if (result != null) {
+      def state = result.newState()
+      def values = state.values()
+      JavaConversions.asJavaCollection(values).each {
+        it.stop()
+      }
     }
   }
 
@@ -34,9 +40,11 @@ class CreateSpec extends Specification {
     def password = 'brentwashere'
 
     when:
-    def result = Create.create('test state', pact, new scala.collection.immutable.HashMap(),
-            new Config(4444, 'localhost', false, 20000, 40000, true,
-                    2, keystorePath, password, 8444))
+    def result = Create.create('test state',
+      JavaConversions.asScalaBuffer([]).toList(),
+      pact, new scala.collection.immutable.HashMap(),
+      new Config(4444, 'localhost', false, 20000, 40000, true,
+              2, keystorePath, password, 8444))
 
     then:
     result.response().status == 201


### PR DESCRIPTION
This change allows the primary pact-jvm server to also run as the entry point to the pacts.  The original use of the server will still work.

With this enhancement, it's now easier to use the pact-jvm server to mock other services.  If you have service A that uses services B and C, then you can run integration or pact tests against service A without needing to run service B and C.  Instead you can point service A to the pact-jvm server.  Without this change, the setup for service A requires dynamic and potentially difficult changes to correctly point its service clients to the correct pact-jvm server ports.  When the pact-jvm server is run as a docker container along with service A, then the setup is even easier by aliasing the pact-jvm server.

The new enhancement only works if the mocked services have distinct REST path prefixes, such as `/functionA/create` and `/functionB/create`.  The RequestRouter will direct the REST request to the pact service with the registered path prefix.