### PR TITLE
fix: publish verification results when Pact URL is overridden #1049

### DIFF
--- a/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/pact-jvm-provider-junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -1,8 +1,8 @@
 package au.com.dius.pact.provider.junit.loader
 
+import au.com.dius.pact.core.model.BrokerUrlSource
 import au.com.dius.pact.core.model.Pact
 import au.com.dius.pact.core.model.PactBrokerSource
-import au.com.dius.pact.core.model.UrlSource
 import au.com.dius.pact.core.pactbroker.IHalClient
 import au.com.dius.pact.core.pactbroker.InvalidHalResponse
 import au.com.dius.pact.core.pactbroker.PactBrokerClient
@@ -383,7 +383,8 @@ class PactBrokerLoaderSpec extends Specification {
     tags = ['demo']
     PactBrokerLoader loader = Spy(pactBrokerLoader())
     loader.overridePactUrl('http://overridden.com', 'overridden')
-    def consumer = new ConsumerInfo('overridden', null, true, [], null, new UrlSource('http://overridden.com'))
+    def brokerUrlSource = new BrokerUrlSource('http://overridden.com', 'http://pactbroker:1234')
+    def consumer = new ConsumerInfo('overridden', null, true, [], null, brokerUrlSource)
 
     when:
     def result = loader.load('test')

--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/junit/loader/PactBrokerLoader.kt
@@ -1,12 +1,12 @@
 package au.com.dius.pact.provider.junit.loader
 
+import au.com.dius.pact.core.model.BrokerUrlSource
 import au.com.dius.pact.core.model.Consumer
 import au.com.dius.pact.core.model.DefaultPactReader
 import au.com.dius.pact.core.model.Interaction
 import au.com.dius.pact.core.model.Pact
 import au.com.dius.pact.core.model.PactBrokerSource
 import au.com.dius.pact.core.model.PactReader
-import au.com.dius.pact.core.model.UrlSource
 import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.pactbroker.PactBrokerClient
 import au.com.dius.pact.core.support.expressions.ExpressionParser.parseExpression
@@ -78,8 +78,9 @@ open class PactBrokerLoader(
     val resolver = setupValueResolver()
     val pacts = when {
       overriddenPactUrl.isNotEmpty() -> {
-        val pactBrokerClient = newPactBrokerClient(brokerUrl(resolver).build(), resolver)
-        val pactSource = UrlSource<Interaction>(overriddenPactUrl!!)
+        val brokerUri = brokerUrl(resolver).build()
+        val pactBrokerClient = newPactBrokerClient(brokerUri, resolver)
+        val pactSource = BrokerUrlSource(overriddenPactUrl!!, brokerUri.toString())
         pactSource.encodePath = false
         listOf(loadPact(ConsumerInfo(name = overriddenConsumer!!, pactSource = pactSource),
           pactBrokerClient.options))


### PR DESCRIPTION
Fixes the problem where `@AllowOverridePactUrl` and `pact.filter.pacturl` are used together with `pact.verifier.publishResults=true` but the results are not published.