### PR TITLE
Revert #1021 Defer JUnit runner initialization

### DIFF
--- a/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/PactRunner.kt
+++ b/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/PactRunner.kt
@@ -53,20 +53,8 @@ open class PactRunner<I>(clazz: Class<*>) : ParentRunner<InteractionRunner<I>>(c
 
   private val child = mutableListOf<InteractionRunner<I>>()
   private var valueResolver = SystemPropertyResolver()
-  private val clazz = clazz
-  private var initialized = false
 
-  override fun run(notifier: RunNotifier?) {
-    initialize()
-
-    super.run(notifier)
-  }
-
-  private fun initialize() {
-    if (initialized) {
-      return
-    }
-
+  init {
     if (clazz.getAnnotation(Ignore::class.java) != null) {
       logger.info("Ignore annotation detected, exiting")
     } else {
@@ -122,7 +110,6 @@ open class PactRunner<I>(clazz: Class<*>) : ParentRunner<InteractionRunner<I>>(c
 
       setupInteractionRunners(testClass, pacts, pactLoader)
     }
-    initialized = true
   }
 
   protected open fun setupInteractionRunners(testClass: TestClass, pacts: List<Pact<I>>, pactLoader: PactLoader) {

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/FilteredPactRunnerSpec.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/FilteredPactRunnerSpec.groovy
@@ -10,7 +10,6 @@ import au.com.dius.pact.provider.junit.loader.PactFilter
 import au.com.dius.pact.provider.junit.loader.PactFolder
 import au.com.dius.pact.provider.junit.target.Target
 import au.com.dius.pact.provider.junit.target.TestTarget
-import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.InitializationError
 import spock.lang.Specification
 
@@ -190,7 +189,7 @@ class FilteredPactRunnerSpec extends Specification {
   @SuppressWarnings('UnusedObject')
   def 'Throws an initialisation error if all pacts are filtered out'() {
     when:
-    new PactRunner(TestFilterOutAllPactsClass).run(new RunNotifier())
+    new PactRunner(TestFilterOutAllPactsClass)
 
     then:
     thrown(InitializationError)

--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/PactRunnerSpec.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/PactRunnerSpec.groovy
@@ -10,7 +10,6 @@ import au.com.dius.pact.provider.junit.loader.PactUrl
 import au.com.dius.pact.provider.junit.loader.PactUrlLoader
 import au.com.dius.pact.provider.junit.target.Target
 import au.com.dius.pact.provider.junit.target.TestTarget
-import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.InitializationError
 import spock.lang.Specification
 
@@ -116,7 +115,7 @@ class PactRunnerSpec extends Specification {
 
   def 'PactRunner throws an exception if there is no @Provider annotation on the test class'() {
     when:
-    new PactRunner(PactRunnerSpec).run(new RunNotifier())
+    new PactRunner(PactRunnerSpec)
 
     then:
     InitializationError e = thrown()
@@ -126,7 +125,7 @@ class PactRunnerSpec extends Specification {
 
   def 'PactRunner throws an exception if there is no pact source'() {
     when:
-    new PactRunner(NoSourceTestClass).run(new RunNotifier())
+    new PactRunner(NoSourceTestClass)
 
     then:
     InitializationError e = thrown()
@@ -135,7 +134,7 @@ class PactRunnerSpec extends Specification {
 
   def 'PactRunner throws an exception if the pact source throws an IO exception'() {
     when:
-    new PactRunner(FailsTestClass).run(new RunNotifier())
+    new PactRunner(FailsTestClass)
 
     then:
     InitializationError e = thrown()
@@ -144,24 +143,11 @@ class PactRunnerSpec extends Specification {
 
   def 'PactRunner throws an exception if there are no pacts to verify'() {
     when:
-    new PactRunner(NoPactsTestClass).run(new RunNotifier())
+    new PactRunner(NoPactsTestClass)
 
     then:
     InitializationError e = thrown()
     e.causes*.message == ['Did not find any pact files for provider Bob']
-  }
-
-  def 'PactRunner only initializes once if run() is called multiple times'() {
-    when:
-    def runner = new PactRunner(TestClass)
-    runner.run(new RunNotifier())
-    def children1 = runner.children.clone()
-
-    runner.run(new RunNotifier())
-    def children2 = runner.children.clone()
-
-    then:
-    children1 == children2
   }
 
   def 'PactRunner does not throw an exception if there are no pacts to verify and @IgnoreNoPactsToVerify'() {
@@ -183,7 +169,7 @@ class PactRunnerSpec extends Specification {
 
   def 'PactRunner throws an exception if there is both a pact source and pact loader annotation'() {
     when:
-    new PactRunner(BothPactSourceAndPactLoaderTestClass).run(new RunNotifier())
+    new PactRunner(BothPactSourceAndPactLoaderTestClass)
 
     then:
     InitializationError e = thrown()
@@ -193,7 +179,6 @@ class PactRunnerSpec extends Specification {
   def 'PactRunner handles a pact source with a pact loader that takes a class parameter'() {
     when:
     def runner = new PactRunner(PactLoaderWithConstructorParameterTestClass)
-    runner.run(new RunNotifier())
 
     then:
     !runner.children.empty
@@ -202,7 +187,6 @@ class PactRunnerSpec extends Specification {
   def 'PactRunner handles a pact source with a pact loader that does not takes a class parameter'() {
     when:
     def runner = new PactRunner(PactLoaderWithDefaultConstructorClass)
-    runner.run(new RunNotifier())
 
     then:
     !runner.children.empty
@@ -211,7 +195,6 @@ class PactRunnerSpec extends Specification {
   def 'PactRunner loads the pact loader class from the pact loader associated with the pact loader annotation'() {
     when:
     def runner = new PactRunner(TestClass)
-    runner.run(new RunNotifier())
 
     then:
     !runner.children.empty


### PR DESCRIPTION
Fixes #1035. @dbevacqua, could you see if this causes a regression of #1020? If so, we should rethink how initialization is handled.