### PR TITLE
feat: Include tag in jUnit test name

### DIFF
--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
@@ -1,15 +1,12 @@
 package au.com.dius.pact.provider.junit
 
-import au.com.dius.pact.core.model.FilteredPact
-import au.com.dius.pact.core.model.Interaction
-import au.com.dius.pact.core.model.Pact
-import au.com.dius.pact.core.model.PactSource
-import au.com.dius.pact.core.model.ProviderState
+import au.com.dius.pact.core.model.*
 import au.com.dius.pact.core.pactbroker.TestResult
 import au.com.dius.pact.provider.DefaultTestResultAccumulator
 import au.com.dius.pact.provider.IProviderVerifier
 import au.com.dius.pact.provider.ProviderUtils
 import au.com.dius.pact.provider.TestResultAccumulator
+import au.com.dius.pact.provider.junit.descriptions.DescriptionGenerator
 import au.com.dius.pact.provider.junit.target.Target
 import au.com.dius.pact.provider.junit.target.TestClassAwareTarget
 import au.com.dius.pact.provider.junit.target.TestTarget
@@ -54,6 +51,8 @@ open class InteractionRunner<I>(
   private val results = ConcurrentHashMap<String, Pair<Boolean, IProviderVerifier>>()
   private val testContext = ConcurrentHashMap<String, Any>()
   private val childDescriptions = ConcurrentHashMap<String, Description>()
+  private val descriptionGenerator = DescriptionGenerator(testClass, pact, pactSource)
+
   var testResultAccumulator: TestResultAccumulator = DefaultTestResultAccumulator
 
   init {
@@ -70,8 +69,7 @@ open class InteractionRunner<I>(
 
   protected fun describeChild(interaction: Interaction): Description {
     if (!childDescriptions.containsKey(interaction.uniqueKey())) {
-      childDescriptions[interaction.uniqueKey()] = Description.createTestDescription(testClass.javaClass,
-        "${pact.consumer.name} - ${interaction.description}")
+      childDescriptions[interaction.uniqueKey()] = descriptionGenerator.generate(interaction)
     }
     return childDescriptions[interaction.uniqueKey()]!!
   }

--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
@@ -20,16 +20,16 @@ class DescriptionGenerator<I : Interaction>(
     /**
      * Builds an instance of junit Description adhering with this logic for building the name:
      * If the PactSource is of type <code>BrokerUrlSource</code> and its tag is not empty then
-     * the test name will be "[tag:#tagname] #consumername - Upon #interaction".
+     * the test name will be "#consumername [tag:#tagname] - Upon #interaction".
      * For all the other cases "#consumername - Upon #interaction"
      * @param interaction the Interaction under test
      */
     fun generate(interaction: Interaction): Description {
         return Description.createTestDescription(testClass.javaClass,
-                "${this.getNamePrefix()}${pact.consumer.name} - Upon ${interaction.description}")
+                "${pact.consumer.name} ${this.getTagDescription()}- Upon ${interaction.description}")
     }
 
-    private fun getNamePrefix(): String {
+    private fun getTagDescription(): String {
         if (pactSource is BrokerUrlSource && pactSource.tag.isNotEmpty()) {
             return "[tag:${pactSource.tag}] "
         }

--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
@@ -11,9 +11,11 @@ import org.junit.runners.model.TestClass
 /**
  * Class responsible for building junit tests Description.
  */
-class DescriptionGenerator<I : Interaction>(private val testClass: TestClass,
-                                            private val pact: Pact<I>,
-                                            private val pactSource: PactSource) {
+class DescriptionGenerator<I : Interaction>(
+  private val testClass: TestClass,
+  private val pact: Pact<I>,
+  private val pactSource: PactSource
+) {
 
     /**
      * Builds an instance of junit Description adhering with this logic for building the name:

--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/descriptions/DescriptionGenerator.kt
@@ -1,0 +1,36 @@
+package au.com.dius.pact.provider.junit.descriptions
+
+import au.com.dius.pact.core.model.BrokerUrlSource
+import au.com.dius.pact.core.model.Interaction
+import au.com.dius.pact.core.model.Pact
+import au.com.dius.pact.core.model.PactSource
+import au.com.dius.pact.core.support.isNotEmpty
+import org.junit.runner.Description
+import org.junit.runners.model.TestClass
+
+/**
+ * Class responsible for building junit tests Description.
+ */
+class DescriptionGenerator<I : Interaction>(private val testClass: TestClass,
+                                            private val pact: Pact<I>,
+                                            private val pactSource: PactSource) {
+
+    /**
+     * Builds an instance of junit Description adhering with this logic for building the name:
+     * If the PactSource is of type <code>BrokerUrlSource</code> and its tag is not empty then
+     * the test name will be "[tag:#tagname] #consumername - Upon #interaction".
+     * For all the other cases "#consumername - Upon #interaction"
+     * @param interaction the Interaction under test
+     */
+    fun generate(interaction: Interaction): Description {
+        return Description.createTestDescription(testClass.javaClass,
+                "${this.getNamePrefix()}${pact.consumer.name} - Upon ${interaction.description}")
+    }
+
+    private fun getNamePrefix(): String {
+        if (pactSource is BrokerUrlSource && pactSource.tag.isNotEmpty()) {
+            return "[tag:${pactSource.tag}] "
+        }
+        return ""
+    }
+}

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
@@ -34,7 +34,7 @@ class DescriptionGeneratorTest extends Specification {
   def 'when BrokerUrlSource tests description includes tag if present'() {
     def interaction = new RequestResponseInteraction('Interaction 1',
             [ new ProviderState('Test State') ], new Request(), new Response())
-    def pact = new RequestResponsePact(new Provider(), new Consumer(), [ interaction ])
+    def pact = new RequestResponsePact(new Provider(), new Consumer("the-consumer-name"), [ interaction ])
 
     expect:
     def pactSource =  new BrokerUrlSource('url', 'url', [:], [:], tag)
@@ -43,9 +43,9 @@ class DescriptionGeneratorTest extends Specification {
 
     where:
     tag      | description
-    'master' | '[tag:master] consumer - Upon Interaction 1'
-    null     | 'consumer - Upon Interaction 1'
-    ''       | 'consumer - Upon Interaction 1'
+    'master' | 'the-consumer-name [tag:master] - Upon Interaction 1'
+    null     | 'the-consumer-name - Upon Interaction 1'
+    ''       | 'the-consumer-name - Upon Interaction 1'
   }
 
   def 'when non broker pact source tests name are built correctly'() {

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
@@ -1,0 +1,48 @@
+package au.com.dius.pact.provider.junit.descriptions
+
+import au.com.dius.pact.core.model.*
+import org.junit.runners.model.TestClass
+import spock.lang.Specification
+
+class DescriptionGeneratorTest extends Specification {
+
+  class DescriptionGeneratorTestClass {
+  }
+
+  private clazz
+  private interaction
+  private pact
+
+  def setup() {
+    clazz = new TestClass(DescriptionGeneratorTestClass)
+  }
+
+  def 'when BrokerUrlSource tests description includes tag if present'() {
+    def interaction = new RequestResponseInteraction('Interaction 1',
+            [ new ProviderState('Test State') ], new Request(), new Response())
+    def pact = new RequestResponsePact(new Provider(), new Consumer(), [ interaction ])
+
+    expect:
+    def pactSource =  new BrokerUrlSource('url', 'url', [:], [:], tag)
+    def generator = new DescriptionGenerator(clazz, pact, pactSource)
+    description == generator.generate(interaction).getMethodName()
+
+    where:
+    tag      | description
+    "master" | "[tag:master] consumer - Upon Interaction 1"
+    null     | "consumer - Upon Interaction 1"
+    ""       | "consumer - Upon Interaction 1"
+  }
+
+  def 'when non broker pact source tests name are built correctly'() {
+    def interaction = new RequestResponseInteraction('Interaction 1',
+            [ new ProviderState('Test State') ], new Request(), new Response())
+    def pact = new RequestResponsePact(new Provider(), new Consumer(), [ interaction ])
+    def file = Mock(File)
+
+    expect:
+    def pactSource = new DirectorySource(file, [file: pact])
+    def generator = new DescriptionGenerator(clazz, pact, pactSource)
+    "consumer - Upon Interaction 1" == generator.generate(interaction).getMethodName()
+  }
+}

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
@@ -1,12 +1,26 @@
 package au.com.dius.pact.provider.junit.descriptions
 
-import au.com.dius.pact.core.model.*
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.BrokerUrlSource
+import au.com.dius.pact.core.model.DirectorySource
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.core.model.Response
+import au.com.dius.pact.core.model.Provider
+import au.com.dius.pact.core.model.Consumer
+import au.com.dius.pact.core.model.ProviderState
+import au.com.dius.pact.provider.junit.target.HttpTarget
+import au.com.dius.pact.provider.junit.target.Target
+import au.com.dius.pact.provider.junit.target.TestTarget
 import org.junit.runners.model.TestClass
 import spock.lang.Specification
 
 class DescriptionGeneratorTest extends Specification {
 
+  @SuppressWarnings('PublicInstanceField')
   class DescriptionGeneratorTestClass {
+    @TestTarget
+    public final Target target = new HttpTarget(8332)
   }
 
   private clazz
@@ -25,13 +39,13 @@ class DescriptionGeneratorTest extends Specification {
     expect:
     def pactSource =  new BrokerUrlSource('url', 'url', [:], [:], tag)
     def generator = new DescriptionGenerator(clazz, pact, pactSource)
-    description == generator.generate(interaction).getMethodName()
+    description == generator.generate(interaction).methodName
 
     where:
     tag      | description
-    "master" | "[tag:master] consumer - Upon Interaction 1"
-    null     | "consumer - Upon Interaction 1"
-    ""       | "consumer - Upon Interaction 1"
+    'master' | '[tag:master] consumer - Upon Interaction 1'
+    null     | 'consumer - Upon Interaction 1'
+    ''       | 'consumer - Upon Interaction 1'
   }
 
   def 'when non broker pact source tests name are built correctly'() {
@@ -43,6 +57,6 @@ class DescriptionGeneratorTest extends Specification {
     expect:
     def pactSource = new DirectorySource(file, [file: pact])
     def generator = new DescriptionGenerator(clazz, pact, pactSource)
-    "consumer - Upon Interaction 1" == generator.generate(interaction).getMethodName()
+    'consumer - Upon Interaction 1' == generator.generate(interaction).methodName
   }
 }


### PR DESCRIPTION
In a scenario where pact provider verification tests possibly run against multiple tags, it would be a nice to have, in case of failures, to easily identify which tag (if present) has caused the failure.

Example of jUnit output:
```
Test suite name: 
      [tag:#tag-name] #consumer-name: Upon #interaction-name
```
