### PR TITLE
Fix off-by-one valueFromProviderState index

### DIFF
--- a/consumer/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/MatcherTestUtils.java
+++ b/consumer/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/MatcherTestUtils.java
@@ -1,6 +1,8 @@
 package au.com.dius.pact.consumer;
 
+import au.com.dius.pact.core.model.PactSpecVersion;
 import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.generators.Generators;
 import au.com.dius.pact.core.model.matchingrules.MatchingRuleGroup;
 import au.com.dius.pact.core.model.matchingrules.MatchingRules;
 import au.com.dius.pact.core.model.messaging.MessagePact;
@@ -35,6 +37,13 @@ public class MatcherTestUtils {
       MatchingRules matchingRules = pact.getInteractions().get(0).getResponse().getMatchingRules();
       Map<String, MatchingRuleGroup> matchers = matchingRules.rulesForCategory(category).getMatchingRules();
       assertEquals(asSet(matcherKeys), new TreeSet<>(matchers.keySet()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void assertResponseGeneratorKeysEqualTo(RequestResponsePact pact, String category, String... matcherKeys) {
+        Generators generators = pact.getInteractions().get(0).getResponse().getGenerators();
+        Map<String, Object> categoryMap = (Map<String, Object>) generators.toMap(PactSpecVersion.V3).get(category);
+        assertEquals(asSet(matcherKeys), new TreeSet<>(categoryMap.keySet()));
     }
 
     public static void assertResponseKeysEqualTo(RequestResponsePact pact, String... keys) {

--- a/consumer/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/junit/PactDslJsonArrayTest.java
+++ b/consumer/pact-jvm-consumer-junit/src/test/java/au/com/dius/pact/consumer/junit/PactDslJsonArrayTest.java
@@ -27,6 +27,9 @@ public class PactDslJsonArrayTest extends ConsumerPactTest {
             .stringValue("name", "Cat in the Hat")
             .timestamp()
             .date("dob", "MM/dd/yyyy")
+            .array("things")
+                .valueFromProviderState("thingName", "Thing 1")
+            .closeArray()
           .closeObject();
         RequestResponsePact pact = builder
           .uponReceiving("java test interaction with a DSL array body")
@@ -46,8 +49,18 @@ public class PactDslJsonArrayTest extends ConsumerPactTest {
             "$[2].v1",
             "$[3].id",
             "$[3].timestamp",
-            "$[3].dob"
+            "$[3].dob",
+            "$[3].things[0]"
         );
+
+        MatcherTestUtils.assertResponseGeneratorKeysEqualTo(pact, "body",
+            "$[2].id",
+            "$[2].timestamp",
+            "$[2].dob",
+            "$[3].id",
+            "$[3].timestamp",
+            "$[3].dob",
+            "$[3].things[0]");
 
         return pact;
     }

--- a/consumer/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
+++ b/consumer/pact-jvm-consumer/src/main/java/au/com/dius/pact/consumer/dsl/PactDslJsonArray.java
@@ -1232,8 +1232,8 @@ public class PactDslJsonArray extends DslPart {
    * @param example Example value to be used in the consumer test
    */
   public PactDslJsonArray valueFromProviderState(String expression, Object example) {
-    generators.addGenerator(Category.BODY, rootPath + appendArrayIndex(0), new ProviderStateGenerator(expression));
     body.put(example);
+    generators.addGenerator(Category.BODY, rootPath + appendArrayIndex(0), new ProviderStateGenerator(expression));
     matchers.addRule(rootPath + appendArrayIndex(0), TypeMatcher.INSTANCE);
     return this;
   }


### PR DESCRIPTION
`PactDslJsonArray.valueFromProviderState()` assigns an index
one less than it should.

Before appending to the `body` array,
the method invokes `appendArrayIndex()`, which in turn emits an
index value of `body.length()-1`. Since the `body` array is yet to
be updated the calculated index is off by one (the most obvious
sign of this is a negative index of `-1`).

This PR moves the append to `body` first.