### PR TITLE
feat: add support for MockMvc in JUnit 5 tests

### DIFF
--- a/provider/pact-jvm-provider-junit5-spring/README.md
+++ b/provider/pact-jvm-provider-junit5-spring/README.md
@@ -38,3 +38,64 @@ pactbroker:
     username: broker-user
     password: broker.password
 ```
+
+You can also run pact tests against `MockMvc` without need to spin up the whole application context which takes time 
+and often requires more additional setup (e.g. database). In order to run lightweight tests just use `@WebMvcTest` 
+from Spring and `MockMvcTestTarget` as a test target before each test. 
+
+For example:
+```java
+@WebMvcTest
+@Provider("myAwesomeService")
+@PactBroker
+class ContractVerificationTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+      context.verifyInteraction();
+    }
+    
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        context.setTarget(new MockMvcTestTarget(mockMvc));
+    }
+}
+```
+
+You can also use `MockMvcTestTarget` for tests without spring context by providing the controllers manually. 
+
+For example:
+```java
+@Provider("myAwesomeService")
+@PactFolder("pacts")
+class MockMvcTestTargetStandaloneMockMvcTestJava {
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new DataResource());
+        context.setTarget(testTarget);
+    }
+
+    @RestController
+    static class DataResource {
+        @GetMapping("/data")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        void getData(@RequestParam("ticketId") String ticketId) {
+        }
+    }
+}
+```
+
+**Important:** Since `@WebMvcTest` starts only Spring MVC components you can't use `PactVerificationSpringProvider` 
+and need to fallback to `PactVerificationInvocationContextProvider`

--- a/provider/pact-jvm-provider-junit5-spring/build.gradle
+++ b/provider/pact-jvm-provider-junit5-spring/build.gradle
@@ -2,7 +2,13 @@ dependencies {
   implementation project(path: ":provider:pact-jvm-provider-junit5", configuration: 'default')
   implementation 'org.springframework:spring-context:5.2.3.RELEASE'
   implementation 'org.springframework:spring-test:5.2.3.RELEASE'
+  implementation 'org.springframework:spring-web:5.2.3.RELEASE'
+  implementation 'javax.servlet:javax.servlet-api:3.1.0'
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test:2.2.5.RELEASE'
   testImplementation 'org.springframework.boot:spring-boot-starter-web:2.2.5.RELEASE'
+  testImplementation "org.codehaus.groovy:groovy:${project.groovyVersion}"
+  testImplementation('org.spockframework:spock-core:2.0-M2-groovy-3.0') {
+    exclude group: 'org.codehaus.groovy'
+  }
 }

--- a/provider/pact-jvm-provider-junit5-spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
+++ b/provider/pact-jvm-provider-junit5-spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
@@ -1,0 +1,191 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.core.model.Interaction
+import au.com.dius.pact.core.model.PactSource
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.provider.IProviderVerifier
+import au.com.dius.pact.provider.ProviderInfo
+import au.com.dius.pact.provider.junit5.TestTarget
+import mu.KLogging
+import org.apache.commons.lang3.StringUtils
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.client.match.MockRestRequestMatchers.anything
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.RequestBuilder
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+import javax.mail.internet.ContentDisposition
+import javax.mail.internet.MimeMultipart
+import javax.mail.util.ByteArrayDataSource
+/**
+ * Test target for tests using Spring MockMvc.
+ */
+class MockMvcTestTarget @JvmOverloads constructor(
+  var mockMvc: MockMvc? = null,
+  var controllers: List<Any> = mutableListOf(),
+  var controllerAdvices: List<Any> = mutableListOf(),
+  var messageConverters: List<HttpMessageConverter<*>> = mutableListOf(),
+  var printRequestResponse: Boolean = false,
+  var servletPath: String? = null
+) : TestTarget {
+    override fun getProviderInfo(serviceName: String, pactSource: PactSource?) = ProviderInfo(serviceName)
+
+    override fun prepareRequest(interaction: Interaction, context: Map<String, Any>): Pair<MockHttpServletRequestBuilder, MockMvc> {
+        if (interaction is RequestResponseInteraction) {
+            return toMockRequestBuilder(interaction.request.generatedRequest(context)) to buildMockMvc()
+        }
+        throw UnsupportedOperationException("Only request/response interactions can be used with an MockMvc test target")
+    }
+
+    fun setControllers(vararg controllers: Any) {
+        this.controllers = controllers.asList()
+    }
+
+    fun setControllerAdvices(vararg controllerAdvices: Any) {
+        this.controllerAdvices = controllerAdvices.asList()
+    }
+
+    fun setMessageConverters(vararg messageConverters: HttpMessageConverter<*>) {
+        this.messageConverters = messageConverters.asList()
+    }
+
+    private fun buildMockMvc(): MockMvc {
+        if (mockMvc != null) {
+            return mockMvc!!
+        }
+
+        val requestBuilder = MockMvcRequestBuilders.get("/")
+        if (!servletPath.isNullOrEmpty()) {
+            requestBuilder.servletPath(servletPath)
+        }
+
+        return MockMvcBuilders.standaloneSetup(*controllers.toTypedArray())
+          .setControllerAdvice(*controllerAdvices.toTypedArray())
+          .setMessageConverters(*messageConverters.toTypedArray())
+          .defaultRequest<StandaloneMockMvcBuilder>(requestBuilder)
+          .build()
+    }
+
+    private fun toMockRequestBuilder(request: Request): MockHttpServletRequestBuilder {
+        val body = request.body
+        val requestBuilder = if (body != null && body.isPresent()) {
+            if (request.isMultipartFileUpload()) {
+                val multipart = MimeMultipart(ByteArrayDataSource(body.unwrap(), request.contentTypeHeader()))
+                val multipartRequest = MockMvcRequestBuilders.fileUpload(requestUriString(request))
+                var i = 0
+                while (i < multipart.count) {
+                    val bodyPart = multipart.getBodyPart(i)
+                    val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
+                    val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
+                    val filename = contentDisposition.getParameter("filename").orEmpty()
+                    multipartRequest.file(MockMultipartFile(name, filename, bodyPart.contentType, bodyPart.inputStream))
+                    i++
+                }
+                multipartRequest.headers(mapHeaders(request, true))
+            } else {
+                MockMvcRequestBuilders.request(HttpMethod.valueOf(request.method), requestUriString(request))
+                  .headers(mapHeaders(request, true))
+                  .content(body.value)
+            }
+        } else {
+            MockMvcRequestBuilders.request(HttpMethod.valueOf(request.method), requestUriString(request))
+              .contentType(request.contentTypeHeader())
+              .headers(mapHeaders(request, false))
+        }
+
+        return requestBuilder
+    }
+
+    private fun requestUriString(request: Request): URI {
+        val uriBuilder = UriComponentsBuilder.fromPath(request.path)
+
+        val query = request.query
+        if (query != null && query.isNotEmpty()) {
+            query.forEach { key, value ->
+                uriBuilder.queryParam(key, *value.toTypedArray())
+            }
+        }
+
+        return URI.create(uriBuilder.toUriString())
+    }
+
+    private fun mapHeaders(request: Request, hasBody: Boolean): HttpHeaders {
+        val httpHeaders = HttpHeaders()
+
+        request.headers?.forEach { k, v ->
+            httpHeaders.add(k, v.joinToString(", "))
+        }
+
+        if (hasBody && !httpHeaders.containsKey(HttpHeaders.CONTENT_TYPE)) {
+            httpHeaders.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        }
+
+        return httpHeaders
+    }
+
+    override fun isHttpTarget() = true
+
+    override fun executeInteraction(client: Any?, request: Any?): Map<String, Any> {
+        val mockMvcClient = client as MockMvc
+        val requestBuilder = request as MockHttpServletRequestBuilder
+        val mvcResult = performRequest(mockMvcClient, requestBuilder).andDo {
+            if (printRequestResponse) {
+                MockMvcResultHandlers.print().handle(it)
+            }
+        }.andReturn()
+
+        return handleResponse(mvcResult.response)
+    }
+
+    private fun performRequest(mockMvc: MockMvc, requestBuilder: RequestBuilder): ResultActions {
+        val resultActions = mockMvc.perform(requestBuilder)
+        return if (resultActions.andReturn().request.isAsyncStarted) {
+            mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(resultActions
+              .andExpect(MockMvcResultMatchers.request().asyncResult(anything()))
+              .andReturn()))
+        } else {
+            resultActions
+        }
+    }
+
+    private fun handleResponse(httpResponse: MockHttpServletResponse): Map<String, Any> {
+        logger.debug { "Received response: ${httpResponse.status}" }
+        val response = mutableMapOf<String, Any>("statusCode" to httpResponse.status)
+
+        val headers = mutableMapOf<String, List<String>>()
+        httpResponse.headerNames.forEach { headerName ->
+            headers[headerName] = listOf(httpResponse.getHeader(headerName))
+        }
+        response["headers"] = headers
+
+        if (httpResponse.contentType.isNullOrEmpty()) {
+            response["contentType"] = org.apache.http.entity.ContentType.APPLICATION_JSON
+        } else {
+            response["contentType"] = org.apache.http.entity.ContentType.parse(httpResponse.contentType)
+        }
+        response["data"] = httpResponse.contentAsString
+
+        logger.debug { "Response: $response" }
+
+        return response
+    }
+
+    override fun prepareVerifier(verifier: IProviderVerifier, testInstance: Any) {
+        /* NO-OP */
+    }
+
+    companion object : KLogging()
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/groovy/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetSpec.groovy
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/groovy/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetSpec.groovy
@@ -1,0 +1,118 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.core.model.OptionalBody
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class MockMvcTestTargetSpec extends Specification {
+
+    MockMvcTestTarget mockMvcTestTarget
+
+    def setup() {
+        mockMvcTestTarget = new MockMvcTestTarget(null, [new TestResource()])
+    }
+
+    def 'should prepare get request'() {
+        given:
+        def request = new Request('GET', '/data', [id: ['1234']])
+        def interaction = new RequestResponseInteraction('some description', [], request)
+        when:
+        def requestAndClient = mockMvcTestTarget.prepareRequest(interaction, [:])
+        def requestBuilder = requestAndClient.first
+        def client = requestAndClient.second
+        then:
+        client instanceof MockMvc
+        def builtRequest = requestBuilder.buildRequest(null)
+        builtRequest.requestURI == '/data'
+        builtRequest.method == 'GET'
+        builtRequest.parameterMap.id[0] == '1234'
+    }
+
+    def 'should prepare get request with custom mockMvc'() {
+        given:
+        def mockMvc = MockMvcBuilders.standaloneSetup(new TestResource()).build()
+        def mockMvcTestTarget = new MockMvcTestTarget(mockMvc)
+        def request = new Request('GET', '/data', [id: ['1234']])
+        def interaction = new RequestResponseInteraction('some description', [], request)
+        when:
+        def requestAndClient = mockMvcTestTarget.prepareRequest(interaction, [:])
+        def requestBuilder = requestAndClient.first
+        def client = requestAndClient.second
+        then:
+        client === mockMvc
+        def builtRequest = requestBuilder.buildRequest(null)
+        builtRequest.requestURI == '/data'
+        builtRequest.method == 'GET'
+        builtRequest.parameterMap.id[0] == '1234'
+    }
+
+    def 'should prepare post request'() {
+        given:
+        def request = new Request('POST', '/data', [id: ['1234']], [:],
+                OptionalBody.body('{"foo":"bar"}'.getBytes(StandardCharsets.UTF_8)))
+        def interaction = new RequestResponseInteraction('some description', [], request)
+        when:
+        def requestAndClient = mockMvcTestTarget.prepareRequest(interaction, [:])
+        def requestBuilder = requestAndClient.first
+        def client = requestAndClient.second
+        then:
+        client instanceof MockMvc
+        def builtRequest = requestBuilder.characterEncoding('UTF-8').buildRequest(null)
+        builtRequest.requestURI == '/data'
+        builtRequest.contentAsString == '{"foo":"bar"}'
+        builtRequest.method == 'POST'
+        builtRequest.parameterMap.id[0] == '1234'
+    }
+
+    def 'should execute interaction'() {
+        given:
+        def request = new Request('GET', '/data', [id: ['1234']])
+        def interaction = new RequestResponseInteraction('some description', [], request)
+        def requestAndClient = mockMvcTestTarget.prepareRequest(interaction, [:])
+        def requestBuilder = requestAndClient.first
+        def client = requestAndClient.second
+        when:
+        def responseMap = mockMvcTestTarget.executeInteraction(client, requestBuilder)
+        then:
+        responseMap.statusCode == 200
+        responseMap.contentType.mimeType == 'application/json'
+        responseMap.data == 'Hello 1234'
+    }
+
+    def 'should execute interaction with custom mockMvc'() {
+        given:
+        def mockMvc = MockMvcBuilders.standaloneSetup(new TestResource()).build()
+        def mockMvcTestTarget = new MockMvcTestTarget(mockMvc)
+
+        def request = new Request('GET', '/data', [id: ['1234']])
+        def interaction = new RequestResponseInteraction('some description', [], request)
+        def requestAndClient = mockMvcTestTarget.prepareRequest(interaction, [:])
+        def requestBuilder = requestAndClient.first
+        def client = requestAndClient.second
+        when:
+        def responseMap = mockMvcTestTarget.executeInteraction(client, requestBuilder)
+        then:
+        responseMap.statusCode == 200
+        responseMap.contentType.mimeType == 'application/json'
+        responseMap.data == 'Hello 1234'
+    }
+
+    @RestController
+    static class TestResource {
+        @GetMapping(value = '/data', produces = 'application/json')
+        @ResponseStatus(HttpStatus.OK)
+        String getData(@RequestParam('id') String id) {
+            "Hello $id"
+        }
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTestJava.java
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTestJava.java
@@ -1,0 +1,40 @@
+package au.com.dius.pact.provider.spring.junit5;
+
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Provider("myAwesomeService")
+@PactFolder("pacts")
+class MockMvcTestTargetStandaloneMockMvcTestJava {
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        MockMvcTestTarget testTarget = new MockMvcTestTarget();
+        testTarget.setControllers(new DataResource());
+        context.setTarget(testTarget);
+    }
+
+    @RestController
+    static class DataResource {
+        @GetMapping("/data")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        void getData(@RequestParam("ticketId") String ticketId) {
+        }
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTestJava.java
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTestJava.java
@@ -1,0 +1,45 @@
+package au.com.dius.pact.provider.spring.junit5;
+
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactFolder;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@WebMvcTest
+@Provider("myAwesomeService")
+@PactFolder("pacts")
+class MockMvcTestTargetWebMvcTestJava {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        context.setTarget(new MockMvcTestTarget(mockMvc));
+    }
+
+    @RestController
+    static class DataResource {
+        @GetMapping("/data")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        void getData(@RequestParam("ticketId") String ticketId) {
+        }
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetNoCustomMockMvcTest.kt
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetNoCustomMockMvcTest.kt
@@ -1,0 +1,40 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junit.Provider
+import au.com.dius.pact.provider.junit.loader.PactFolder
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Provider("myAwesomeService")
+@IgnoreNoPactsToVerify
+@PactFolder("pacts")
+internal class MockMvcTestTargetNoCustomMockMvcTest {
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @BeforeEach
+    fun before(context: PactVerificationContext?) {
+        context?.target = MockMvcTestTarget(controllers = listOf(DataResource()))
+    }
+
+    @RestController
+    internal class DataResource {
+        @GetMapping("/data")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        fun getData(@RequestParam("ticketId") ticketId: String) {
+        }
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTest.kt
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTest.kt
@@ -1,0 +1,43 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junit.Provider
+import au.com.dius.pact.provider.junit.loader.PactFolder
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Provider("myAwesomeService")
+@IgnoreNoPactsToVerify
+@PactFolder("pacts")
+internal class MockMvcTestTargetStandaloneMockMvcTest {
+
+    val mockMvc = MockMvcBuilders.standaloneSetup(DataResource()).build()
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @BeforeEach
+    fun before(context: PactVerificationContext?) {
+        context?.target = MockMvcTestTarget(mockMvc)
+    }
+
+    @RestController
+    internal class DataResource {
+        @GetMapping("/data")
+        @ResponseStatus(HttpStatus.NO_CONTENT)
+        fun getData(@RequestParam("ticketId") ticketId: String) {
+        }
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTest.kt
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTest.kt
@@ -1,0 +1,47 @@
+package au.com.dius.pact.provider.spring.junit5
+
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junit.Provider
+import au.com.dius.pact.provider.junit.loader.PactFolder
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@WebMvcTest
+@Provider("myAwesomeService")
+@IgnoreNoPactsToVerify
+@PactFolder("pacts")
+internal class MockMvcTestTargetWebMvcTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun pactVerificationTestTemplate(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @BeforeEach
+    fun before(context: PactVerificationContext?) {
+        context?.target = MockMvcTestTarget(mockMvc)
+    }
+}
+
+@RestController
+internal class DataResource {
+    @GetMapping("/data")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun getData(@RequestParam("ticketId") ticketId: String) {
+    }
+}

--- a/provider/pact-jvm-provider-junit5-spring/src/test/resources/pacts/contract.json
+++ b/provider/pact-jvm-provider-junit5-spring/src/test/resources/pacts/contract.json
@@ -1,0 +1,27 @@
+{
+  "provider" : {
+    "name" : "myAwesomeService"
+  },
+  "consumer" : {
+    "name" : "anotherService"
+  },
+  "interactions" : [ {
+    "description" : "Get data",
+    "request" : {
+      "method" : "GET",
+      "path" : "/data",
+      "query": "ticketId=0000"
+    },
+    "response" : {
+      "status" : 204
+    }
+  } ],
+  "metadata" : {
+    "pact-specification" : {
+      "version" : "2.0.0"
+    },
+    "pact-jvm" : {
+      "version" : "3.1.1"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for Spring MockMvc in JUnit5-based pact tests by providing a specialized `MockMvcTestTarget` target class.

Closes #1066