### PR TITLE
:sparkles: Support Bearer Authentication for verifying pacts with the maven plugin

### DIFF
--- a/provider/pact-jvm-provider-maven/README.md
+++ b/provider/pact-jvm-provider-maven/README.md
@@ -366,16 +366,16 @@ For example:
 
 ### Verifying pacts from an authenticated pact broker
 
-If your pact broker requires authentication (basic authentication is only supported), you can configure the username
+If your pact broker requires authentication (basic and bearer authentication are supported), you can configure the username
 and password to use by configuring the `authentication` element of the `pactBroker` element of your provider.
 
-For example:
+For example, here is how you configure the plugin to use basic authentication for verifying pacts:
 
 ```xml
 <plugin>
     <groupId>au.com.dius</groupId>
     <artifactId>pact-jvm-provider-maven</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <configuration>
       <serviceProviders>
         <serviceProvider>
@@ -384,8 +384,34 @@ For example:
           <pactBroker>
               <url>http://pactbroker:1234</url>
               <authentication>
+                  <scheme>basic</scheme>
                   <username>test</username>
                   <password>test</password>
+              </authentication>
+          </pactBroker>
+        </serviceProvider>
+      </serviceProviders>
+    </configuration>
+</plugin>
+```
+
+Here is how you configure the plugin to use basic authentication for verifying pacts
+
+```xml
+<plugin>
+    <groupId>au.com.dius</groupId>
+    <artifactId>pact-jvm-provider-maven</artifactId>
+    <version>4.0.1</version>
+    <configuration>
+      <serviceProviders>
+        <serviceProvider>
+          <name>provider1</name>
+          <stateChangeUrl>http://localhost:8080/tasks/pactStateChange</stateChangeUrl>
+          <pactBroker>
+              <url>http://pactbroker:1234</url>
+              <authentication>
+                  <scheme>bearer</scheme>
+                  <username>TOKEN</username>
               </authentication>
           </pactBroker>
         </serviceProvider>

--- a/provider/pact-jvm-provider-maven/README.md
+++ b/provider/pact-jvm-provider-maven/README.md
@@ -395,7 +395,7 @@ For example, here is how you configure the plugin to use basic authentication fo
 </plugin>
 ```
 
-Here is how you configure the plugin to use basic authentication for verifying pacts
+Here is how you configure the plugin to use bearer token authentication for verifying pacts
 
 ```xml
 <plugin>

--- a/provider/pact-jvm-provider-maven/README.md
+++ b/provider/pact-jvm-provider-maven/README.md
@@ -411,7 +411,7 @@ Here is how you configure the plugin to use bearer token authentication for veri
               <url>http://pactbroker:1234</url>
               <authentication>
                   <scheme>bearer</scheme>
-                  <username>TOKEN</username>
+                  <token>TOKEN</token>
               </authentication>
           </pactBroker>
         </serviceProvider>

--- a/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBroker.groovy
+++ b/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBroker.groovy
@@ -9,6 +9,6 @@ import groovy.transform.Canonical
 class PactBroker {
   URL url
   List<String> tags = []
-  BasicAuth authentication
+  PactBrokerAuth authentication
   String serverId
 }

--- a/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBrokerAuth.groovy
+++ b/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBrokerAuth.groovy
@@ -8,6 +8,7 @@ import groovy.transform.Canonical
 @Canonical
 class PactBrokerAuth {
   String scheme = 'basic'
+  String token
   String username
   String password
 }

--- a/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBrokerAuth.groovy
+++ b/provider/pact-jvm-provider-maven/src/main/groovy/au/com/dius/pact/provider/maven/PactBrokerAuth.groovy
@@ -3,10 +3,11 @@ package au.com.dius.pact.provider.maven
 import groovy.transform.Canonical
 
 /**
- * Basic authentication for the pact broker
+ * Authentication for the pact broker, defaulting to Basic Authentication
  */
 @Canonical
-class BasicAuth {
+class PactBrokerAuth {
+  String scheme = 'basic'
   String username
   String password
 }

--- a/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -136,11 +136,11 @@ open class PactProviderMojo : AbstractMojo() {
     val options = mutableMapOf<String, Any>()
 
     if (pactBroker?.authentication != null) {
-      if (provider.pactBroker.authentication.password != null) {
+      if ("bearer" == provider.pactBroker.authentication.scheme || provider.pactBroker.authentication.token != null) {
+        options["authentication"] = listOf("bearer", provider.pactBroker.authentication.token)
+      } else if ("basic" == provider.pactBroker.authentication.scheme) {
         options["authentication"] = listOf(provider.pactBroker.authentication.scheme, provider.pactBroker.authentication.username,
                 provider.pactBroker.authentication.password)
-      } else {
-        options["authentication"] = listOf(provider.pactBroker.authentication.scheme, provider.pactBroker.authentication.username)
       }
     } else if (!pactBroker?.serverId.isNullOrEmpty()) {
       val serverDetails = settings.getServer(provider.pactBroker!!.serverId)

--- a/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -136,8 +136,12 @@ open class PactProviderMojo : AbstractMojo() {
     val options = mutableMapOf<String, Any>()
 
     if (pactBroker?.authentication != null) {
-      options["authentication"] = listOf("basic", provider.pactBroker.authentication.username,
-        provider.pactBroker.authentication.password)
+      if (provider.pactBroker.authentication.password != null) {
+        options["authentication"] = listOf(provider.pactBroker.authentication.scheme, provider.pactBroker.authentication.username,
+                provider.pactBroker.authentication.password)
+      } else {
+        options["authentication"] = listOf(provider.pactBroker.authentication.scheme, provider.pactBroker.authentication.username)
+      }
     } else if (!pactBroker?.serverId.isNullOrEmpty()) {
       val serverDetails = settings.getServer(provider.pactBroker!!.serverId)
       val request = DefaultSettingsDecryptionRequest(serverDetails)

--- a/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -69,7 +69,7 @@ class PactProviderMojoSpec extends Specification {
     list
   }
 
-  def 'load pacts from pact broker uses the configured pactBroker authentication'() {
+  def 'load pacts from pact broker uses the configured pactBroker basic authentication'() {
     given:
     def provider = Mock(Provider) {
       getPactBrokerUrl() >> null
@@ -84,6 +84,25 @@ class PactProviderMojoSpec extends Specification {
     then:
     1 * provider.hasPactsFromPactBroker([authentication: ['basic', 'test', 'test']], 'http://broker:1234') >> [
       new Consumer()
+    ]
+    list
+  }
+
+  def 'load pacts from pact broker uses the configured pactBroker bearer authentication'() {
+    given:
+    def provider = Mock(Provider) {
+      getPactBrokerUrl() >> null
+      getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null,
+              new PactBrokerAuth('bearer', 'test', null))
+    }
+    def list = []
+
+    when:
+    mojo.loadPactsFromPactBroker(provider, list)
+
+    then:
+    1 * provider.hasPactsFromPactBroker([authentication: ['bearer', 'test']], 'http://broker:1234') >> [
+            new Consumer()
     ]
     list
   }

--- a/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -107,6 +107,25 @@ class PactProviderMojoSpec extends Specification {
     list
   }
 
+  def 'load pacts from pact broker uses bearer authentication if token attribute is set without scheme being set'() {
+    given:
+    def provider = Mock(Provider) {
+      getPactBrokerUrl() >> null
+      getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null,
+              new PactBrokerAuth(null, 'test', null, null))
+    }
+    def list = []
+
+    when:
+    mojo.loadPactsFromPactBroker(provider, list)
+
+    then:
+    1 * provider.hasPactsFromPactBroker([authentication: ['bearer', 'test']], 'http://broker:1234') >> [
+            new Consumer()
+    ]
+    list
+  }
+
   def 'load pacts from pact broker for each configured pactBroker tag'() {
     given:
     def provider = Mock(Provider) {

--- a/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -73,7 +73,8 @@ class PactProviderMojoSpec extends Specification {
     given:
     def provider = Mock(Provider) {
       getPactBrokerUrl() >> null
-      getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null, new BasicAuth('test', 'test'))
+      getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null,
+              new PactBrokerAuth('basic', 'test', 'test'))
     }
     def list = []
 

--- a/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/pact-jvm-provider-maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -74,7 +74,7 @@ class PactProviderMojoSpec extends Specification {
     def provider = Mock(Provider) {
       getPactBrokerUrl() >> null
       getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null,
-              new PactBrokerAuth('basic', 'test', 'test'))
+              new PactBrokerAuth('basic', null, 'test', 'test'))
     }
     def list = []
 
@@ -93,7 +93,7 @@ class PactProviderMojoSpec extends Specification {
     def provider = Mock(Provider) {
       getPactBrokerUrl() >> null
       getPactBroker() >> new PactBroker(new URL('http://broker:1234'), null,
-              new PactBrokerAuth('bearer', 'test', null))
+              new PactBrokerAuth('bearer', 'test', null, null))
     }
     def list = []
 


### PR DESCRIPTION
- Modified the `BasicAuth` class to encapsulate the authentication mechanism for verifying pacts from pact brokers. This includes an extra field on the class called `scheme`, which has a default value of `basic` so as not to interfere with existing users of basic auth
- Modified the setting of the `authentication` option to only include `PactBrokerAuth#password` if password is not `null` and to set the scheme from config rather than a hardcoded value.
- Update docs to demonstrate how to use basic and bearer authentication for verifying pacts
- Added unit test for verifying authentication header gets set correctly if using bearer authentication


closes #954 