### PR TITLE
Extended PactFilter to allow variable filter criterias

### DIFF
--- a/consumer/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
+++ b/consumer/pact-jvm-consumer/src/test/java/au/com/dius/pact/consumer/PactDslJsonBodyTest.java
@@ -265,7 +265,7 @@ public class PactDslJsonBodyTest {
         .date("lastUpdate", DATE_FORMAT)
         .date("creationDate", DATE_FORMAT);
       JSONObject jsonObject = (JSONObject) response.getBody();
-      assertThat(jsonObject.get("lastUpdate").toString(), matchesPattern("\\w{3}\\.?, \\d{2} \\w{3}\\.? \\d{4} \\d{2}:00:00 \\+\\d+ GMT"));
+      assertThat(jsonObject.get("lastUpdate").toString(), matchesPattern("\\w{2,3}\\.?, \\d{2} \\w{3}\\.? \\d{4} \\d{2}:00:00 \\+\\d+ GMT"));
     }
 
     @Test

--- a/provider/pact-jvm-provider-junit/README.md
+++ b/provider/pact-jvm-provider-junit/README.md
@@ -324,23 +324,22 @@ public class PactJUnitTest {
 }
 ```
 
-#### Filtering by Provider State
+#### Interaction Filtering
 
 You can filter the interactions that are executed by adding a `@PactFilter` annotation to your test class. The pact 
-filter annotation will then only verify interactions that have a matching provider state. You can provide multiple 
-states to match with.
+filter annotation will then only verify interactions that have a matching value, by default provider state.
+You can provide multiple values to match with.
+
+The filter criteria is defined by the filter property. The filter must implement the
+`au.com.dius.pact.provider.junit.filter.InteractionFilter` interface. Also check the `InteractionFilter` interface
+for default filter implementations.
 
 For example: 
 
 ```java
 @RunWith(PactRunner.class)
-@Provider("Activity Service")
-@PactBroker(host = "localhost", port = "80")
-@PactFilter('Activity 100 exists in the database')
+@PactFilter("Activity 100 exists in the database")
 public class PactJUnitTest {
-
-  @TestTarget
-  public final Target target = new HttpTarget(5050);
 
 }
 ```
@@ -349,7 +348,7 @@ You can also use regular expressions with the filter. For example:
 
 ```java
 @RunWith(PactRunner.class)
-@PactFilter('Activity \\d+ exists in the database')
+@PactFilter(values = {"^\\/somepath.*"}, filter = InteractionFilter.ByRequestPath.class)
 public class PactJUnitTest {
 
 }

--- a/provider/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/filter/FilterByRequestPathTest.kt
+++ b/provider/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/filter/FilterByRequestPathTest.kt
@@ -1,0 +1,67 @@
+package au.com.dius.pact.provider.junit.filter
+
+import au.com.dius.pact.provider.junit.PactRunner
+import au.com.dius.pact.provider.junit.Provider
+import au.com.dius.pact.provider.junit.State
+import au.com.dius.pact.provider.junit.StateChangeAction
+import au.com.dius.pact.provider.junit.loader.PactFilter
+import au.com.dius.pact.provider.junit.loader.PactFolder
+import au.com.dius.pact.provider.junit.target.HttpTarget
+import au.com.dius.pact.provider.junit.target.TestTarget
+import com.github.restdriver.clientdriver.ClientDriverRule
+import com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse
+import com.github.restdriver.clientdriver.RestClientDriver.onRequestTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.runner.RunWith
+
+@RunWith(PactRunner::class)
+@Provider("providerWithMultipleInteractions")
+@PactFolder("pacts")
+@PactFilter("^\\/data.*", filter = InteractionFilter.ByRequestPath::class)
+class FilterByRequestPathTest {
+  @TestTarget
+  val target = HttpTarget(port = 8332)
+
+  @Before
+  fun before() {
+    embeddedService.addExpectation(
+      onRequestTo("/data").withAnyParams(), giveEmptyResponse()
+    )
+  }
+
+  @State("state1")
+  fun state1() {
+    executedStates.add("state1")
+  }
+
+  @State("state1", action = StateChangeAction.TEARDOWN)
+  fun state1Teardown() {
+    executedStates.add("state1 Teardown")
+  }
+
+  companion object {
+    @ClassRule
+    @JvmField
+    val embeddedService = ClientDriverRule(8332)
+
+    val executedStates = mutableListOf<String>()
+
+    @BeforeClass
+    @JvmStatic
+    fun beforeTest() {
+      executedStates.clear()
+    }
+
+    @AfterClass
+    @JvmStatic
+    fun afterTest() {
+      assertThat(executedStates, `is`(equalTo(listOf("state1", "state1 Teardown"))))
+    }
+  }
+}

--- a/provider/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/filter/FilterStateByDefaultTest.kt
+++ b/provider/pact-jvm-provider-junit/src/test/kotlin/au/com/dius/pact/provider/junit/filter/FilterStateByDefaultTest.kt
@@ -1,0 +1,67 @@
+package au.com.dius.pact.provider.junit.filter
+
+import au.com.dius.pact.provider.junit.PactRunner
+import au.com.dius.pact.provider.junit.Provider
+import au.com.dius.pact.provider.junit.State
+import au.com.dius.pact.provider.junit.StateChangeAction
+import au.com.dius.pact.provider.junit.loader.PactFilter
+import au.com.dius.pact.provider.junit.loader.PactFolder
+import au.com.dius.pact.provider.junit.target.HttpTarget
+import au.com.dius.pact.provider.junit.target.TestTarget
+import com.github.restdriver.clientdriver.ClientDriverRule
+import com.github.restdriver.clientdriver.RestClientDriver.giveEmptyResponse
+import com.github.restdriver.clientdriver.RestClientDriver.onRequestTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.runner.RunWith
+
+@RunWith(PactRunner::class)
+@Provider("providerWithMultipleInteractions")
+@PactFolder("pacts")
+@PactFilter("state1")
+class FilterStateByDefaultTest {
+  @TestTarget
+  val target = HttpTarget(port = 8332)
+
+  @Before
+  fun before() {
+    embeddedService.addExpectation(
+      onRequestTo("/data").withAnyParams(), giveEmptyResponse()
+    )
+  }
+
+  @State("state1")
+  fun state1() {
+    executedStates.add("state1")
+  }
+
+  @State("state1", action = StateChangeAction.TEARDOWN)
+  fun state1Teardown() {
+    executedStates.add("state1 Teardown")
+  }
+
+  companion object {
+    @ClassRule
+    @JvmField
+    val embeddedService = ClientDriverRule(8332)
+
+    val executedStates = mutableListOf<String>()
+
+    @BeforeClass
+    @JvmStatic
+    fun beforeTest() {
+      executedStates.clear()
+    }
+
+    @AfterClass
+    @JvmStatic
+    fun afterTest() {
+      assertThat(executedStates, `is`(equalTo(listOf("state1", "state1 Teardown"))))
+    }
+  }
+}

--- a/provider/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/junit/filter/InteractionFilter.java
+++ b/provider/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/junit/filter/InteractionFilter.java
@@ -1,0 +1,47 @@
+package au.com.dius.pact.provider.junit.filter;
+
+import au.com.dius.pact.core.model.Interaction;
+import au.com.dius.pact.core.model.RequestResponseInteraction;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+public interface InteractionFilter<I extends Interaction> {
+
+    Predicate<I> buildPredicate(String[] values);
+
+    /**
+     * Filter interactions by any of their provider state. If one matches any of the values, the interaction
+     * is kept and verified.
+     */
+    class ByProviderState<I extends Interaction> implements InteractionFilter<I> {
+
+        @Override
+        public Predicate<I> buildPredicate(String[] values) {
+            return interaction -> Arrays.stream(values).anyMatch(
+                value -> interaction.getProviderStates().stream().anyMatch(
+                    state -> state .getName() != null && state.getName().matches(value)
+                )
+            );
+        }
+    }
+
+    /**
+     * Filter interactions by their request path, e.g. with value "^\\/somepath.*".
+     */
+    class ByRequestPath<I extends Interaction> implements InteractionFilter<I> {
+
+        @Override
+        public Predicate<I> buildPredicate(String[] values) {
+            return interaction -> {
+                if (interaction instanceof RequestResponseInteraction) {
+                    return Arrays.stream(values).anyMatch(value ->
+                        ((RequestResponseInteraction) interaction).getRequest().getPath().matches(value)
+                    );
+                } else {
+                    return false;
+                }
+            };
+        }
+    }
+}

--- a/provider/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/junit/loader/PactFilter.java
+++ b/provider/pact-jvm-provider/src/main/java/au/com/dius/pact/provider/junit/loader/PactFilter.java
@@ -1,5 +1,7 @@
 package au.com.dius.pact.provider.junit.loader;
 
+import au.com.dius.pact.provider.junit.filter.InteractionFilter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -7,11 +9,25 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to filter pacts by provider state. Supports regular expressions.
+ * Annotation to filter pacts. The default implementation is to filter by provider state.
+ * The filter supports regular expressions.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
 public @interface PactFilter {
+
+    /**
+     * Values to use for filtering. Regular expressions are allowed, like "^state \\d".
+     * If none of the provided values matches, the interaction is not verified.
+     */
     String[] value();
+
+    /**
+     * Use this class as filter implementation. The class must implement the {@link InteractionFilter}
+     * interface and provide a default constructor.
+     *
+     * The default value is filtering by provider state.
+     */
+    Class<? extends InteractionFilter> filter() default InteractionFilter.ByProviderState.class;
 }

--- a/provider/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/junit/filter/InteractionFilterTest.java
+++ b/provider/pact-jvm-provider/src/test/java/au/com/dius/pact/provider/junit/filter/InteractionFilterTest.java
@@ -1,0 +1,88 @@
+package au.com.dius.pact.provider.junit.filter;
+
+import au.com.dius.pact.core.model.Interaction;
+import au.com.dius.pact.core.model.ProviderState;
+import au.com.dius.pact.core.model.Request;
+import au.com.dius.pact.core.model.RequestResponseInteraction;
+import au.com.dius.pact.core.model.messaging.Message;
+import org.junit.Assert;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
+
+class InteractionFilterTest {
+
+    @Nested
+    class ByProviderState {
+
+        InteractionFilter<? super Interaction> interactionFilter =
+            InteractionFilter.ByProviderState.class.getDeclaredConstructor().newInstance();
+
+        ByProviderState() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        }
+
+        @Test
+        public void filterRequestResponseInteraction() {
+            RequestResponseInteraction interaction = new RequestResponseInteraction(
+                "test",
+                Arrays.asList(new ProviderState("state1"), new ProviderState("state2"))
+            );
+
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{"noop"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1", "state2"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"noop", "state2"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1", "state2"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{""}).test(interaction));
+        }
+
+        @Test
+        public void filterMessageInteraction() {
+            Message interaction = new Message(
+                "test",
+                Arrays.asList(new ProviderState("state1"), new ProviderState("state2"))
+            );
+
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{"noop"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1", "state2"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"noop", "state2"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"state1", "state2"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{""}).test(interaction));
+        }
+    }
+
+    @Nested
+    class ByRequestPath {
+
+        InteractionFilter<? super Interaction> interactionFilter =
+            InteractionFilter.ByRequestPath.class.getDeclaredConstructor().newInstance();
+
+        ByRequestPath() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        }
+
+        @Test
+        public void filterRequestResponseInteraction() {
+            RequestResponseInteraction interaction = new RequestResponseInteraction(
+                "test",
+                Collections.emptyList(),
+                new Request("GET", "/some-path")
+            );
+
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"\\/some-path"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{"other"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{"\\/some-path.*"}).test(interaction));
+            Assert.assertTrue(interactionFilter.buildPredicate(new String[]{".*some-path"}).test(interaction));
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{""}).test(interaction));
+        }
+
+        @Test
+        public void filterMessageInteraction() {
+            Message interaction = new Message("test", Collections.emptyList());
+            Assert.assertFalse(interactionFilter.buildPredicate(new String[]{".*"}).test(interaction));
+        }
+    }
+}


### PR DESCRIPTION
Add a filter property to the PactFilter annotation to allow generic filtering, not only based on the provider state. The implementation is a non breaking change since the default behaviour is just like before but it not also allows to filter for the request path.

What do you think about this?