### PR TITLE
[pact-jvm-provider-maven] Adds skipPactPublish property

### DIFF
--- a/provider/pact-jvm-provider-maven/README.md
+++ b/provider/pact-jvm-provider-maven/README.md
@@ -612,6 +612,7 @@ For example:
       <pactBrokerUrl>http://pactbroker:1234</pactBrokerUrl>
       <projectVersion>1.0.100</projectVersion> <!-- Defaults to ${project.version} -->
       <trimSnapshot>true</trimSnapshot> <!-- Defaults to false -->
+      <skipPactPublish>false</skipPactPublish> <!-- Defaults to false -->
     </configuration>
 </plugin>
 ```

--- a/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
+++ b/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
@@ -13,6 +13,9 @@ import java.io.File
 @Mojo(name = "publish")
 open class PactPublishMojo : PactBaseMojo() {
 
+    @Parameter(defaultValue = "false", expression="${skipPactPublish}")
+    private var skipPactPublish: Boolean = false
+
     @Parameter(required = true, defaultValue = "\${project.version}")
     private lateinit var projectVersion: String
 
@@ -32,6 +35,11 @@ open class PactPublishMojo : PactBaseMojo() {
 
     override fun execute() {
       AnsiConsole.systemInstall()
+
+      if (skipPactPublish) {
+        println("'skipPactPublish' is set to true, skipping uploading of pacts")
+        return
+      }
 
       if (pactBrokerUrl.isNullOrEmpty() && brokerClient == null) {
         throw MojoExecutionException("pactBrokerUrl is required")

--- a/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
+++ b/provider/pact-jvm-provider-maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
@@ -13,7 +13,7 @@ import java.io.File
 @Mojo(name = "publish")
 open class PactPublishMojo : PactBaseMojo() {
 
-    @Parameter(defaultValue = "false", expression="${skipPactPublish}")
+    @Parameter(defaultValue = "false", expression = "\${skipPactPublish}")
     private var skipPactPublish: Boolean = false
 
     @Parameter(required = true, defaultValue = "\${project.version}")


### PR DESCRIPTION
Allowing skiping of pact publishing with a plugin property without the need of maven profiles.

Thanks a lot.