### PR TITLE
Add system properties configuration to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ You want to look at: [pact gradle plugin](pact-jvm-provider-gradle)
 
 You want to look at: [pact maven plugin](pact-jvm-provider-maven)
 
-For publishing pacts to a pact broker, have a look at https://github.com/warmuuh/pactbroker-maven-plugin
-
 #### verify pacts with JUnit tests [version 2.3.3+, 3.1.3+]
 
 You want to look at: [junit provider support](pact-jvm-provider-junit) for JUnit 4 tests and 

--- a/pact-jvm-provider-maven/README.md
+++ b/pact-jvm-provider-maven/README.md
@@ -674,4 +674,4 @@ pact {
 For pacts that are loaded from a Pact Broker, the results of running the verification can be published back to the
  broker against the URL for the pact. You will be able to then see the result on the Pact Broker home screen.
  
-To turn on the verification publishing, set the system property `pact.verifier.publishResults` to `true`.
+To turn on the verification publishing, set the system property `pact.verifier.publishResults` to `true` in the pact maven plugin, not surefire, configuration.

--- a/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -28,6 +28,9 @@ open class PactProviderMojo : AbstractMojo() {
   private lateinit var classpathElements: List<String>
 
   @Parameter
+  private var systemPropertyVariables = mutableMapOf<String, String>()
+
+  @Parameter
   lateinit var serviceProviders: List<Provider>
 
   @Parameter
@@ -63,6 +66,10 @@ open class PactProviderMojo : AbstractMojo() {
         urls.toTypedArray()
       }
       it
+    }
+
+    systemPropertyVariables.forEach { (property, value) ->
+      System.setProperty(property, value)
     }
 
     serviceProviders.forEach { provider ->

--- a/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -28,7 +28,7 @@ open class PactProviderMojo : AbstractMojo() {
   private lateinit var classpathElements: List<String>
 
   @Parameter
-  private var systemPropertyVariables = mutableMapOf<String, String>()
+  var systemPropertyVariables: Map<String, String> = mutableMapOf()
 
   @Parameter
   lateinit var serviceProviders: List<Provider>

--- a/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -51,6 +51,10 @@ open class PactProviderMojo : AbstractMojo() {
   override fun execute() {
     AnsiConsole.systemInstall()
 
+    systemPropertyVariables.forEach { (property, value) ->
+      System.setProperty(property, value)
+    }
+
     val failures = mutableMapOf<Any, Any>()
     val verifier = providerVerifier().let {
       it.projectHasProperty = Function { p: String -> this.propertyDefined(p) }
@@ -66,10 +70,6 @@ open class PactProviderMojo : AbstractMojo() {
         urls.toTypedArray()
       }
       it
-    }
-
-    systemPropertyVariables.forEach { (property, value) ->
-      System.setProperty(property, value)
     }
 
     serviceProviders.forEach { provider ->

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -193,4 +193,26 @@ class PactProviderMojoSpec extends Specification {
     then:
     noExceptionThrown()
   }
+
+  def 'system property pact.verifier.publishResults true when set with systemPropertyVariables' () {
+    given:
+    def provider = new Provider(pactFileDirectory: 'dir1' as File)
+    def verifier = Mock(ProviderVerifier) {
+      verifyProvider(provider) >> [:]
+    }
+    mojo = Spy(PactProviderMojo) {
+      loadPactFiles(provider, _) >> []
+      providerVerifier() >> verifier
+    }
+    mojo.serviceProviders = [ provider ]
+    mojo.failIfNoPactsFound = false
+    mojo.systemPropertyVariables.put('pact.verifier.publishResults', 'true')
+
+    when:
+    mojo.execute()
+
+    then:
+    noExceptionThrown()
+    System.getProperty('pact.verifier.publishResults') == 'true'
+  }
 }

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoTest.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoTest.groovy
@@ -48,16 +48,4 @@ class PactProviderMojoTest {
         assert mojo.property('pact.test.105') == null
     }
 
-    @Test
-    void 'property declared though systemPropertyVariables is a system property'() {
-        mojo.systemPropertyVariables.put('systemPropertyVariables', 'true')
-
-        when:
-        mojo.execute()
-
-        then:
-        assert System.getProperty('systemPropertyVariables') == 'true'
-
-    }
-
 }

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoTest.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoTest.groovy
@@ -48,4 +48,16 @@ class PactProviderMojoTest {
         assert mojo.property('pact.test.105') == null
     }
 
+    @Test
+    void 'property declared though systemPropertyVariables is a system property'() {
+        mojo.systemPropertyVariables.put('systemPropertyVariables', 'true')
+
+        when:
+        mojo.execute()
+
+        then:
+        assert System.getProperty('systemPropertyVariables') == 'true'
+
+    }
+
 }


### PR DESCRIPTION
Fixes #730.
* Allows systemPropertyVariables tag within pact-jvm-provider-maven_2.12 configuration.
* Sets the system property when executed
* updated  project root's` Readme.md` as pact-maven plugin can publish pacts and referenced project has not been updated in a while and has some problems with requesting pact files.
