### PR TITLE
Extended Kotlin DSL

### DIFF
--- a/consumer/pact-jvm-consumer-java8/README.md
+++ b/consumer/pact-jvm-consumer-java8/README.md
@@ -189,15 +189,22 @@ newJsonArray((rootArray) -> {
     rootArray.array((a) -> a.numberValue(1).numberValue(2));
     rootArray.array((a) -> a.object((o) -> o.stringValue("foo", "Foo")));
 }).build();
-
 ```
 
-`object` is a reserved word in Kotlin. To allow using the DSL without escaping, a Kotlin extension `newObject` is available:
+##### Kotlin Lambda DSL
 
 ```kotlin
-newJsonArray { rootArray ->
-    rootArray.array { a -> a.stringValue("a1").stringValue("a2") }
-    rootArray.array { a -> a.numberValue(1).numberValue(2) }
-    rootArray.array { a -> a.newObject { o -> o.stringValue("foo", "Foo") } }
-}.build();
+newJsonArray {
+    newArray {
+      stringValue("a1")
+      stringValue("a2")
+    }
+    newArray {
+      numberValue(1)
+      numberValue(2)
+    }
+    newArray {
+      newObject { stringValue("foo", "Foo") }
+    }
+ }
 ```

--- a/consumer/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
+++ b/consumer/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
@@ -1,5 +1,38 @@
 package io.pactfoundation.consumer.dsl
 
-fun LambdaDslJsonArray.newObject(o: (LambdaDslObject) -> (Unit)): LambdaDslJsonArray {
-  return this.`object`(o)
+import au.com.dius.pact.consumer.dsl.DslPart
+
+/**
+ * DSL function to simplify creating a [DslPart] generated from a [LambdaDslJsonBody].
+ */
+fun newJsonObject(body: LambdaDslJsonBody.() -> Unit): DslPart {
+    return LambdaDsl.newJsonBody { it.body() }.build()
+}
+
+/**
+ * DSL function to simplify creating a [DslPart] generated from a [LambdaDslJsonArray].
+ */
+fun newJsonArray(body: LambdaDslJsonArray.() -> Unit): DslPart {
+    return LambdaDsl.newJsonArray { it.body() }.build()
+}
+
+/**
+ * Extension function to make [LambdaDslObject.object] Kotlin friendly.
+ */
+fun LambdaDslObject.newObject(name: String, nestedObject: LambdaDslObject.() -> Unit): LambdaDslObject {
+    return `object`(name) { it.nestedObject() }
+}
+
+/**
+ * Extension function to make [LambdaDslJsonArray.array] Kotlin friendly.
+ */
+fun LambdaDslJsonArray.newArray(body: LambdaDslJsonArray.() -> (Unit)): LambdaDslJsonArray {
+    return array { it.body() }
+}
+
+/**
+ * Extension function to make [LambdaDslJsonArray.array] Kotlin friendly.
+ */
+fun LambdaDslJsonArray.newObject(body: LambdaDslObject.() -> (Unit)): LambdaDslJsonArray {
+    return `object` { it.body() }
 }

--- a/consumer/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
+++ b/consumer/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
@@ -5,6 +5,15 @@ import org.junit.jupiter.api.Test
 class ExtensionsTest {
   @Test
   fun `can use LambdaDslJsonArray#newObject`() {
-    LambdaDsl.newJsonArray { array -> array.newObject { o -> o.stringType("foo") } }
+    newJsonArray { newObject { stringType("foo") } }
+  }
+
+  @Test
+  fun `can use LambdaDslObject#newObject`() {
+    newJsonObject {
+      newObject("object") {
+        stringType("field")
+      }
+    }
   }
 }


### PR DESCRIPTION
The purpose of this pull request is to improve the Kotlin experience when using the consumer DSL. Differently from the previous `LambdaDslJsonArray.newObject`, the new methods avoid the repetition of `it` inside the lambda by using, as a parameter, a lambda with receiver.

Questions:
- What is the best way to test these extensions?
- What kind of documentation is it needed (JavaDoc, README examples, ...)

Thank you in advance for investing your time in looking into it.