### PR TITLE
Snapshot trim change proposal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-groovyVersion=2.5.4
+groovyVersion=2.5.3
 kotlinVersion=1.3.0
 httpBuilderVersion=0.7.1
 commonsLang3Version=3.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-groovyVersion=2.5.3
+groovyVersion=2.5.4
 kotlinVersion=1.3.0
 httpBuilderVersion=0.7.1
 commonsLang3Version=3.4

--- a/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
+++ b/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
@@ -59,8 +59,10 @@ open class PactPublishMojo : AbstractMojo() {
     override fun execute() {
       AnsiConsole.systemInstall()
 
-      if (trimSnapshot && projectVersion.endsWith("-SNAPSHOT")) {
-          projectVersion = projectVersion.substring(0, projectVersion.length - 9)
+        val snapShotDefinitionString = "-SNAPSHOT"
+        val emptyString = ""
+        if (trimSnapshot && projectVersion.contains(snapShotDefinitionString)) {
+          projectVersion = projectVersion.replaceFirst(snapShotDefinitionString, emptyString)
       }
 
       if (brokerClient == null) {

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactPublishMojoSpec.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactPublishMojoSpec.groovy
@@ -86,6 +86,18 @@ class PactPublishMojoSpec extends Specification {
         assert mojo.projectVersion == '1.0.0'
     }
 
+    def 'trimSnapshot=true removes the "-SNAPSHOT" in the middle'() {
+        given:
+        mojo.projectVersion = '1.0.0-SNAPSHOT-3ffe453efr'
+        mojo.trimSnapshot = true
+
+        when:
+        mojo.execute()
+
+        then:
+        assert mojo.projectVersion == '1.0.0-3ffe453efr'
+    }
+
     def 'trimSnapshot=false leaves version unchanged'() {
         given:
         mojo.projectVersion = '1.0.0-SNAPSHOT'


### PR DESCRIPTION
Problem:
I want to to be able to get rid of `-SNAPSHOT` even if my version has trailing characters (like git commit id)
and so being able to still relay on the plugin configuration `<trimSnapshot>true</trimSnapshot>`