### PR TITLE
java8 dsl only needs the java model dependency

### DIFF
--- a/pact-jvm-consumer-java8/build.gradle
+++ b/pact-jvm-consumer-java8/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-  compile project(":pact-jvm-consumer-junit_${project.scalaVersion}")
+  compile project(":pact-jvm-consumer_${project.scalaVersion}")
 }


### PR DESCRIPTION
I want to use the java8 dsl for my junit5 tests without pulling in junit 4.12 dependencies.