### PR TITLE
feat: specify the pact tag if applicable

### DIFF
--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/AmqpTarget.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/AmqpTarget.kt
@@ -79,7 +79,7 @@ open class AmqpTarget @JvmOverloads constructor(
     setupReporters(verifier, provider.name, interaction.description)
 
     verifier.initialiseReporters(provider)
-    verifier.reportVerificationForConsumer(consumer, provider)
+    verifier.reportVerificationForConsumer(consumer, provider, null)
 
     if (!interaction.providerStates.isEmpty()) {
       for ((name) in interaction.providerStates) {

--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/HttpTarget.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/HttpTarget.kt
@@ -94,7 +94,7 @@ open class HttpTarget
     setupReporters(verifier, provider.name, interaction.description)
 
     verifier.initialiseReporters(provider)
-    verifier.reportVerificationForConsumer(consumer, provider)
+    verifier.reportVerificationForConsumer(consumer, provider, null)
 
     if (interaction.providerStates.isNotEmpty()) {
       for ((name) in interaction.providerStates) {

--- a/provider/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
+++ b/provider/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
@@ -171,7 +171,7 @@ class PactVerificationExtension(
     val providerInfo = testContext.target.getProviderInfo(serviceName, pactSource)
     testContext.providerInfo = providerInfo
 
-    prepareVerifier(testContext, context)
+    prepareVerifier(testContext, context, pactSource)
     store.put("verifier", testContext.verifier)
 
     val requestAndClient = testContext.target.prepareRequest(interaction, testContext.executionContext ?: emptyMap())
@@ -185,7 +185,7 @@ class PactVerificationExtension(
     }
   }
 
-  private fun prepareVerifier(testContext: PactVerificationContext, extContext: ExtensionContext) {
+  private fun prepareVerifier(testContext: PactVerificationContext, extContext: ExtensionContext, pactSource: au.com.dius.pact.core.model.PactSource) {
     val consumer = ConsumerInfo(consumerName ?: pact.consumer.name)
 
     val verifier = ProviderVerifier()
@@ -194,7 +194,7 @@ class PactVerificationExtension(
     setupReporters(verifier, serviceName, interaction.description, extContext, testContext.valueResolver)
 
     verifier.initialiseReporters(testContext.providerInfo)
-    verifier.reportVerificationForConsumer(consumer, testContext.providerInfo)
+    verifier.reportVerificationForConsumer(consumer, testContext.providerInfo, pactSource)
 
     if (!interaction.providerStates.isEmpty()) {
       for ((name) in interaction.providerStates) {

--- a/provider/pact-jvm-provider-spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/MockMvcTarget.kt
+++ b/provider/pact-jvm-provider-spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/MockMvcTarget.kt
@@ -112,7 +112,7 @@ class MockMvcTarget @JvmOverloads constructor(
     verifier.projectClasspath = Supplier { (ClassLoader.getSystemClassLoader() as URLClassLoader).urLs.toList() }
 
     verifier.initialiseReporters(provider)
-    verifier.reportVerificationForConsumer(consumer, provider)
+    verifier.reportVerificationForConsumer(consumer, provider, null)
 
     if (!interaction.providerStates.isEmpty()) {
       for ((name) in interaction.providerStates) {

--- a/provider/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/reporters/JsonReporter.groovy
+++ b/provider/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/reporters/JsonReporter.groovy
@@ -64,7 +64,7 @@ class JsonReporter implements VerifierReporter {
   }
 
   @Override
-  void reportVerificationForConsumer(IConsumerInfo consumer, IProviderInfo provider) {
+  void reportVerificationForConsumer(IConsumerInfo consumer, IProviderInfo provider, @Nullable String tag) {
     jsonData.execution << [
       consumer: [
         name: consumer.name

--- a/provider/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/reporters/MarkdownReporter.groovy
+++ b/provider/pact-jvm-provider/src/main/groovy/au/com/dius/pact/provider/reporters/MarkdownReporter.groovy
@@ -40,8 +40,13 @@ class MarkdownReporter implements VerifierReporter {
   }
 
   @Override
-  void reportVerificationForConsumer(IConsumerInfo consumer, IProviderInfo provider) {
-    reportFile.append "## Verifying a pact between _${consumer.name}_ and _${provider.name}_\n"
+  void reportVerificationForConsumer(IConsumerInfo consumer, IProviderInfo provider, @Nullable String tag) {
+    def report = new StringBuilder("## Verifying a pact between _${consumer.name}_ and _${provider.name}_")
+    if (tag != null) {
+      report.append(" for tag ${tag}")
+    }
+    report.append('\n')
+    reportFile.append report.toString()
     reportFile.append '\n'
   }
 

--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/AnsiConsoleReporter.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/AnsiConsoleReporter.kt
@@ -45,9 +45,13 @@ class AnsiConsoleReporter(
 
   override fun finaliseReport() { }
 
-  override fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo) {
-    AnsiConsole.out().println(Ansi.ansi().a("\nVerifying a pact between ").bold().a(consumer.name)
-      .boldOff().a(" and ").bold().a(provider.name).boldOff())
+  override fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String?) {
+    val ansi = Ansi.ansi().a("\nVerifying a pact between ").bold().a(consumer.name)
+            .boldOff().a(" and ").bold().a(provider.name).boldOff()
+
+    if (tag != null) ansi.a(" for tag ").a(tag)
+
+    AnsiConsole.out().println(ansi)
   }
 
   override fun verifyConsumerFromUrl(pactUrl: UrlPactSource, consumer: IConsumerInfo) {

--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/VerifierReporter.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/VerifierReporter.kt
@@ -22,7 +22,7 @@ interface VerifierReporter {
 
   fun initialise(provider: IProviderInfo)
   fun finaliseReport()
-  fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo)
+  fun reportVerificationForConsumer(consumer: IConsumerInfo, provider: IProviderInfo, tag: String?)
   fun verifyConsumerFromUrl(pactUrl: UrlPactSource, consumer: IConsumerInfo)
   fun verifyConsumerFromFile(pactFile: PactSource, consumer: IConsumerInfo)
   fun pactLoadFailureForConsumer(consumer: IConsumerInfo, message: String)

--- a/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/readme/ReadmeExamplePactJVMProviderJUnitTest.groovy
+++ b/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/readme/ReadmeExamplePactJVMProviderJUnitTest.groovy
@@ -81,7 +81,7 @@ class ReadmeExamplePactJVMProviderJUnitTest {
     ProviderVerifier verifier = new ProviderVerifier()
 
     verifier.initialiseReporters(provider)
-    verifier.reportVerificationForConsumer(consumer, provider)
+    verifier.reportVerificationForConsumer(consumer, provider, new UrlSource('http://example.example'))
 
     if (!interaction.getProviderStates().isEmpty()) {
       for (ProviderState providerState: interaction.getProviderStates()) {

--- a/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/reporters/JsonReporterSpec.groovy
+++ b/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/reporters/JsonReporterSpec.groovy
@@ -49,11 +49,11 @@ class JsonReporterSpec extends Specification {
 
     when:
     reporter.initialise(provider1)
-    reporter.reportVerificationForConsumer(consumer, provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, null)
     reporter.interactionDescription(interaction1)
     reporter.finaliseReport()
     reporter.initialise(provider2)
-    reporter.reportVerificationForConsumer(consumer, provider2)
+    reporter.reportVerificationForConsumer(consumer, provider2, null)
     reporter.interactionDescription(interaction2)
     reporter.finaliseReport()
 
@@ -92,7 +92,7 @@ class JsonReporterSpec extends Specification {
 
     when:
     reporter.initialise(provider1)
-    reporter.reportVerificationForConsumer(consumer, provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, null)
     reporter.interactionDescription(interaction1)
     reporter.finaliseReport()
 

--- a/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/reporters/MarkdownReporterSpec.groovy
+++ b/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/reporters/MarkdownReporterSpec.groovy
@@ -46,19 +46,38 @@ class MarkdownReporterSpec extends Specification {
 
     when:
     reporter.initialise(provider1)
-    reporter.reportVerificationForConsumer(consumer, provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, 'staging')
     reporter.interactionDescription(interaction1)
     reporter.finaliseReport()
     reporter.initialise(provider1)
-    reporter.reportVerificationForConsumer(consumer, provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, 'production')
     reporter.interactionDescription(interaction2)
     reporter.finaliseReport()
 
     def results = new File(reportDir, 'provider1.md').text
 
     then:
+    results.contains('## Verifying a pact between _Consumer_ and _provider1_ for tag staging\n\nInteraction 1 ')
+    results.contains('## Verifying a pact between _Consumer_ and _provider1_ for tag production\n\nInteraction 2 ')
+  }
+
+  def 'does not specify tag if not tag is not specified'() {
+    given:
+    def reporter = new MarkdownReporter(reportDir: reportDir)
+    def provider1 = new ProviderInfo(name: 'provider1')
+    def consumer = new ConsumerInfo(name: 'Consumer')
+    def interaction1 = new RequestResponseInteraction('Interaction 1', [], new Request(), new Response())
+
+    when:
+    reporter.initialise(provider1)
+    reporter.reportVerificationForConsumer(consumer, provider1, null)
+    reporter.interactionDescription(interaction1)
+    reporter.finaliseReport()
+
+    def results = new File(reportDir, 'provider1.md').text
+
+    then:
     results.contains('## Verifying a pact between _Consumer_ and _provider1_\n\nInteraction 1 ')
-    results.contains('## Verifying a pact between _Consumer_ and _provider1_\n\nInteraction 2 ')
   }
 
 }


### PR DESCRIPTION
When provider tests are  run using the PactBroker, and multiple tags are
specified, it can be to figure out which verification was for which tag. This
is slightly annoying especially when verifications fail. This commit prints out
the tag if supplied.

Note: This is my first time doing anything in kotlin/groovy proper, so definitely do point out any bad practices.