### PR TITLE
made default content-type more lenient to common variants

### DIFF
--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslResponse.java
@@ -2,9 +2,7 @@ package au.com.dius.pact.consumer.dsl;
 
 import au.com.dius.pact.consumer.ConsumerPactBuilder;
 import au.com.dius.pact.model.OptionalBody;
-import au.com.dius.pact.model.Pact;
 import au.com.dius.pact.model.PactFragment;
-import au.com.dius.pact.model.PactReader;
 import au.com.dius.pact.model.ProviderState;
 import au.com.dius.pact.model.Request;
 import au.com.dius.pact.model.RequestResponseInteraction;
@@ -21,18 +19,18 @@ import org.w3c.dom.Document;
 import scala.collection.JavaConversions$;
 
 import javax.xml.transform.TransformerException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class PactDslResponse {
     private static final String CONTENT_TYPE = "Content-Type";
+    static final String DEFAULT_JSON_CONTENT_TYPE_REGEX = "application/json;\\s?charset=(utf|UTF)-8";
+
     private final ConsumerPactBuilder consumerPactBuilder;
     private PactDslRequestWithPath request;
-  private final PactDslRequestWithoutPath defaultRequestValues;
-  private final PactDslResponse defaultResponseValues;
+    private final PactDslRequestWithoutPath defaultRequestValues;
+    private final PactDslResponse defaultResponseValues;
 
     private int responseStatus = 200;
     private Map<String, String> responseHeaders = new HashMap<String, String>();
@@ -194,7 +192,7 @@ public class PactDslResponse {
     public PactDslResponse body(JSONObject body) {
         this.responseBody = OptionalBody.body(body.toString());
         if (!responseHeaders.containsKey(CONTENT_TYPE)) {
-            responseHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+            matchHeader(CONTENT_TYPE, DEFAULT_JSON_CONTENT_TYPE_REGEX, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }
@@ -220,7 +218,7 @@ public class PactDslResponse {
         }
 
         if (!responseHeaders.containsKey(CONTENT_TYPE)) {
-            responseHeaders.put(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+            matchHeader(CONTENT_TYPE, DEFAULT_JSON_CONTENT_TYPE_REGEX, ContentType.APPLICATION_JSON.toString());
         }
         return this;
     }

--- a/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/dsl/PactDslResponseSpec.groovy
+++ b/pact-jvm-consumer/src/test/groovy/au/com/dius/pact/consumer/dsl/PactDslResponseSpec.groovy
@@ -6,7 +6,11 @@ import au.com.dius.pact.model.generators.Generators
 import au.com.dius.pact.model.matchingrules.MatchingRuleGroup
 import au.com.dius.pact.model.matchingrules.MatchingRulesImpl
 import au.com.dius.pact.model.matchingrules.TypeMatcher
+import com.google.common.net.MediaType
+import org.apache.http.entity.ContentType
 import spock.lang.Specification
+
+import static au.com.dius.pact.consumer.dsl.PactDslResponse.DEFAULT_JSON_CONTENT_TYPE_REGEX
 
 class PactDslResponseSpec extends Specification {
 
@@ -25,6 +29,22 @@ class PactDslResponseSpec extends Specification {
       .toPact()
     interaction = pact.interactions.first()
     response = interaction.response
+  }
+
+  def 'default json content type should match common variants'() {
+      def acceptableDefaultContentTypes = [
+              'application/json;charset=utf-8',
+              'application/json; charset=UTF-8',
+              'application/json; charset=utf-8',
+
+              ContentType.APPLICATION_JSON.toString(),
+              MediaType.JSON_UTF_8.toString(),
+      ]
+
+      expect:
+        acceptableDefaultContentTypes.each {
+            it.matches(DEFAULT_JSON_CONTENT_TYPE_REGEX)
+        }
   }
 
   def 'sets up any default state when created'() {


### PR DESCRIPTION
PactDslResponse.body() now defaults to match content-type against `application/json;\s?charset=(utf|UTF)-8` instead of requiring the exact value `application/json; charset=UTF-8`.

This makes the default work with producers running for example jersey and jetty which uses the compact format `application/json;charset=utf-8`.