### PR TITLE
fix: @PactBroker not reading Spring properties with JUnit 5 #1023

### DIFF
--- a/provider/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
+++ b/provider/pact-jvm-provider-junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PactJUnit5VerificationProvider.kt
@@ -392,11 +392,11 @@ open class PactVerificationInvocationContextProvider : TestTemplateInvocationCon
     logger.debug { "Verifying pacts for provider '$serviceName' and consumer '$consumerName'" }
 
     val pactSources = findPactSources(context).flatMap {
-      description += "\nSource: ${it.description()}"
       val valueResolver = getValueResolver(context)
       if (valueResolver != null) {
         it.setValueResolver(valueResolver)
       }
+      description += "\nSource: ${it.description()}"
       val pacts = it.load(serviceName)
       filterPactsByAnnotations(pacts, context.requiredTestClass).map { pact -> pact to it.pactSource }
     }.filter { p -> consumerName == null || p.first.consumer.name == consumerName }


### PR DESCRIPTION
Fixes an issue in `PactVerificationInvocationContextProvider.resolvePactSources()` where calling `PactBrokerLoader.description()` ignores the value resolver that is being set after the call.

The method calling order breaks the `PactVerificationSpringProvider` that is trying to override the `getValueResolver()` method to be able to load broker properties from a Spring Boot `application.yml` file.