### PR TITLE
Added methods newJsonArrayMinLike and newJsonArrayMaxLike to LambdaDsl

### DIFF
--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDsl.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDsl.java
@@ -2,6 +2,8 @@ package io.pactfoundation.consumer.dsl;
 
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.matchingrules.MaxTypeMatcher;
+import au.com.dius.pact.model.matchingrules.MinTypeMatcher;
 
 import java.util.function.Consumer;
 
@@ -17,12 +19,31 @@ public class LambdaDsl {
         return dslArray;
     }
 
+    public static LambdaDslJsonArray newJsonArrayMinLike(Integer size, Consumer<LambdaDslJsonArray> array) {
+        final PactDslJsonArray pactDslJsonArray = new PactDslJsonArray();
+        pactDslJsonArray.setNumberExamples(size);
+        pactDslJsonArray.getMatchers().addRule(new MinTypeMatcher(size));
+
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(pactDslJsonArray);
+        array.accept(dslArray);
+        return dslArray;
+    }
+
+    public static LambdaDslJsonArray newJsonArrayMaxLike(Integer size, Consumer<LambdaDslJsonArray> array) {
+        final PactDslJsonArray pactDslJsonArray = new PactDslJsonArray();
+        pactDslJsonArray.setNumberExamples(1);
+        pactDslJsonArray.getMatchers().addRule(new MaxTypeMatcher(size));
+
+        final LambdaDslJsonArray dslArray = new LambdaDslJsonArray(pactDslJsonArray);
+        array.accept(dslArray);
+        return dslArray;
+    }
+
     public static LambdaDslJsonBody newJsonBody(Consumer<LambdaDslJsonBody> array) {
         final PactDslJsonBody pactDslJsonBody = new PactDslJsonBody();
         final LambdaDslJsonBody dslBody = new LambdaDslJsonBody(pactDslJsonBody);
         array.accept(dslBody);
         return dslBody;
     }
-
 
 }

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslTest.java
@@ -156,4 +156,55 @@ public class LambdaDslTest {
         assertThat(actualJson, is(pactDslJson));
     }
 
+    @Test
+    public void testArrayMinLike() {
+        /*
+            [
+                {
+                    "foo": "string"
+                },
+                {
+                    "foo": "string"
+                }
+            ]
+         */
+
+        String pactDslJson = PactDslJsonArray.arrayMinLike(2)
+            .stringType("foo")
+            .close()
+            .getBody()
+            .toString();
+
+        DslPart actualPactDsl = LambdaDsl.newJsonArrayMinLike(2, o -> o.object(
+            oo -> oo.stringType("foo")
+        )).build();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+    }
+
+    @Test
+    public void testArrayMaxLike() {
+        /*
+            [
+                {
+                    "foo": "string"
+                }
+            ]
+         */
+
+        String pactDslJson = PactDslJsonArray.arrayMaxLike(2)
+            .stringType("foo")
+            .close()
+            .getBody()
+            .toString();
+
+        DslPart actualPactDsl = LambdaDsl.newJsonArrayMaxLike(2, o -> o.object(
+            oo -> oo.stringType("foo")
+        )).build();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+    }
+
 }


### PR DESCRIPTION
Currently there is no option to create an array on root level with a minimum or maximum number of objects using the LambdaDsl class. This commit adds this functionality by setting number of examples and adding a rule to the pactDslJsonArray object.