### PR TITLE
Update default pact version in PactSpecVersion annotation to match docs.

### DIFF
--- a/consumer/pact-jvm-consumer-junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
+++ b/consumer/pact-jvm-consumer-junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
@@ -76,7 +76,7 @@ annotation class PactTestFor(
   val port: String = "",
 
   /**
-   * Pact specification version to support. Default is V3.
+   * Pact specification version to support. Will default to V3.
    */
   val pactVersion: PactSpecVersion = PactSpecVersion.UNSPECIFIED,
 


### PR DESCRIPTION
~~Update pact version in `PactTestFor` to match documentation. Is this desired or would it be better to update the documentation instead?~~

I initially changed the default value in the annotation from UNSPECIFIED to V3 because I was debugging an issue in my test and was confused by the comment. After I committed and saw the test failure I realized that the UNSPECIFIED value is probably set to ensure that a method-level annotation does not override the class-level annotation's value. Thus, I slightly changed the comment. 