### PR TITLE
Stop pushing compile dependencies to all projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,21 +88,8 @@ subprojects {
     }
 
     dependencies {
-      compile "org.slf4j:slf4j-api:${project.slf4jVersion}"
-
-      compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
-      compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-      compile('io.github.microutils:kotlin-logging:1.4.4') {
-        exclude group: 'org.jetbrains.kotlin'
-      }
-
       if (project.hasProperty('scalaVersion')) {
-          compile "org.scala-lang:scala-library:${project.scalaFullVersion}"
-          compile("com.typesafe.scala-logging:scala-logging_${project.scalaVersion}:3.7.2") {
-            exclude group: 'org.scala-lang'
-          }
-
-          testCompile "org.specs2:specs2-core_${project.scalaVersion}:${project.specs2Version}",
+        testCompile "org.specs2:specs2-core_${project.scalaVersion}:${project.specs2Version}",
             "org.specs2:specs2-junit_${project.scalaVersion}:${project.specs2Version}"
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,10 @@ subprojects {
     }
 
     dependencies {
+      compile "org.slf4j:slf4j-api:${project.slf4jVersion}"
+
       compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
       compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-      compile "org.slf4j:slf4j-api:${project.slf4jVersion}"
-      compile "org.codehaus.groovy:groovy-all:${project.groovyVersion}:indy"
       compile('io.github.microutils:kotlin-logging:1.4.4') {
         exclude group: 'org.jetbrains.kotlin'
       }
@@ -113,9 +113,10 @@ subprojects {
       testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'
       }
-      testCompile "cglib:cglib:${project.cglibVersion}"
+      testRuntime "cglib:cglib:${project.cglibVersion}"
       testCompile 'org.objenesis:objenesis:2.6'
       testCompile 'io.kotlintest:kotlintest:2.0.7'
+      testCompile "org.codehaus.groovy:groovy-all:${project.groovyVersion}:indy" // transitive deps use a buggy version
     }
 
     tasks.withType(ScalaCompile) {

--- a/pact-jvm-matchers/build.gradle
+++ b/pact-jvm-matchers/build.gradle
@@ -5,7 +5,12 @@ dependencies {
     exclude group: 'org.scala-lang'
   }
   compile 'com.googlecode.java-diff-utils:diffutils:1.3.0'
+
   compile "org.scala-lang.modules:scala-xml_${project.scalaVersion}:1.0.6"
+  compile "org.scala-lang:scala-library:${project.scalaFullVersion}"
+  compile("com.typesafe.scala-logging:scala-logging_${project.scalaVersion}:3.7.2") {
+    exclude group: 'org.scala-lang'
+  }
 
   testCompile "ch.qos.logback:logback-classic:${project.logbackVersion}"
 }

--- a/pact-jvm-model/build.gradle
+++ b/pact-jvm-model/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile 'org.apache.commons:commons-collections4:4.1'
   compile 'com.github.mifmif:generex:1.0.1'
   compile 'javax.mail:mail:1.5.0-b01'
+  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 
   testCompile "ch.qos.logback:logback-classic:${project.logbackVersion}"
   testCompile "org.codehaus.groovy.modules.http-builder:http-builder:${project.httpBuilderVersion}"

--- a/pact-jvm-pact-broker/build.gradle
+++ b/pact-jvm-pact-broker/build.gradle
@@ -6,6 +6,10 @@ dependencies {
   compile "org.apache.httpcomponents:httpclient:${project.httpClientVersion}"
   compile "com.google.guava:guava:${project.guavaVersion}"
   compile 'org.dmfs:rfc3986-uri:0.8'
+
+  compile('io.github.microutils:kotlin-logging:1.4.4') {
+    exclude group: 'org.jetbrains.kotlin'
+  }
 }
 
 compileGroovy {

--- a/pact-jvm-pact-broker/build.gradle
+++ b/pact-jvm-pact-broker/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile project(":pact-jvm-support")
   compile "org.apache.commons:commons-lang3:$commonsLang3Version"
+  compile "org.codehaus.groovy:groovy-all:${project.groovyVersion}:indy"
   compile 'com.github.salomonbrys.kotson:kotson:2.5.0'
   compile "org.apache.httpcomponents:httpclient:${project.httpClientVersion}"
   compile "com.google.guava:guava:${project.guavaVersion}"

--- a/pact-jvm-provider-junit/build.gradle
+++ b/pact-jvm-provider-junit/build.gradle
@@ -5,6 +5,7 @@ dependencies {
       "junit:junit:${project.junitVersion}",
       "org.apache.commons:commons-lang3:${project.commonsLang3Version}",
       'org.jooq:jool:0.9.11'
+    compile "org.slf4j:slf4j-api:${project.slf4jVersion}"
     compile('com.github.rholder:guava-retrying:2.0.0')
     compile 'javax.mail:mail:1.5.0-b01'
 

--- a/pact-jvm-support/build.gradle
+++ b/pact-jvm-support/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
   compile "org.apache.commons:commons-lang3:${project.commonsLang3Version}"
 }


### PR DESCRIPTION
Use only transitive dependencies for compile dependencies.
Pushing dependencies to subprojects introduces a risk of polluting published POM with unneeded dependencies.
    
Keep pushing test dependencies as it does not affect library clients.