### PR TITLE
Added support for inherited `@State` annotations

### DIFF
--- a/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
+++ b/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
@@ -234,8 +234,8 @@ class PactVerificationExtension(
 /**
  * JUnit 5 test extension class for executing state change callbacks
  */
-class PactVerificationStateChangeExtension(private val interaction: Interaction) : BeforeEachCallback {
-  override fun beforeEach(context: ExtensionContext) {
+class PactVerificationStateChangeExtension(private val interaction: Interaction) : BeforeTestExecutionCallback {
+  override fun beforeTestExecution(context: ExtensionContext) {
     logger.debug { "beforeEach for interaction '${interaction.description}'" }
     invokeStateChangeMethods(context, interaction.providerStates)
   }

--- a/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateAnnotationsOnInterfaceTest.java
+++ b/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateAnnotationsOnInterfaceTest.java
@@ -1,0 +1,43 @@
+package au.com.dius.pact.provider.junit5;
+
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver.WiremockUri;
+
+@Provider("providerWithMultipleInteractions")
+@PactFolder("pacts")
+@ExtendWith({
+    WiremockResolver.class,
+    WiremockUriResolver.class
+})
+class StateAnnotationsOnInterfaceTest implements StateInterface1, StateInterface2 {
+
+  private WireMockServer server;
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void testTemplate(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  @BeforeEach
+  void before(PactVerificationContext context, @Wiremock WireMockServer server,
+      @WiremockUri String uri) throws MalformedURLException {
+    this.server = server;
+    context.setTarget(HttpTestTarget.fromUrl(new URL(uri)));
+  }
+
+  @Override
+  public WireMockServer server() {
+    return this.server;
+  }
+}

--- a/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateInterface1.java
+++ b/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateInterface1.java
@@ -1,0 +1,22 @@
+package au.com.dius.pact.provider.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import au.com.dius.pact.provider.junit.State;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public interface StateInterface1 {
+
+  @State("state1")
+  default void toState1() {
+    server().stubFor(
+        get(urlPathEqualTo("/data"))
+            .willReturn(aResponse()
+                .withStatus(204)));
+  }
+
+  WireMockServer server();
+
+}

--- a/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateInterface2.java
+++ b/pact-jvm-provider-junit5/src/test/java/au/com/dius/pact/provider/junit5/StateInterface2.java
@@ -1,0 +1,22 @@
+package au.com.dius.pact.provider.junit5;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import au.com.dius.pact.provider.junit.State;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public interface StateInterface2 {
+
+  @State("state2")
+  default void toState2() {
+    server().stubFor(
+        get(urlPathEqualTo("/moreData"))
+            .willReturn(aResponse()
+                .withStatus(204)));
+  }
+
+  WireMockServer server();
+
+}

--- a/pact-jvm-provider-junit5/src/test/resources/pacts/contract-with-multiple-interactions.json
+++ b/pact-jvm-provider-junit5/src/test/resources/pacts/contract-with-multiple-interactions.json
@@ -1,0 +1,40 @@
+{
+  "provider": {
+    "name": "providerWithMultipleInteractions"
+  },
+  "consumer": {
+    "name": "consumerWithMultipleInteractions"
+  },
+  "interactions": [
+    {
+      "provider_state": "state1",
+      "description": "Get data",
+      "request": {
+        "method": "GET",
+        "path": "/data"
+      },
+      "response": {
+        "status": 204
+      }
+    },
+    {
+      "provider_state": "state2",
+      "description": "GET moreData",
+      "request": {
+        "method": "GET",
+        "path": "/moreData"
+      },
+      "response": {
+        "status": 204
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.1.1"
+    }
+  }
+}


### PR DESCRIPTION
To enable the provider test style described in #646 with JUnit 5, I moved the `PactVerificationStateChangeExtension` from `beforeEach` to `beforeTestExecution`.

This makes sure that the state changes are called **after** all `@BeforeEach` methods have been called. This, in turn, makes it possible to use the `@BeforeEach` methods to populate class members which can then be used in the `@State`-annotated methods.

Without this change, when you set a class member within a `@BeforeEach` method and then tried to access it in a `@State` method, you would get a `NullPointerException`.

This PR also adds a test that asserts this behavior works.