### PR TITLE
feat: create Kotlin friendly extension for arrays

### DIFF
--- a/consumer/pact-jvm-consumer-java8/build.gradle
+++ b/consumer/pact-jvm-consumer-java8/build.gradle
@@ -1,12 +1,10 @@
 dependencies {
   api project(path: ":consumer:pact-jvm-consumer", configuration: 'default')
 
-  testCompile "org.junit.jupiter:junit-jupiter-api:${project.junit5Version}"
-  testRuntime "org.junit.vintage:junit-vintage-engine:${project.junit5Version}"
+  testImplementation "org.junit.jupiter:junit-jupiter:${project.junit5Version}"
   testRuntime "ch.qos.logback:logback-classic:${project.logbackVersion}"
-  testCompile "junit:junit:${project.junitVersion}"
-  testCompile "org.codehaus.groovy:groovy:${project.groovyVersion}"
-  testCompile('org.spockframework:spock-core:2.0-M2-groovy-3.0') {
+  testImplementation "org.codehaus.groovy:groovy:${project.groovyVersion}"
+  testImplementation('org.spockframework:spock-core:2.0-M2-groovy-3.0') {
     exclude group: 'org.codehaus.groovy'
   }
 }

--- a/consumer/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
+++ b/consumer/pact-jvm-consumer-java8/src/main/kotlin/io/pactfoundation/consumer/dsl/Extensions.kt
@@ -24,6 +24,13 @@ fun LambdaDslObject.newObject(name: String, nestedObject: LambdaDslObject.() -> 
 }
 
 /**
+ * Extension function to make [LambdaDslObject.array] Kotlin friendly.
+ */
+fun LambdaDslObject.newArray(name: String, body: LambdaDslJsonArray.() -> (Unit)): LambdaDslObject {
+    return array(name) { it.body() }
+}
+
+/**
  * Extension function to make [LambdaDslJsonArray.array] Kotlin friendly.
  */
 fun LambdaDslJsonArray.newArray(body: LambdaDslJsonArray.() -> (Unit)): LambdaDslJsonArray {

--- a/consumer/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
+++ b/consumer/pact-jvm-consumer-java8/src/test/kotlin/io/pactfoundation/consumer/dsl/ExtensionsTest.kt
@@ -1,19 +1,41 @@
 package io.pactfoundation.consumer.dsl
 
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
 import org.junit.jupiter.api.Test
 
 class ExtensionsTest {
-  @Test
-  fun `can use LambdaDslJsonArray#newObject`() {
-    newJsonArray { newObject { stringType("foo") } }
-  }
+    @Test
+    fun `can use Kotlin DSL to create a Json Array`() {
+        val expectedJson = """[
+        |{"key":"value"},
+        |{"key_1":"value_1"}
+        |]""".trimMargin().replace("\n", "")
 
-  @Test
-  fun `can use LambdaDslObject#newObject`() {
-    newJsonObject {
-      newObject("object") {
-        stringType("field")
-      }
+        val actualJson = newJsonArray {
+            newObject { stringValue("key", "value") }
+            newObject { stringValue("key_1", "value_1") }
+        }.body.toString()
+
+        assertThat(actualJson, equalTo(expectedJson))
     }
-  }
+
+    @Test
+    fun `can use Kotlin DSL to create a Json`() {
+        val expectedJson = """{
+        |"array":[{"key":"value"}],
+        |"object":{"property":"value"}
+        |}""".trimMargin().replace("\n", "")
+
+        val actualJson = newJsonObject {
+            newArray("array") {
+                newObject { stringValue("key", "value") }
+            }
+            newObject("object") {
+                stringValue("property", "value")
+            }
+        }.body.toString()
+
+        assertThat(actualJson, equalTo(expectedJson))
+    }
 }


### PR DESCRIPTION
This PR adds a Kotlin extension to make more friendly adding an array inside an object.

For example the following code:
```kotlin
newObject {
  array("array") {
    it.stringType("property")
  }
}
```
can now be written:
```kotlin
newObject {
  newArray("array") {
    stringType("property")
  }
}
```

Also, I've fixed the dependencies for the `pact-jvm-consumer-java8` module. The Junit 5 tests were not running with the previous setup.