### PR TITLE
Fixing broken link to the Pact JUnit providers.

### DIFF
--- a/pact-jvm-provider-spring/README.md
+++ b/pact-jvm-provider-spring/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Library provides ability to play contract tests against a provider using Spring & JUnit.
-This library is based on and references the JUnit package, so see [junit provider support](pact-jvm-provider-junit) for more details regarding configuration using JUnit.
+This library is based on and references the JUnit package, so see the [Pact JUnit 4](../pact-jvm-provider-junit) or [Pact JUnit 5](../pact-jvm-provider-junit5) providers for more details regarding configuration using JUnit.
 
 Supports:
 


### PR DESCRIPTION
Quick fix for a broken link I found while reading through the docs. 