### PR TITLE
Add option to use concrete timezone for example date formatting

### DIFF
--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -7,6 +7,7 @@ import au.com.dius.pact.model.matchingrules.MatchingRule;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -160,6 +161,19 @@ public class LambdaDslObject {
     }
 
     /**
+     * Attribute that must match the provided date format
+     *
+     * @param name    attribute date
+     * @param format  date format to match
+     * @param example example date to use for generated values
+     * @param timeZone time zone used for formatting of example date
+     */
+    public LambdaDslObject date(String name, String format, Date example, TimeZone timeZone) {
+        object.date(name, format, example, timeZone);
+        return this;
+    }
+
+    /**
      * Attribute named 'time' that must be an ISO formatted time
      */
     public LambdaDslObject time() {
@@ -197,6 +211,18 @@ public class LambdaDslObject {
      */
     public LambdaDslObject time(String name, String format, Date example) {
         object.time(name, format, example);
+        return this;
+    }
+    /**
+     * Attribute that must match the provided time format
+     *
+     * @param name    attribute name
+     * @param format  time format to match
+     * @param example example time to use for generated values
+     * @param timeZone time zone used for formatting of example time
+     */
+    public LambdaDslObject time(String name, String format, Date example, TimeZone timeZone) {
+        object.time(name, format, example, timeZone);
         return this;
     }
 
@@ -238,6 +264,19 @@ public class LambdaDslObject {
      */
     public LambdaDslObject timestamp(String name, String format, Date example) {
         object.timestamp(name, format, example);
+        return this;
+    }
+
+    /**
+     * Attribute that must match the given timestamp format
+     *
+     * @param name    attribute name
+     * @param format  timestamp format
+     * @param example example date and time to use for generated bodies
+     * @param timeZone time zone used for formatting of example date and time
+     */
+    public LambdaDslObject timestamp(String name, String format, Date example, TimeZone timeZone) {
+        object.timestamp(name, format, example, timeZone);
         return this;
     }
 

--- a/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
+++ b/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonBody.java
@@ -23,6 +23,7 @@ import au.com.dius.pact.model.matchingrules.TypeMatcher;
 import au.com.dius.pact.model.matchingrules.ValuesMatcher;
 import com.mifmif.common.regex.Generex;
 import io.gatling.jsonpath.Parser$;
+import java.util.TimeZone;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
@@ -424,7 +425,18 @@ public class PactDslJsonBody extends DslPart {
      * @param example example date and time to use for generated bodies
      */
     public PactDslJsonBody timestamp(String name, String format, Date example) {
-        FastDateFormat instance = FastDateFormat.getInstance(format);
+        return timestamp(name, format, example, TimeZone.getDefault());
+    }
+
+    /**
+     * Attribute that must match the given timestamp format
+     * @param name attribute name
+     * @param format timestamp format
+     * @param example example date and time to use for generated bodies
+     * @param timeZone time zone used for formatting of example date and time
+     */
+    public PactDslJsonBody timestamp(String name, String format, Date example, TimeZone timeZone) {
+        FastDateFormat instance = FastDateFormat.getInstance(format, timeZone);
         body.put(name, instance.format(example));
         matchers.addRule(matcherKey(name), matchTimestamp(format));
         return this;
@@ -469,7 +481,18 @@ public class PactDslJsonBody extends DslPart {
      * @param example example date to use for generated values
      */
     public PactDslJsonBody date(String name, String format, Date example) {
-        FastDateFormat instance = FastDateFormat.getInstance(format);
+        return date(name, format, example, TimeZone.getDefault());
+    }
+
+    /**
+     * Attribute that must match the provided date format
+     * @param name attribute date
+     * @param format date format to match
+     * @param example example date to use for generated values
+     * @param timeZone time zone used for formatting of example date
+     */
+    public PactDslJsonBody date(String name, String format, Date example, TimeZone timeZone) {
+        FastDateFormat instance = FastDateFormat.getInstance(format, timeZone);
         body.put(name, instance.format(example));
         matchers.addRule(matcherKey(name), matchDate(format));
         return this;
@@ -514,7 +537,18 @@ public class PactDslJsonBody extends DslPart {
      * @param example example time to use for generated bodies
      */
     public PactDslJsonBody time(String name, String format, Date example) {
-        FastDateFormat instance = FastDateFormat.getInstance(format);
+        return time(name, format, example, TimeZone.getDefault());
+    }
+
+    /**
+     * Attribute that must match the given time format
+     * @param name attribute name
+     * @param format time format to match
+     * @param example example time to use for generated bodies
+     * @param timeZone time zone used for formatting of example time
+     */
+    public PactDslJsonBody time(String name, String format, Date example, TimeZone timeZone) {
+        FastDateFormat instance = FastDateFormat.getInstance(format, timeZone);
         body.put(name, instance.format(example));
         matchers.addRule(matcherKey(name), matchTime(format));
         return this;

--- a/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -2,6 +2,8 @@ package au.com.dius.pact.consumer;
 
 import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import java.util.Date;
+import java.util.TimeZone;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -264,5 +266,24 @@ public class PactDslJsonBodyTest {
         .date("creationDate", DATE_FORMAT);
       JSONObject jsonObject = (JSONObject) response.getBody();
       assertThat(jsonObject.get("lastUpdate").toString(), matchesPattern("\\w{3}, \\d{2} \\w{3} \\d{4} \\d{2}:00:00 \\+\\d+ GMT"));
+    }
+
+    @Test
+    public void testExampleTimestampTimezone() {
+      final PactDslJsonBody response = new PactDslJsonBody();
+      response
+        .timestamp("timestampLosAngeles", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Date(0), TimeZone.getTimeZone("America/Los_Angeles"))
+        .timestamp("timestampBerlin", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Date(0), TimeZone.getTimeZone("Europe/Berlin"))
+        .date("dateLosAngeles", "yyyy-MM-dd", new Date(0), TimeZone.getTimeZone("America/Los_Angeles"))
+        .date("dateBerlin", "yyyy-MM-dd", new Date(0), TimeZone.getTimeZone("Europe/Berlin"))
+        .time("timeLosAngeles", "HH:mm:ss", new Date(0), TimeZone.getTimeZone("America/Los_Angeles"))
+        .time("timeBerlin", "HH:mm:ss", new Date(0), TimeZone.getTimeZone("Europe/Berlin"));
+      JSONObject jsonObject = (JSONObject) response.getBody();
+      assertThat(jsonObject.get("timestampLosAngeles").toString(), is(equalTo("1969-12-31T16:00:00.000Z")));
+      assertThat(jsonObject.get("timestampBerlin").toString(), is(equalTo("1970-01-01T01:00:00.000Z")));
+      assertThat(jsonObject.get("dateLosAngeles").toString(), is(equalTo("1969-12-31")));
+      assertThat(jsonObject.get("dateBerlin").toString(), is(equalTo("1970-01-01")));
+      assertThat(jsonObject.get("timeLosAngeles").toString(), is(equalTo("16:00:00")));
+      assertThat(jsonObject.get("timeBerlin").toString(), is(equalTo("01:00:00")));
     }
 }


### PR DESCRIPTION
Otherwise the default timezone is always used which may result in different bodies depending in the system's default.