### PR TITLE
fix: Use concise Pact Source descriptions

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactSource.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactSource.kt
@@ -22,7 +22,9 @@ data class DirectorySource<I> @JvmOverloads constructor(
   val dir: File,
   val pacts: MutableMap<File, Pact<I>> = mutableMapOf()
 ) : PactSource()
-  where I : Interaction
+  where I : Interaction {
+  override fun description() = "Directory $dir"
+}
 
 data class PactBrokerSource<I> @JvmOverloads constructor(
   val host: String,
@@ -30,7 +32,14 @@ data class PactBrokerSource<I> @JvmOverloads constructor(
   val scheme: String = "http",
   val pacts: MutableMap<Consumer, MutableList<Pact<I>>> = mutableMapOf()
 ) : PactSource()
-  where I : Interaction
+  where I : Interaction {
+  override fun description() =
+    if (port == null) {
+      "Pact Broker $scheme://$host"
+    } else {
+      "Pact Broker $scheme://$host:$port"
+    }
+}
 
 data class FileSource<I> @JvmOverloads constructor(val file: File, val pact: Pact<I>? = null) :
   PactSource() where I : Interaction {

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/DirectorySourceSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/DirectorySourceSpec.groovy
@@ -1,0 +1,17 @@
+package au.com.dius.pact.core.model
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DirectorySourceSpec extends Specification {
+
+  @Unroll
+  def 'description includes the directory Pacts are contained in'() {
+    when:
+    def path = new File('/target/pacts')
+    def source = new DirectorySource(path)
+
+    then:
+    source.description() == "Directory ${path}"
+  }
+}

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/PactBrokerSourceSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/PactBrokerSourceSpec.groovy
@@ -1,0 +1,18 @@
+package au.com.dius.pact.core.model
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PactBrokerSourceSpec extends Specification {
+
+  @Unroll
+  def 'description includes the URL for the Broker'() {
+    expect:
+    source.description() == description
+
+    where:
+    source                                                  | description
+    new PactBrokerSource('localhost', '80', 'http')         | 'Pact Broker http://localhost:80'
+    new PactBrokerSource('www.example.com', '443', 'https') | 'Pact Broker https://www.example.com:443'
+  }
+}

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -1,6 +1,7 @@
 package au.com.dius.pact.provider.junit.loader
 
 import au.com.dius.pact.core.model.Pact
+import au.com.dius.pact.core.model.PactBrokerSource
 import au.com.dius.pact.core.model.UrlSource
 import au.com.dius.pact.core.pactbroker.IHalClient
 import au.com.dius.pact.core.pactbroker.InvalidHalResponse
@@ -136,6 +137,26 @@ class PactBrokerLoaderSpec extends Specification {
     then:
     result == []
     1 * brokerClient.fetchConsumers('test') >> []
+  }
+
+  @RestoreSystemProperties
+  void 'Uses fallback PactBroker System Properties for PactSource'() {
+    given:
+    host = 'my.pactbroker.host'
+    port = '4711'
+    System.setProperty('pactbroker.host', host)
+    System.setProperty('pactbroker.port', port)
+
+    when:
+    def pactSource = new PactBrokerLoader(MinimalPactBrokerAnnotation.getAnnotation(PactBroker)).pactSource
+
+    then:
+    assert pactSource instanceof PactBrokerSource
+
+    def pactBrokerSource = (PactBrokerSource) pactSource
+    assert pactBrokerSource.scheme == 'http'
+    assert pactBrokerSource.host == host
+    assert pactBrokerSource.port == port
   }
 
   @RestoreSystemProperties


### PR DESCRIPTION
## Problem to solve

Pact provider tests print out overly verbose Pact source descriptions (i.e. use default Kotlin toString) when using a Directory or Pact Broker source.

### Steps to reproduce

Seen when running provider tests using Pacts from a directory or Pact-Broker with pact-jvm-provider-junit5 plugin.

### Current behavior
```
Verifying a pact between JsonConsumer and JsonProvider
  [Using DirectorySource(dir=target\pacts, pacts={target\pacts\JsonConsumer-JsonProvider.json=MessagePact(provider=Provider(name=JsonProvider), consumer=Consumer(name=JsonConsumer), messages=[Message(description='json array with extra values', providerStates=[ProviderState(name=some state, params={})], contents=PRESENT({"JsonArray":[{"key":"required"},{"key":"something else"}]}), matchingRules=MatchingRules(rules={body=Category(name=body, matchingRules={$.JsonArray=MatchingRuleGroup(rules=[MinTypeMatcher(min=1)], ruleLogic=AND), $.JsonArray[*].key=MatchingRuleGroup(rules=[au.com.dius.pact.core.model.matchingrules.TypeMatcher@6c0d7c83], ruleLogic=AND)})}), generators=Generators(categories={}), metaData={contentType=application/json; charset=UTF-8}), Message(description='json object with extra values', providerStates=[ProviderState(name=some state, params={})], contents=PRESENT({"JsonObject":{"key":"required"}}), matchingRules=MatchingRules(rules={body=Category(name=body, matchingRules={$.JsonObject.key=MatchingRuleGroup(rules=[au.com.dius.pact.core.model.matchingrules.TypeMatcher@6c0d7c83], ruleLogic=AND)})}), generators=Generators(categories={}), metaData={contentType=application/json; charset=UTF-8})], metadata={pactSpecification={version=3.0.0}, pact-jvm={version=4.0.1}})})]
  Given some state
  json array with extra values
    generates a message which
      has a matching body (OK)
      has matching metadata (OK)
```

### Expected behavior
```
Verifying a pact between JsonConsumer and JsonProvider
  [Using Directory target\pacts]
  Given some state
  json array with extra values
    generates a message which
      has a matching body (OK)
      has matching metadata (OK)
```

### Proposed Fix

Implement description methods for DirectorySource and PactBrokerSource,
instead of having them fallback to default Kotlin toString.

Have PactBrokerLoader resolve system parameters, so PactBrokerSource
shows a valid url instead of ${...} placeholders.
## NOTICE

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.
