### PR TITLE
Use kotlin-stdlib-jdk8 insted of kotlin-stdlib-jre8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ subprojects {
     }
 
     dependencies {
-      compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+      compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
       compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
       compile "org.slf4j:slf4j-api:${project.slf4jVersion}"
       compile "org.codehaus.groovy:groovy-all:${project.groovyVersion}:indy"

--- a/pact-jvm-provider-maven/build.gradle
+++ b/pact-jvm-provider-maven/build.gradle
@@ -5,7 +5,7 @@ dependencies {
       'org.apache.maven:maven-plugin-api:3.5.0',
       'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
     compile 'org.apache.maven:maven-core:3.5.0'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compile "org.fusesource.jansi:jansi:${project.jansiVersion}"
 }


### PR DESCRIPTION
Because kotlin-stdlib-jre8 is depcated. It seems good to use  kotlin-stdlib-jdk8. 