### PR TITLE
#1013 - Fix to issue when in pact contract content type is not provided

### DIFF
--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderClient.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/ProviderClient.kt
@@ -44,7 +44,7 @@ import java.util.concurrent.Callable
 import java.util.function.Consumer
 import java.util.function.Function
 import java.util.function.Supplier
-
+import au.com.dius.pact.core.model.ContentType as PactContentType
 interface IHttpClientFactory {
   fun newClient(provider: IProviderInfo): CloseableHttpClient
 }
@@ -294,7 +294,11 @@ open class ProviderClient(
     }
 
     if (!method.containsHeader(CONTENT_TYPE) && request.body.isPresent()) {
-      method.addHeader(CONTENT_TYPE, "text/plain; charset=ISO-8859-1")
+      val contentType = when (request.body.contentType) {
+        PactContentType.UNKNOWN -> "text/plain; charset=ISO-8859-1"
+        else -> request.body.contentType.toString()
+      }
+      method.addHeader(CONTENT_TYPE, contentType)
     }
   }
 

--- a/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/groovysupport/ProviderClientSpec.groovy
+++ b/provider/pact-jvm-provider/src/test/groovy/au/com/dius/pact/provider/groovysupport/ProviderClientSpec.groovy
@@ -4,6 +4,7 @@ import au.com.dius.pact.core.model.OptionalBody
 import au.com.dius.pact.core.model.ProviderState
 import au.com.dius.pact.core.model.Request
 import au.com.dius.pact.core.support.Json
+import au.com.dius.pact.core.model.ContentType as PactContentType
 @SuppressWarnings('UnusedImport')
 import au.com.dius.pact.provider.GroovyScalaUtils$
 import au.com.dius.pact.provider.IHttpClientFactory
@@ -102,6 +103,28 @@ class ProviderClientSpec extends Specification {
       1 * httpRequest.addHeader(it.key, it.value[0])
     }
     1 * httpRequest.addHeader('Content-Type', 'text/plain; charset=ISO-8859-1')
+
+    0 * httpRequest._
+  }
+
+  def 'setting up headers adds an content type if none was provided and there is a body with content type'() {
+    given:
+    def headers = [
+            A: ['a'],
+            B: ['b'],
+            C: ['c']
+    ]
+    request = new Request('PUT', '/', [:], headers, OptionalBody.body('{}'.bytes, PactContentType.JSON))
+
+    when:
+    client.setupHeaders(request, httpRequest)
+
+    then:
+    1 * httpRequest.containsHeader('Content-Type') >> false
+    headers.each {
+      1 * httpRequest.addHeader(it.key, it.value[0])
+    }
+    1 * httpRequest.addHeader('Content-Type', ContentType.APPLICATION_JSON.getMimeType())
 
     0 * httpRequest._
   }


### PR DESCRIPTION
When the body is of type JSON use the application/json content type
Breaking change between pact 4.0.6 -> 4.0.7