### PR TITLE
Pact broker filter by consumers

### DIFF
--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBroker.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBroker.java
@@ -41,6 +41,12 @@ public @interface PactBroker {
      */
     String[] tags() default "${pactbroker.tags:latest}";
 
+    /**
+     * Consumers to fetch pacts for, defaults to all consumers
+     * If you set the consumers through the `pactbroker.consumers` system property, separate the consumers by commas
+     */
+    String[] consumers() default "${pactbroker.consumers:}";
+
   /**
    * If the test should fail if no pacts are found for the provider, default is true
    * @deprecated Use a @IgnoreNoPactsToVerify annotation on the test class instead

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBroker.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBroker.java
@@ -37,7 +37,7 @@ public @interface PactBroker {
 
     /**
      * Tags to use to fetch pacts for, defaults to `latest`
-     * If you set the tags through the `pactbroker.tag` system property, separate the tags by commas
+     * If you set the tags through the `pactbroker.tags` system property, separate the tags by commas
      */
     String[] tags() default "${pactbroker.tags:latest}";
 

--- a/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
+++ b/pact-jvm-provider-junit/src/main/java/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.java
@@ -58,7 +58,7 @@ public class PactBrokerLoader implements PactLoader {
     this.pactBrokerTags = tags.stream().flatMap(tag -> parseListExpression(tag).stream()).collect(toList());
     this.pactBrokerConsumers = consumers.stream().flatMap(consumer -> parseListExpression(consumer).stream()).collect(toList());
     this.failIfNoPactsFound = true;
-    this.pactSource = new PactBrokerSource(this.pactBrokerHost, this.pactBrokerPort);
+    this.pactSource = new PactBrokerSource(this.pactBrokerHost, this.pactBrokerPort, this.pactBrokerProtocol);
   }
 
   public PactBrokerLoader(final PactBroker pactBroker) {

--- a/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -18,6 +18,7 @@ class PactBrokerLoaderSpec extends Specification {
   private String port
   private String protocol
   private List tags
+  private List consumers
   private PactBrokerClient brokerClient
   private Pact mockPact
 
@@ -26,11 +27,12 @@ class PactBrokerLoaderSpec extends Specification {
     port = '1234'
     protocol = 'http'
     tags = ['latest']
+    consumers = []
     brokerClient = Mock(PactBrokerClient)
     mockPact = Mock(Pact)
 
     pactBrokerLoader = { boolean failIfNoPactsFound = true ->
-      def loader = new PactBrokerLoader(host, port, protocol, tags) {
+      def loader = new PactBrokerLoader(host, port, protocol, tags, consumers) {
         @Override
         PactBrokerClient newPactBrokerClient(URI url, ValueResolver resolver) throws URISyntaxException {
           brokerClient
@@ -210,6 +212,82 @@ class PactBrokerLoaderSpec extends Specification {
     then:
     result.size() == 1
     1 * brokerClient.fetchConsumers('test') >> [ new PactBrokerConsumer('test', 'latest', '', []) ]
+  }
+
+  def 'Loads pacts only for provided consumers'() {
+    given:
+    consumers = ['a', 'b', 'c']
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    1 * brokerClient.fetchConsumers('test') >> [
+            new PactBrokerConsumer('a', 'latest', '', []),
+            new PactBrokerConsumer('b', 'latest', '', []),
+            new PactBrokerConsumer('c', 'latest', '', []),
+            new PactBrokerConsumer('d', 'latest', '', [])
+    ]
+    0 * _
+    result.size() == 3
+  }
+
+  @RestoreSystemProperties
+  @SuppressWarnings('GStringExpressionWithinString')
+  def 'Processes consumers before pact load'() {
+    given:
+    System.setProperty('composite', "a${VALUES_SEPARATOR}b${VALUES_SEPARATOR}c")
+    consumers = ['${composite}']
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    1 * brokerClient.fetchConsumers('test') >> [
+            new PactBrokerConsumer('a', 'latest', '', []),
+            new PactBrokerConsumer('b', 'latest', '', []),
+            new PactBrokerConsumer('c', 'latest', '', []),
+            new PactBrokerConsumer('d', 'latest', '', [])
+    ]
+    0 * _
+    result.size() == 3
+  }
+
+  def 'Loads all consumer pacts if no consumer is provided'() {
+    given:
+    consumers = []
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    1 * brokerClient.fetchConsumers('test') >> [
+            new PactBrokerConsumer('a', 'latest', '', []),
+            new PactBrokerConsumer('b', 'latest', '', []),
+            new PactBrokerConsumer('c', 'latest', '', []),
+            new PactBrokerConsumer('d', 'latest', '', [])
+    ]
+    0 * _
+    result.size() == 4
+  }
+
+  def 'Loads pacts only for provided consumers with the specified tags'() {
+    given:
+    consumers = ['a', 'b', 'c']
+    tags = ['demo']
+
+    when:
+    def result = pactBrokerLoader().load('test')
+
+    then:
+    1 * brokerClient.fetchConsumersWithTag('test', 'demo') >> [
+            new PactBrokerConsumer('a', 'demo', '', []),
+            new PactBrokerConsumer('b', 'demo', '', []),
+            new PactBrokerConsumer('c', 'demo', '', []),
+            new PactBrokerConsumer('d', 'demo', '', [])
+    ]
+    0 * _
+    result.size() == 3
   }
 
   @PactBroker(host = 'pactbroker.host', port = '1000', failIfNoPactsFound = false)

--- a/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
+++ b/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
@@ -70,14 +70,14 @@ class PactBrokerAnnotationDefaultsTest {
 
     @Test
     fun `can set single tags`() {
-        props.setProperty("pactbroker.protocol", "myProtocol")
-        assertThat(parseListExpression(annotation.protocol), contains("myProtocol"))
+        props.setProperty("pactbroker.tags", "myTag")
+        assertThat(parseListExpression(annotation.tags[0]), contains("myTag"))
     }
 
     @Test
     fun `can set multiple tags`() {
-        props.setProperty("pactbroker.protocol", "myProtocol1,myProtocol2")
-        assertThat(parseListExpression(annotation.protocol), contains("myProtocol1", "myProtocol2"))
+        props.setProperty("pactbroker.tags", "myTag1,myTag2")
+        assertThat(parseListExpression(annotation.tags[0]), contains("myTag1", "myTag2"))
     }
 
     @Test

--- a/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
+++ b/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
@@ -5,7 +5,7 @@ import au.com.dius.pact.support.expressions.ExpressionParser.parseExpression
 import au.com.dius.pact.support.expressions.ExpressionParser.parseListExpression
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.*
 import org.hamcrest.collection.IsArrayWithSize.arrayWithSize
 import org.junit.Before
 import org.junit.Test
@@ -78,6 +78,24 @@ class PactBrokerAnnotationDefaultsTest {
     fun `can set multiple tags`() {
         props.setProperty("pactbroker.tags", "myTag1,myTag2")
         assertThat(parseListExpression(annotation.tags[0]), contains("myTag1", "myTag2"))
+    }
+
+    @Test
+    fun `default consumer filter is empty (all consumers)`() {
+        assertThat(annotation.consumers, arrayWithSize(1))
+        assertThat(parseListExpression(annotation.consumers[0]), empty())
+    }
+
+    @Test
+    fun `can set single consumer`() {
+        props.setProperty("pactbroker.consumers", "myConsumer")
+        assertThat(parseListExpression(annotation.consumers[0]), contains("myConsumer"))
+    }
+
+    @Test
+    fun `can set multiple consumers`() {
+        props.setProperty("pactbroker.consumers", "myConsumer1,myConsumer2")
+        assertThat(parseListExpression(annotation.consumers[0]), contains("myConsumer1", "myConsumer2"))
     }
 
     @Test

--- a/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
+++ b/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/PactBrokerAnnotationDefaultsTest.kt
@@ -5,7 +5,8 @@ import au.com.dius.pact.support.expressions.ExpressionParser.parseExpression
 import au.com.dius.pact.support.expressions.ExpressionParser.parseListExpression
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.empty
 import org.hamcrest.collection.IsArrayWithSize.arrayWithSize
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
Hey all,

This is to add the ability to filter provider pact test runs that are loaded via the `PactBrokerLoader` by specific consumers (comma-separated list of consumers)

This, as is done for tags, can be read through a system property `pactbroker.consumers` in cases where we're only interested in testing selected consumer pacts for a provider.

Use case: a consumer has updated their pact and wants to validate it with the provider - a provider pact test run is then triggered for only this pact, ignoring the provider's other pacts with other consumers.

Cheers