### PR TITLE
The request body should be encoded according to the request header

### DIFF
--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderClient.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderClient.kt
@@ -39,6 +39,7 @@ import java.lang.Boolean.getBoolean
 import java.net.URI
 import java.net.URL
 import java.net.URLDecoder
+import java.nio.charset.UnsupportedCharsetException
 import java.util.concurrent.Callable
 import java.util.function.Consumer
 import java.util.function.Function
@@ -270,7 +271,17 @@ open class ProviderClient(
 
   open fun setupBody(request: Request, method: HttpRequest) {
     if (method is HttpEntityEnclosingRequest && request.body.isPresent()) {
-      method.entity = StringEntity(request.body.valueAsString())
+      val contentTypeHeader = request.contentTypeHeader()
+      if (null != contentTypeHeader) {
+        try {
+          val contentType = ContentType.parse(contentTypeHeader)
+          method.entity = StringEntity(request.body.valueAsString(), contentType)
+        } catch (e: UnsupportedCharsetException) {
+          method.entity = StringEntity(request.body.valueAsString())
+        }
+      } else {
+        method.entity = StringEntity(request.body.valueAsString())
+      }
     }
   }
 


### PR DESCRIPTION
Currently the setupBody() method in the ProviderClient class does not set a contentType. This results in the StringEntity() constructor to use the HTTP.DEF_CONTENT_CHARSET, which in turn resolves to Consts.ISO_8859_1.

This is a problem when you have a UTF-8 encoded pact.json file with special characters. The request that is being sent by the mock consumer, will read the UTF-8 encoded body (from the pact file) as ISO-8859-1, thus messing up any special characters it contains.

I've also got a very basic Spring Boot project set up to show the problem at https://github.com/BenVercammen/pact-jvm-provider-encoding-issue.git
(make sure the pact files are properly encoded, probably will check out in default encoding)

Disclaimer: I'm not familiar with kotlin or groovy...