### PR TITLE
Avoid unhandled exception in `validateTestTarget`

### DIFF
--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/InteractionRunner.kt
@@ -26,7 +26,6 @@ import org.junit.runner.Description
 import org.junit.runner.Runner
 import org.junit.runner.notification.Failure
 import org.junit.runner.notification.RunNotifier
-import org.junit.runners.model.FrameworkField
 import org.junit.runners.model.FrameworkMethod
 import org.junit.runners.model.InitializationError
 import org.junit.runners.model.Statement
@@ -117,7 +116,7 @@ open class InteractionRunner<I>(
 
   protected fun hasOneConstructor() = testClass.javaClass.constructors.size == 1
 
-  protected fun validateTestTarget(errors: MutableList<Throwable>): FrameworkField {
+  protected fun validateTestTarget(errors: MutableList<Throwable>) {
     val annotatedFields = testClass.getAnnotatedFields(TestTarget::class.java)
     if (annotatedFields.size != 1) {
       errors.add(Exception("Test class should have exactly one field annotated with ${TestTarget::class.java.name}"))
@@ -125,7 +124,6 @@ open class InteractionRunner<I>(
       errors.add(Exception("Field annotated with ${TestTarget::class.java.name} should implement " +
         "${Target::class.java.name} interface"))
     }
-    return annotatedFields[0]
   }
 
   protected fun validateRules(errors: List<Throwable>) {


### PR DESCRIPTION
`InteractionRunner.validateTestTarget()` throws an `IndexOutOfBoundsException`
when it tries to `return annotatedFields[0]` if the collection is empty.

Instead it should return nothing/void as it adds an `Exception` to the
`errors` list prior to the return statement, and this fulfills the
expectation of the caller and mirrors the other `validateX()` methods
in the class.