### PR TITLE
Feat: snapshot trimming on provider version

### DIFF
--- a/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
+++ b/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
@@ -173,7 +173,6 @@ open class InteractionRunner<I>(
     }
   }
 
-
   protected open fun createTest(): Any {
     return testClass.onlyConstructor.newInstance()
   }

--- a/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
+++ b/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
@@ -6,6 +6,7 @@ import au.com.dius.pact.model.Pact
 import au.com.dius.pact.model.PactSource
 import au.com.dius.pact.provider.DefaultVerificationReporter
 import au.com.dius.pact.provider.IProviderVerifier
+import au.com.dius.pact.provider.ProviderUtils
 import au.com.dius.pact.provider.ProviderVerifierBase.Companion.PACT_VERIFIER_PUBLISH_RESULTS
 import au.com.dius.pact.provider.junit.target.Target
 import au.com.dius.pact.provider.junit.target.TestClassAwareTarget
@@ -165,12 +166,13 @@ open class InteractionRunner<I>(
   private fun providerVersion(): String {
     val version = System.getProperty("pact.provider.version")
     return if (version != null) {
-      version
+      ProviderUtils.getProviderVersion(version)
     } else {
       logger.warn { "Set the provider version using the 'pact.provider.version' property. Defaulting to '0.0.0'" }
       "0.0.0"
     }
   }
+
 
   protected open fun createTest(): Any {
     return testClass.onlyConstructor.newInstance()

--- a/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/InteractionRunnerSpec.groovy
+++ b/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/InteractionRunnerSpec.groovy
@@ -6,17 +6,13 @@ import au.com.dius.pact.model.Provider
 import au.com.dius.pact.model.RequestResponseInteraction
 import au.com.dius.pact.model.RequestResponsePact
 import au.com.dius.pact.model.UnknownPactSource
-import au.com.dius.pact.provider.DefaultVerificationReporter
 import au.com.dius.pact.provider.junit.target.HttpTarget
 import au.com.dius.pact.provider.junit.target.Target
 import au.com.dius.pact.provider.junit.target.TestTarget
-import org.junit.Assert
 import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.TestClass
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
-
-import static org.junit.Assert.assertEquals
 
 class InteractionRunnerSpec extends Specification {
 

--- a/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -72,7 +72,7 @@ open class PactProviderMojo : AbstractMojo() {
         "You must specify the pact file to execute for consumer '${consumer.name}' (use <pactFile> or <pactUrl>)"
       }
       verifier.checkBuildSpecificTask = Function { false }
-      verifier.providerVersion = Supplier { projectVersion }
+      verifier.providerVersion = Supplier { ProviderUtils.getProviderVersion(projectVersion) }
 
       verifier.projectClasspath = Supplier { classpathElements.map { File(it).toURI().toURL() } }
 

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -7,13 +7,8 @@ import org.apache.maven.settings.Server
 import org.apache.maven.settings.Settings
 import org.apache.maven.settings.crypto.SettingsDecrypter
 import org.apache.maven.settings.crypto.SettingsDecryptionResult
-import org.junit.Assert
-import org.mockito.Mockito
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
-
-import static org.junit.Assert.assertEquals
-import static org.mockito.Mockito.when
 
 @SuppressWarnings(['UnnecessaryGetter', 'ClosureAsLastMethodParameter'])
 class PactProviderMojoSpec extends Specification {

--- a/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -7,8 +7,13 @@ import org.apache.maven.settings.Server
 import org.apache.maven.settings.Settings
 import org.apache.maven.settings.crypto.SettingsDecrypter
 import org.apache.maven.settings.crypto.SettingsDecryptionResult
+import org.junit.Assert
+import org.mockito.Mockito
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
+
+import static org.junit.Assert.assertEquals
+import static org.mockito.Mockito.when
 
 @SuppressWarnings(['UnnecessaryGetter', 'ClosureAsLastMethodParameter'])
 class PactProviderMojoSpec extends Specification {
@@ -225,5 +230,30 @@ class PactProviderMojoSpec extends Specification {
     then:
     noExceptionThrown()
     System.getProperty('pact.verifier.publishResults') == 'true'
+  }
+
+  @RestoreSystemProperties
+  def 'system property pact.provider.version.trimSnapshot true when set with systemPropertyVariables' () {
+    given:
+    def provider = new Provider(pactFileDirectory: 'dir1' as File)
+    def verifier = Mock(ProviderVerifier) {
+      verifyProvider(provider) >> [:]
+    }
+    mojo = Spy(PactProviderMojo) {
+      loadPactFiles(provider, _) >> []
+      providerVerifier() >> verifier
+    }
+    mojo.serviceProviders = [ provider ]
+    mojo.failIfNoPactsFound = false
+    mojo.systemPropertyVariables.put('pact.provider.version.trimSnapshot', 'true')
+    mojo.reports = [ 'console' ]
+    mojo.buildDir = new File('/tmp')
+
+    when:
+    mojo.execute()
+
+    then:
+    noExceptionThrown()
+    System.getProperty('pact.provider.version.trimSnapshot') == 'true'
   }
 }

--- a/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderUtils.kt
+++ b/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderUtils.kt
@@ -3,6 +3,7 @@ package au.com.dius.pact.provider
 import au.com.dius.pact.model.FileSource
 import au.com.dius.pact.model.Interaction
 import groovy.json.JsonSlurper
+import org.apache.commons.lang3.BooleanUtils
 import org.fusesource.jansi.AnsiConsole
 import java.io.File
 
@@ -82,5 +83,20 @@ object ProviderUtils {
 
   fun isS3Url(pactFile: Any?): Boolean {
     return pactFile is String && pactFile.toLowerCase().startsWith("s3://")
+  }
+
+  @JvmStatic
+  fun getProviderVersion(projectVersion : String) : String {
+    val trimSnapshotProperty = System.getProperty(ProviderVerifierBase.PACT_PROVIDER_VERSION_TRIM_SNAPSHOT)
+    val isTrimSnapshot: Boolean = if (trimSnapshotProperty.isBlank()) false else BooleanUtils.toBoolean(trimSnapshotProperty)
+    return if (isTrimSnapshot) trimSnapshot(projectVersion) else projectVersion
+  }
+
+  private fun trimSnapshot(providerVersion : String) : String {
+    val SNAPSHOT_STRING = "-SNAPSHOT"
+    if (providerVersion.contains(SNAPSHOT_STRING)) {
+      return providerVersion.replaceFirst(SNAPSHOT_STRING, "")
+    }
+    return providerVersion;
   }
 }

--- a/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderUtils.kt
+++ b/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderUtils.kt
@@ -86,17 +86,21 @@ object ProviderUtils {
   }
 
   @JvmStatic
-  fun getProviderVersion(projectVersion : String) : String {
+  fun getProviderVersion(projectVersion: String): String {
     val trimSnapshotProperty = System.getProperty(ProviderVerifierBase.PACT_PROVIDER_VERSION_TRIM_SNAPSHOT)
-    val isTrimSnapshot: Boolean = if (trimSnapshotProperty.isBlank()) false else BooleanUtils.toBoolean(trimSnapshotProperty)
+    val isTrimSnapshot: Boolean = if (trimSnapshotProperty == null || trimSnapshotProperty.isBlank()) {
+      false
+    } else {
+      BooleanUtils.toBoolean(trimSnapshotProperty)
+    }
     return if (isTrimSnapshot) trimSnapshot(projectVersion) else projectVersion
   }
 
-  private fun trimSnapshot(providerVersion : String) : String {
+  private fun trimSnapshot(providerVersion: String): String {
     val SNAPSHOT_STRING = "-SNAPSHOT"
     if (providerVersion.contains(SNAPSHOT_STRING)) {
       return providerVersion.replaceFirst(SNAPSHOT_STRING, "")
     }
-    return providerVersion;
+    return providerVersion
   }
 }

--- a/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
+++ b/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
@@ -303,6 +303,7 @@ abstract class ProviderVerifierBase @JvmOverloads constructor (
     const val PACT_SHOW_STACKTRACE = "pact.showStacktrace"
     const val PACT_SHOW_FULLDIFF = "pact.showFullDiff"
     const val PACT_PROVIDER_VERSION = "pact.provider.version"
+    const val PACT_PROVIDER_VERSION_TRIM_SNAPSHOT = "pact.provider.version.trimSnapshot"
 
     fun invokeProviderMethod(m: Method, instance: Any?): Any? {
       try {

--- a/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/ProviderUtilsSpec.groovy
+++ b/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/ProviderUtilsSpec.groovy
@@ -2,6 +2,9 @@ package au.com.dius.pact.provider
 
 import spock.lang.IgnoreIf
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import static org.junit.Assert.assertEquals
 
 @SuppressWarnings('UnnecessaryBooleanExpression')
 class ProviderUtilsSpec extends Specification {
@@ -72,6 +75,18 @@ class ProviderUtilsSpec extends Specification {
     new ProviderInfo() | new ConsumerInfo(packagesToScan: ['a.b.c']) || ['a.b.c']
     new ProviderInfo(packagesToScan: ['d.e.f']) | new ConsumerInfo(packagesToScan: ['a.b.c']) || ['a.b.c']
     new ProviderInfo(packagesToScan: ['d.e.f']) | new ConsumerInfo() || ['d.e.f']
+  }
+
+  @RestoreSystemProperties
+  def 'provider versions with trim snapshot' () {
+
+    expect:
+    ProviderUtils.getProviderVersion(projectVersion) == result
+
+    where:
+    systemProperty | projectVersion || result
+    System.setProperty('pact.provider.version.trimSnapshot', 'true') | '1.0.0-SNAPSHOT-re234hj' | '1.0.0-re234hj'
+    System.setProperty('pact.provider.version.trimSnapshot', null) | '1.0.0-SNAPSHOT-re234hj' | '1.0.0-SNAPSHOT-re234hj'
   }
 
 }

--- a/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/ProviderUtilsSpec.groovy
+++ b/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/ProviderUtilsSpec.groovy
@@ -4,8 +4,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.util.environment.RestoreSystemProperties
 
-import static org.junit.Assert.assertEquals
-
 @SuppressWarnings('UnnecessaryBooleanExpression')
 class ProviderUtilsSpec extends Specification {
 
@@ -78,15 +76,53 @@ class ProviderUtilsSpec extends Specification {
   }
 
   @RestoreSystemProperties
-  def 'provider versions with trim snapshot' () {
+  def 'provider versions with trim snapshot property true' () {
 
     expect:
     ProviderUtils.getProviderVersion(projectVersion) == result
 
     where:
     systemProperty | projectVersion || result
-    System.setProperty('pact.provider.version.trimSnapshot', 'true') | '1.0.0-SNAPSHOT-re234hj' | '1.0.0-re234hj'
-    System.setProperty('pact.provider.version.trimSnapshot', null) | '1.0.0-SNAPSHOT-re234hj' | '1.0.0-SNAPSHOT-re234hj'
+    System.setProperty(ProviderVerifierBase.PACT_PROVIDER_VERSION_TRIM_SNAPSHOT, 'true') |
+            '1.0.0-SNAPSHOT-re234hj' |
+            '1.0.0-re234hj'
+  }
+
+  @RestoreSystemProperties
+  def 'provider versions with trim snapshot property false' () {
+
+    expect:
+    ProviderUtils.getProviderVersion(projectVersion) == result
+
+    where:
+    systemProperty | projectVersion || result
+    System.setProperty(ProviderVerifierBase.PACT_PROVIDER_VERSION_TRIM_SNAPSHOT, 'false') |
+            '1.0.0-SNAPSHOT-re234hj' |
+            '1.0.0-SNAPSHOT-re234hj'
+  }
+
+  @RestoreSystemProperties
+  def 'provider versions with trim snapshot property wrong value' () {
+
+    expect:
+    ProviderUtils.getProviderVersion(projectVersion) == result
+
+    where:
+    systemProperty | projectVersion || result
+    System.setProperty(ProviderVerifierBase.PACT_PROVIDER_VERSION_TRIM_SNAPSHOT, 'aweirdstring') |
+            '1.0.0-SNAPSHOT-re234hj' |
+            '1.0.0-SNAPSHOT-re234hj'
+  }
+
+  @RestoreSystemProperties
+  def 'provider versions with trim snapshot property not set' () {
+
+    expect:
+    ProviderUtils.getProviderVersion(projectVersion) == result
+
+    where:
+    systemProperty | projectVersion || result
+    _ | '1.0.0-SNAPSHOT-re234hj' | '1.0.0-SNAPSHOT-re234hj'
   }
 
 }


### PR DESCRIPTION
As a provider, I would like to be able to trim the -SNAPSHOT on my version during verification result publications