### PR TITLE
Stop pact-jvm-consumer-java8 being dependent on JUnit 4

### DIFF
--- a/pact-jvm-consumer-java8/build.gradle
+++ b/pact-jvm-consumer-java8/build.gradle
@@ -1,11 +1,7 @@
-apply plugin: 'java'
-
-sourceCompatibility = 1.8
-
 repositories {
     mavenCentral()
 }
 
 dependencies {
-  compile project(":pact-jvm-consumer-junit_${project.scalaVersion}")
+  compile project(":pact-jvm-consumer_${project.scalaVersion}")
 }


### PR DESCRIPTION
Unnecessary dependency caused problems when using JUnit 5.
Actually the code is completely independent of JUnit.

Additionally remove repetitions from root build.gradle