### PR TITLE
add LambdaDslJsonArray.newObject Kotlin extension

### DIFF
--- a/pact-jvm-consumer-java8/README.md
+++ b/pact-jvm-consumer-java8/README.md
@@ -192,4 +192,12 @@ newJsonArray((rootArray) -> {
 
 ```
 
+`object` is a reserved word in Kotlin. To allow using the DSL without escaping, a Kotlin extension `newObject` is available:
 
+```kotlin
+newJsonArray { rootArray ->
+    rootArray.array { a -> a.stringValue("a1").stringValue("a2") }
+    rootArray.array { a -> a.numberValue(1).numberValue(2) }
+    rootArray.array { a -> a.newObject { o -> o.stringValue("foo", "Foo") } }
+}.build()
+```

--- a/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/package-info.java
+++ b/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/package-info.java
@@ -1,0 +1,4 @@
+@NonNullApi
+package io.pactfoundation.consumer.dsl;
+
+import au.com.dius.pact.support.NonNullApi;

--- a/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
+++ b/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
@@ -1,0 +1,5 @@
+package io.pactfoundation.consumer.dsl
+
+fun LambdaDslJsonArray.newObject(o: (LambdaDslObject) -> (Unit)): LambdaDslJsonArray {
+  return this.`object`(o)
+}

--- a/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
+++ b/pact-jvm-consumer-java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArrayTest.java
@@ -1,9 +1,7 @@
 package io.pactfoundation.consumer.dsl;
 
-import au.com.dius.pact.consumer.dsl.DslPart;
 import au.com.dius.pact.consumer.dsl.PM;
 import au.com.dius.pact.consumer.dsl.PactDslJsonArray;
-import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
+++ b/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
@@ -1,0 +1,10 @@
+package io.pactfoundation.consumer.dsl
+
+import org.junit.jupiter.api.Test
+
+class ExtensionsTest {
+  @Test
+  fun `can use LambdaDslJsonArray#newObject`() {
+    LambdaDsl.newJsonArray { array -> array.newObject { o -> o.stringType("foo") } }
+  }
+}

--- a/pact-jvm-support/build.gradle
+++ b/pact-jvm-support/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
   compile "org.apache.commons:commons-lang3:${project.commonsLang3Version}"
+  compile "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/pact-jvm-support/src/main/java/au/com/dius/pact/support/NonNullApi.java
+++ b/pact-jvm-support/src/main/java/au/com/dius/pact/support/NonNullApi.java
@@ -1,0 +1,12 @@
+package au.com.dius.pact.support;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PACKAGE)
+@Nonnull
+@TypeQualifierDefault({ElementType.METHOD, ElementType.PARAMETER})
+public @interface NonNullApi {
+}


### PR DESCRIPTION
Allow to use jvm-consumer-java8 DSL in Kotlin without escaping 'object'.

Also set nullability of jvm-consumer-java8

Fixes #803