### PR TITLE
Add teardown support to JUnit provider

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/State.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/State.java
@@ -18,4 +18,6 @@ public @interface State {
      * @return list of state names
      */
     String[] value();
+
+    StateChangeAction action() default StateChangeAction.SETUP;
 }

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/StateChangeAction.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/StateChangeAction.java
@@ -1,0 +1,8 @@
+package au.com.dius.pact.provider.junit;
+
+public enum StateChangeAction {
+
+    SETUP,
+
+    TEARDOWN;
+}

--- a/pact-jvm-provider-junit/src/test/java/au/com/dius/pact/provider/junit/StateTeardownTest.java
+++ b/pact-jvm-provider-junit/src/test/java/au/com/dius/pact/provider/junit/StateTeardownTest.java
@@ -1,0 +1,56 @@
+package au.com.dius.pact.provider.junit;
+
+import static com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse;
+import static com.github.restdriver.clientdriver.RestClientDriver.onRequestTo;
+import static org.junit.Assert.assertEquals;
+
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit.target.HttpTarget;
+import au.com.dius.pact.provider.junit.target.Target;
+import au.com.dius.pact.provider.junit.target.TestTarget;
+import com.github.restdriver.clientdriver.ClientDriverRule;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("providerTeardownTest")
+@PactFolder("pacts")
+public class StateTeardownTest {
+
+    private static Collection<Object> stateNameParamValues = new ArrayList<>();
+
+    @ClassRule
+    public static final ClientDriverRule embeddedProvider = new ClientDriverRule(8333);
+
+    @TestTarget
+    public final Target target = new HttpTarget(8333);
+
+    @State(value = {"state 1", "state 2"}, action = StateChangeAction.SETUP)
+    public void toDefaultState() {
+        embeddedProvider.addExpectation(
+            onRequestTo("/data"), giveEmptyResponse()
+        );
+    }
+
+    @State(value = "state 1", action = StateChangeAction.TEARDOWN)
+    public void teardownDefaultState(Map<String, Object> params) {
+        stateNameParamValues.addAll(params.values());
+    }
+
+    @After
+    public void after() {
+        embeddedProvider.reset();
+    }
+
+    @AfterClass
+    public static void assertTeardownWasCalledForState1() {
+        assertEquals(Collections.singletonList("state 1"), stateNameParamValues);
+    }
+
+}

--- a/pact-jvm-provider-junit/src/test/resources/pacts/contract-teardown-test.json
+++ b/pact-jvm-provider-junit/src/test/resources/pacts/contract-teardown-test.json
@@ -1,0 +1,40 @@
+{
+  "provider" : {
+    "name" : "providerTeardownTest"
+  },
+  "consumer" : {
+    "name" : "consumerTeardownTest"
+  },
+  "interactions" : [ {
+    "providerStates": [
+      {
+        "name": "state 1",
+        "params": {
+          "name": "state 1"
+        }
+      },
+      {
+        "name": "state 2",
+        "params": {
+          "name": "state 2"
+        }
+      }
+    ],
+    "description" : "Get data",
+    "request" : {
+      "method" : "GET",
+      "path" : "/data"
+    },
+    "response" : {
+      "status" : 204
+    }
+  } ],
+  "metadata" : {
+    "pact-specification" : {
+      "version" : "3.0.0"
+    },
+    "pact-jvm" : {
+      "version" : "3.1.1"
+    }
+  }
+}


### PR DESCRIPTION
Hi, 

this is a first attempt at adding teardown support to the Junit provider. Are you ok with this approach in general or would you prefer a different one?
Where should I add the tests? There are groovy, java and kotlin folders and I don't know where to put them.