### PR TITLE
feat: Allow Provider State Parameters for MessagePactBuilder

### DIFF
--- a/consumer/pact-jvm-consumer-junit/src/test/groovy/au/com/dius/pact/consumer/MessagePactBuilderSpec.groovy
+++ b/consumer/pact-jvm-consumer-junit/src/test/groovy/au/com/dius/pact/consumer/MessagePactBuilderSpec.groovy
@@ -3,6 +3,7 @@ package au.com.dius.pact.consumer
 import au.com.dius.pact.consumer.dsl.Matchers
 import au.com.dius.pact.consumer.dsl.PactDslJsonBody
 import au.com.dius.pact.core.model.messaging.Message
+import au.com.dius.pact.core.model.ProviderState
 import groovy.json.JsonSlurper
 import spock.lang.Issue
 import spock.lang.Specification
@@ -117,4 +118,33 @@ class MessagePactBuilderSpec extends Specification {
     messageMetadata == [contentType: 'application/json', otherValue: 10L]
   }
 
+  def 'provider state can accept key/value pairs'() {
+    given:
+    def description = 'some state description'
+    def params = ['stateKey': 'stateValue']
+    def expectedProviderState = new ProviderState(description, params)
+
+    when:
+    def pact = MessagePactBuilder
+      .consumer('MessagePactBuilderSpec')
+      .given(description, params)
+
+    then:
+    pact.providerStates.last() == expectedProviderState
+  }
+
+  def 'provider state can accept ProviderState object'() {
+    given:
+    def description = 'some state description'
+    def params = ['stateKey': 'stateValue']
+    def expectedProviderState = new ProviderState(description, params)
+
+    when:
+    def pact = MessagePactBuilder
+            .consumer('MessagePactBuilderSpec')
+            .given(expectedProviderState)
+
+    then:
+    pact.providerStates.last() == expectedProviderState
+  }
 }

--- a/consumer/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MessagePactBuilder.kt
+++ b/consumer/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MessagePactBuilder.kt
@@ -50,11 +50,34 @@ class MessagePactBuilder(
   /**
    * Sets the provider state.
    *
-   * @param providerState state of the provider
+   * @param providerState description of the provider state
    * @return this builder.
    */
   fun given(providerState: String): MessagePactBuilder {
     this.providerStates.add(ProviderState(providerState))
+    return this
+  }
+
+  /**
+   * Sets the provider state.
+   *
+   * @param providerState description of the provider state
+   * @param params key/value pairs to describe state
+   * @return this builder.
+   */
+  fun given(providerState: String, params: Map<String, Any>): MessagePactBuilder {
+    this.providerStates.add(ProviderState(providerState, params))
+    return this
+  }
+
+  /**
+   * Sets the provider state.
+   *
+   * @param providerState state of the provider
+   * @return this builder.
+   */
+  fun given(providerState: ProviderState): MessagePactBuilder {
+    this.providerStates.add(providerState)
     return this
   }
 


### PR DESCRIPTION
## Problem to solve

[`MessagePactBuilder`](
https://github.com/DiUS/pact-jvm/blob/3860faa5d3e67b7bbf42d25cc7e689314a905859/consumer/pact-jvm-consumer/src/main/kotlin/au/com/dius/pact/consumer/MessagePactBuilder.kt#L56) does not allow key/value parameters to be specified as part of a provider state.

## Proposed changes

Overload `MessagePactBuilder.given` to also accept a provider state with parameters or a `ProviderState` object.

## NOTICE

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.
