### PR TITLE
#976: always prepend prefix to existing key

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/Category.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/Category.kt
@@ -123,7 +123,6 @@ data class Category @JvmOverloads constructor(
   fun applyMatcherRootPrefix(prefix: String) {
     matchingRules = matchingRules.mapKeys { e ->
       when {
-        e.key.startsWith(prefix) -> e.key
         e.key.startsWith("$") -> prefix + e.key.substring(1)
         else -> prefix + e.key
       }

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/matchingrules/CategorySpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/matchingrules/CategorySpec.groovy
@@ -73,4 +73,20 @@ class CategorySpec extends Specification {
       'payload.bestandsid': [matchers: [[match: 'type']], combine: 'AND']
     ]
   }
+  @Issue(['#976'])
+  def 'when re-keying the matchers, always prepend prefix to existing key'() {
+    given:
+    def matchingRule = new MatchingRuleGroup([TypeMatcher.INSTANCE])
+    def category = new Category('body', [
+            '.blueberry': matchingRule
+    ])
+    category.applyMatcherRootPrefix('blue')
+
+    expect:
+    category.toMap(PactSpecVersion.V2) == [
+            '$.body.blue.blueberry': [match: 'type']]
+
+    category.toMap(PactSpecVersion.V3) == [
+            'blue.blueberry': [matchers: [[match: 'type']], combine: 'AND']]
+  }
 }


### PR DESCRIPTION
When adding a PactDslJsonBody to a parent through the use of PactDslJsonBody.object
we can experience an issue where if the parent body is called

blue (for example)
and the new part being added is called blueberry then the key is not updated to be blue.blueberry
and we see:
```
    "$.fruitByColour.blueberry": {
         "matchers": [
              {
                  "match": "type",
                }
              ],
              "combine": "AND"
            },
"fruitByColour": {
            "blue": {
              "blueberry": {
               <-- some random blueberry properties here -->
              },
```
this happens because of:
```
PactDslJsonBody().object(String name, DslPart value)
|
|_new PactDslJsonBody(base, "", this, (PactDslJsonBody) value) 
   |
   |_ Category.copyWithUpdatedMatcherRootPrefix
      |
      |_  e.key.startsWith(prefix) -> e.key
```
https://github.com/DiUS/pact-jvm/issues/976