### PR TITLE
Added and or functionality to Java 8 Dsl

### DIFF
--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
@@ -3,6 +3,7 @@ package io.pactfoundation.consumer.dsl;
 import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.model.matchingrules.MatchingRule;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -217,6 +218,26 @@ public class LambdaDslJsonArray {
 
     public LambdaDslJsonArray ipV4Address() {
         pactArray.ipAddress();
+        return this;
+    }
+
+    /**
+     * Combine all the matchers using AND
+     * @param value Attribute example value
+     * @param rules Matching rules to apply
+     */
+    public LambdaDslJsonArray and(Object object, MatchingRule... rules) {
+        pactArray.and(object, rules);
+        return this;
+    }
+
+    /**
+     * Combine all the matchers using OR
+     * @param value Attribute example value
+     * @param rules Matching rules to apply
+     */
+    public LambdaDslJsonArray or(Object object, MatchingRule... rules) {
+        pactArray.or(object, rules);
         return this;
     }
 

--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -3,6 +3,7 @@ package io.pactfoundation.consumer.dsl;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue;
+import au.com.dius.pact.model.matchingrules.MatchingRule;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -247,6 +248,29 @@ public class LambdaDslObject {
      */
     public LambdaDslObject ipV4Address(String name) {
         object.ipAddress(name);
+        return this;
+    }
+
+    /** Combine all the matchers using AND
+    * @param name  Attribute name
+    * @param value Attribute example value
+    * @param rules Matching rules to apply
+    * @return
+    */
+    public LambdaDslObject and(String name, Object value, MatchingRule... rules) {
+        object.and(name, value, rules);
+        return this;
+    }
+
+    /**
+    * Combine all the matchers using OR
+    * @param name  Attribute name
+    * @param value Attribute example value
+    * @param rules Matching rules to apply
+    * @return
+    */
+    public LambdaDslObject or(String name, Object value, MatchingRule... rules) {
+        object.or(name, value, rules);
         return this;
     }
 

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
@@ -1,5 +1,6 @@
 package io.pactfoundation.consumer.dsl;
 
+import au.com.dius.pact.consumer.dsl.PM;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
 import org.junit.Test;
 
@@ -103,6 +104,67 @@ public class LambdaDslJsonArrayTest {
 
         String actualJson = actualPactDsl.getBody().toString();
         assertThat(actualJson, is(pactDslJson));
+    }
+
+    @Test
+    public void testAndMatchingRules() {
+        /*
+            [
+                "fooBar"
+            ]
+         */
+
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray("", "", null, false)
+                .and("foobar", PM.stringType(), PM.includesStr("foo"), PM.stringMatcher("*Bar"))
+                .getBody().toString();
+
+        // Lambda DSL
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .and("foobar", PM.stringType(), PM.includesStr("foo"), PM.stringMatcher("*Bar"))
+                .build();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(3));
+        Map matcher = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(matcher.get("match"), is("type"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(matcher.get("match"), is("include"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(2).toMap();
+        assertThat(matcher.get("match"), is("regex"));
+    }
+
+    @Test
+    public void testOrMatchingRules() {
+        /*
+            [
+                null
+            ]
+         */
+        // Old DSL
+        final String pactDslJson = new PactDslJsonArray("", "", null, false)
+                .or(null, PM.nullValue(), PM.date(), PM.ipAddress())
+                .getBody().toString();
+
+        // Lambda DSL
+        final PactDslJsonArray actualPactDsl = new PactDslJsonArray("", "", null, false);
+        final LambdaDslJsonArray array = new LambdaDslJsonArray(actualPactDsl);
+        array
+                .or(null, PM.nullValue(), PM.date(), PM.ipAddress())
+                .build();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(3));
+        Map matcher = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(matcher.get("match"), is("null"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(matcher.get("match"), is("date"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(2).toMap();
+        assertThat(matcher.get("match"), is("regex"));
     }
 
     @Test

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
@@ -1,5 +1,6 @@
 package io.pactfoundation.consumer.dsl;
 
+import au.com.dius.pact.consumer.dsl.PM;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
 import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue;
 import org.junit.Test;
@@ -160,6 +161,72 @@ public class LambdaDslObjectTest {
         assertThat(matcher.get("match"), is("type"));
         matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
         assertThat(matcher.get("match"), is("type"));
+    }
+
+    @Test
+    public void testAndMatchingRules() {
+        /*
+            {
+                "foo" : "Foo"
+            }
+         */
+
+        // Old Dsl
+        final String pactDslJson = new PactDslJsonBody()
+                .and("foo", "Foo", PM.stringType(), PM.includesStr("F"), PM.includesStr("oo"))
+                .getBody().toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
+        object
+                .and("foo", "Foo", PM.stringType(), PM.includesStr("F"), PM.includesStr("oo"));
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(3));
+        assertThat(actualJson, containsString("foo"));
+        assertThat(actualJson, containsString("Foo"));
+        Map matcher = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(matcher.get("match"), is("type"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(matcher.get("match"), is("include"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(2).toMap();
+        assertThat(matcher.get("match"), is("include"));
+    }
+
+    @Test
+    public void testOrMatchingRules() {
+        /*
+            {
+                "foo" : null
+            }
+         */
+
+        // Old Dsl
+        final String pactDslJson = new PactDslJsonBody()
+                .or("foo", null, PM.nullValue(), PM.booleanType(), PM.numberType())
+                .getBody().toString();
+
+        // Lambda DSL
+        final PactDslJsonBody actualPactDsl = new PactDslJsonBody();
+        final LambdaDslObject object = new LambdaDslObject(actualPactDsl);
+        object
+                .or("foo", null, PM.nullValue(), PM.booleanType(), PM.numberType());
+        actualPactDsl.close();
+
+        String actualJson = actualPactDsl.getBody().toString();
+        assertThat(actualJson, is(pactDslJson));
+        assertThat(actualPactDsl.getMatchers().allMatchingRules().size(), is(3));
+        assertThat(actualJson, containsString("foo"));
+        assertThat(actualJson, containsString("null"));
+        Map matcher = actualPactDsl.getMatchers().allMatchingRules().get(0).toMap();
+        assertThat(matcher.get("match"), is("null"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(1).toMap();
+        assertThat(matcher.get("match"), is("type"));
+        matcher = actualPactDsl.getMatchers().allMatchingRules().get(2).toMap();
+        assertThat(matcher.get("match"), is("number"));
     }
 
     @Test


### PR DESCRIPTION
Added the ability to use and or functionality in Java 8 Dsl. As much of the and or logic is handled by  the originating `PactDslJsonBody.java` and `PactDslJsonArray.java` files, the Lambda Dsl functions are quite compact.

As this is my first non-trivial open-source contribution, please let me know if there is anything else I can do to make this contribution better. Thanks!