### PR TITLE
[pact-jvm-consumer-java8] Allow access to original PactDsl object and array

### DIFF
--- a/consumer/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
+++ b/consumer/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslJsonArray.java
@@ -20,6 +20,10 @@ public class LambdaDslJsonArray {
         this.pactArray = pactArray;
     }
 
+    public PactDslJsonArray getPactDslJsonArray() {
+        return pactArray;
+    }
+
     public LambdaDslJsonArray object(final Consumer<LambdaDslObject> o) {
         final PactDslJsonBody pactObject = pactArray.object();
         LambdaDslObject object = new LambdaDslObject(pactObject);

--- a/consumer/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/consumer/pact-jvm-consumer-java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -21,6 +21,10 @@ public class LambdaDslObject {
         this.object = object;
     }
 
+    public PactDslJsonBody getPactDslObject() {
+        return object;
+    }
+
     public LambdaDslObject stringValue(final String name, final String value) {
         object.stringValue(name, value);
         return this;


### PR DESCRIPTION
Allow access to original PactDsl object so we can access methods not wrapped by the labmdadsl like:

`getDslObject().valueFromProviderState(...)`

This provides more flexibility to dsl users and will allow acces to new funcionality when original dsl evolves.

Thanks a lot.