### PR TITLE
fix: lint issue in test

### DIFF
--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/descriptions/DescriptionGeneratorTest.groovy
@@ -34,7 +34,7 @@ class DescriptionGeneratorTest extends Specification {
   def 'when BrokerUrlSource tests description includes tag if present'() {
     def interaction = new RequestResponseInteraction('Interaction 1',
             [ new ProviderState('Test State') ], new Request(), new Response())
-    def pact = new RequestResponsePact(new Provider(), new Consumer("the-consumer-name"), [ interaction ])
+    def pact = new RequestResponsePact(new Provider(), new Consumer('the-consumer-name'), [ interaction ])
 
     expect:
     def pactSource =  new BrokerUrlSource('url', 'url', [:], [:], tag)


### PR DESCRIPTION
A double quote (instead of single) was causing codenarc task to fail