### PR TITLE
Wrong number of args passed to ex-info

### DIFF
--- a/provider/pact-jvm-provider-lein/src/main/clojure/au/com/dius/pact/provider/lein/verify_provider.clj
+++ b/provider/pact-jvm-provider-lein/src/main/clojure/au/com/dius/pact/provider/lein/verify_provider.clj
@@ -72,7 +72,7 @@
     (if (not-empty failures)
       (do
         (.displayFailures verifier (into {} failures))
-        (throw (ex-info (str "There were " (count failures) " pact failures")))))))
+        (throw (ex-info (str "There were " (count failures) " pact failures")) {})))))
 
 (defn verify [verifier pact-info]
   (verify-providers verifier (:service-providers pact-info)))

--- a/provider/pact-jvm-provider-lein/src/main/clojure/leiningen/pact_verify.clj
+++ b/provider/pact-jvm-provider-lein/src/main/clojure/leiningen/pact_verify.clj
@@ -20,4 +20,4 @@
       (if (contains? project :pact)
         (let [verifier (LeinVerifierProxy. project (parse-args args))]
           (verify/verify verifier (-> project :pact)))
-        (throw (ex-info "No pact definition was found in the project"))))
+        (throw (ex-info "No pact definition was found in the project" {}))))


### PR DESCRIPTION
clojure.lang.ArityException  Wrong number of args (1) passed to: clojure.core/ex-info