### PR TITLE
Send detailed verification results to pact broker

### DIFF
--- a/pact-jvm-pact-broker/src/main/kotlin/au/com/dius/pact/pactbroker/PactBrokerClient.kt
+++ b/pact-jvm-pact-broker/src/main/kotlin/au/com/dius/pact/pactbroker/PactBrokerClient.kt
@@ -27,12 +27,16 @@ abstract class PactBrokerClientBase(val pactBrokerUrl: String, val options: Map<
     docAttributes: Map<String, Map<String, Any>>,
     result: Boolean,
     version: String,
+    testResults: String? = null,
     buildUrl: String? = null
   ): Result<Boolean, Exception> {
     val halClient = newHalClient()
     val publishLink = docAttributes.mapKeys { it.key.toLowerCase() } ["pb:publish-verification-results"] // ktlint-disable curly-spacing
     return if (publishLink != null) {
       val jsonObject = jsonObject("success" to result, "providerApplicationVersion" to version)
+      if (testResults != null) {
+        jsonObject.add("testResults", testResults.toJson())
+      }
       if (buildUrl != null) {
         jsonObject.add("buildUrl", buildUrl.toJson())
       }

--- a/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderVerifier.groovy
+++ b/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/ProviderVerifier.groovy
@@ -65,7 +65,7 @@ class ProviderVerifier extends ProviderVerifierBase {
         log.warn('Skipping publishing of verification results as it has been disabled ' +
           "(${PACT_VERIFIER_PUBLISH_RESULTS} is not 'true')")
       } else {
-        verificationReporter.reportResults(pact, result, providerVersion?.get() ?: '0.0.0', client)
+        verificationReporter.reportResults(pact, result, providerVersion?.get() ?: '0.0.0', client, failures.toString())
       }
     }
   }


### PR DESCRIPTION
This is a first attempt to implement the following request mentioned in the pact-jvm slack channel:

> Hi, The Matrix on Pact Broker shows the high-level verification results, is there any way in Pact Broker where a user can see detailed verification result. 

(See https://pact-foundation.slack.com/archives/C9VPNUJR2/p1539079990000100)

I only tested it manually for Maven and Junit 4 and I didn't add any automated tests yet because I would like to get some feedback on the approach first. The formatting is far from perfect but maybe it' sufficient, what do you think?

Maven:
```
{
  "providerName": "user-service",
  "providerApplicationVersion": "1.0.0-SNAPSHOT",
  "success": false,
  "verificationDate": "2018-10-17T22:12:22+00:00",
  "testResults": "{Verifying a pact between messaging-app and user-service - A request for a non-existing user  Given default returns a response which has status code 404=expected status of 404 but was 200}”
}
```

Junit 4:
```
{
  "providerName": "user-service",
  "providerApplicationVersion": "0.0.0",
  "success": false,
  "verificationDate": "2018-10-17T22:49:24+00:00",
  "testResults": "[messaging-app - A request for a non-existing user(de.kreuzwerker.cdc.userservice.GenericStateWithParameterContractTest): \n0 - expected status of 404 but was 200]"
}
```