### PR TITLE
Don't run servers on commonly used ports during tests

### DIFF
--- a/pact-jvm-consumer-junit/src/test/groovy/au/com/dius/pact/consumer/Defect221Test.groovy
+++ b/pact-jvm-consumer-junit/src/test/groovy/au/com/dius/pact/consumer/Defect221Test.groovy
@@ -13,7 +13,7 @@ class Defect221Test {
 
     @Rule
     @SuppressWarnings('PublicInstanceField')
-    public final PactProviderRuleMk2 provider = new PactProviderRuleMk2('221_provider', 'localhost', 8081, this)
+    public final PactProviderRuleMk2 provider = new PactProviderRuleMk2('221_provider', 'localhost', 8112, this)
 
     @Pact(provider= '221_provider', consumer= 'test_consumer')
     @SuppressWarnings('JUnitPublicNonTestMethod')
@@ -34,7 +34,7 @@ class Defect221Test {
     @PactVerification('221_provider')
     void runTest() {
         assert '{"responsetest":true,"name":"harry","data":1234.0}' ==
-          Request.Put('http://localhost:8081/numbertest')
+          Request.Put('http://localhost:8112/numbertest')
             .addHeader('Accept', APPLICATION_JSON)
             .bodyString('{"name": "harry","data": 1234.0 }', ContentType.APPLICATION_JSON)
             .execute().returnContent().asString()

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ArrayExampleTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ArrayExampleTest.java
@@ -22,7 +22,7 @@ public class ArrayExampleTest {
     private static final String APPLICATION_JSON = "application/json";
 
     @Rule
-    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("ArrayExampleProvider", "localhost", 8082, this);
+    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("ArrayExampleProvider", "localhost", 8113, this);
 
     @Pact(consumer = "ArrayExampleConsumer")
     public RequestResponsePact createFragment(PactDslWithProvider builder) {
@@ -47,7 +47,7 @@ public class ArrayExampleTest {
     @Test
     @PactVerification
     public void examplesAreGeneratedForArray() throws IOException {
-        final String response = Request.Get("http://localhost:8082/")
+        final String response = Request.Get("http://localhost:8113/")
                                        .addHeader("Accept", APPLICATION_JSON)
                                        .execute()
                                        .returnContent()

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerPactWithThriftMimeTypeTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/ConsumerPactWithThriftMimeTypeTest.java
@@ -23,7 +23,7 @@ public class ConsumerPactWithThriftMimeTypeTest {
     private static final String APPLICATION_X_THRIFT_JSON = "application/x-thrift+json";
 
     @Rule
-    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("test_provider", "localhost", 8080, this);
+    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("test_provider", "localhost", 8114, this);
 
     @Pact(provider="test_provider", consumer="test_consumer")
     public RequestResponsePact createFragment(PactDslWithProvider builder) {
@@ -45,7 +45,7 @@ public class ConsumerPactWithThriftMimeTypeTest {
     @Test
     @PactVerification("test_provider")
     public void runTest() throws IOException {
-        assertEquals(Request.Get("http://localhost:8080/persons/429605785802342400")
+        assertEquals(Request.Get("http://localhost:8114/persons/429605785802342400")
             .addHeader("Accept", "application/x-thrift+json")
             .execute().returnContent().getType().getMimeType(), "application/x-thrift+json");
     }

--- a/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/WildcardKeysTest.java
+++ b/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/WildcardKeysTest.java
@@ -25,7 +25,7 @@ public class WildcardKeysTest {
     private static final String APPLICATION_JSON = "application/json";
 
     @Rule
-    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("WildcardKeysProvider", "localhost", 8081, this);
+    public PactProviderRuleMk2 provider = new PactProviderRuleMk2("WildcardKeysProvider", "localhost", 8111, this);
 
     @Pact(provider="WildcardKeysProvider", consumer="WildcardKeysConsumer")
     public RequestResponsePact createFragment(PactDslWithProvider builder) {
@@ -82,7 +82,7 @@ public class WildcardKeysTest {
     @Test
     @PactVerification("WildcardKeysProvider")
     public void runTest() throws IOException {
-      String result = Request.Get("http://localhost:8081/")
+      String result = Request.Get("http://localhost:8111/")
         .addHeader("Accept", APPLICATION_JSON)
         .execute().returnContent().asString();
       Map<String, Object> body = (Map<String, Object>) new JsonSlurper().parseText(result);


### PR DESCRIPTION
Tests failed if I had a Tomcat instance running on 8080