### PR TITLE
feat: add namespace-aware XML matching

### DIFF
--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
@@ -34,7 +34,7 @@ fun valueOf(value: Any?): String {
   return when (value) {
     null -> "null"
     is String -> "'$value'"
-    is Element -> "<${value.tagName}>"
+    is Element -> "<${QualifiedName(value)}>"
     is Text -> "'${value.wholeText}'"
     else -> value.toString()
   }
@@ -131,7 +131,7 @@ fun <M : Mismatch> matchEquality(
 ): List<M> {
   val matches = when {
     (actual == null || actual is JsonNull) && (expected == null || expected is JsonNull) -> true
-    actual is Element && expected is Element -> actual.tagName == expected.tagName
+    actual is Element && expected is Element -> QualifiedName(actual) == QualifiedName(expected)
     else -> actual != null && actual == expected
   }
   logger.debug { "comparing ${valueOf(actual)} to ${valueOf(expected)} at $path -> $matches" }
@@ -176,7 +176,7 @@ fun <M : Mismatch> matchType(
     expected is JsonArray && actual is JsonArray ||
     expected is Map<*, *> && actual is Map<*, *> ||
     expected is JsonObject && actual is JsonObject ||
-    expected is Element && actual is Element && actual.tagName == expected.tagName
+    expected is Element && actual is Element && QualifiedName(actual) == QualifiedName(expected)
   ) {
     emptyList()
   } else if (expected is JsonPrimitive && actual is JsonPrimitive &&

--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/QualifiedName.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/QualifiedName.kt
@@ -1,0 +1,54 @@
+package au.com.dius.pact.core.matchers
+
+import org.w3c.dom.Node
+
+/**
+ * Namespace-aware XML node qualified names.
+ *
+ * Used for comparison and display purposes. Uses the XML namespace and local name if present in the [Node].
+ * Falls back to using the default node name if a namespace isn't present.
+ */
+class QualifiedName(node: Node) {
+  val namespaceUri: String? = node.namespaceURI
+  val localName: String? = node.localName
+  val nodeName: String = node.nodeName
+
+  /**
+   * When both do not have a namespace, check equality using node name.
+   * Otherwise, check equality using both namespace and local name.
+   */
+  override fun equals(other: Any?): Boolean = when (other) {
+    is QualifiedName -> {
+      when {
+        this.namespaceUri == null && other.namespaceUri == null -> other.nodeName == nodeName
+        else -> other.namespaceUri == namespaceUri && other.localName == localName
+      }
+    }
+    else -> false
+  }
+
+  /**
+   * When a namespace isn't present, return the hash of the node name.
+   * Otherwise, return the hash of the namespace and local name.
+   */
+  override fun hashCode(): Int = when (namespaceUri) {
+    null -> nodeName.hashCode()
+    else -> 31 * (31 + namespaceUri.hashCode()) + localName.hashCode()
+  }
+
+  /**
+   * Returns the qualified name using Clark-notation if
+   * a namespace is present, otherwise returns the node name.
+   *
+   * Clark-notation uses the format `{namespace}localname`
+   * per https://sabre.io/xml/clark-notation/.
+   *
+   * @see Node.getNodeName
+   */
+  override fun toString(): String {
+    return when (namespaceUri) {
+      null -> nodeName
+      else -> "{$namespaceUri}$localName"
+    }
+  }
+}

--- a/pact-specification-test/src/main/resources/v3/response/body/different xml namespace prefixes.json
+++ b/pact-specification-test/src/main/resources/v3/response/body/different xml namespace prefixes.json
@@ -1,0 +1,12 @@
+{
+  "match": true,
+  "comment": "different XML namespace declarations/prefixes",
+  "expected" : {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator xmlns=\"urn:alligators\" xmlns:names=\"urn:names\" names:name=\"Mary\"><favouriteNumbers xmlns:fn=\"urn:favourite:numbers\"><fn:favouriteNumber>1</fn:favouriteNumber></favouriteNumbers></alligator>"
+  },
+  "actual": {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a:alligator xmlns:a=\"urn:alligators\" xmlns:n=\"urn:names\" n:name=\"Mary\"><a:favouriteNumbers><favouriteNumber xmlns=\"urn:favourite:numbers\">1</favouriteNumber></a:favouriteNumbers></a:alligator>"
+  }
+}

--- a/pact-specification-test/src/main/resources/v3/response/body/different xml namespaces.json
+++ b/pact-specification-test/src/main/resources/v3/response/body/different xml namespaces.json
@@ -1,0 +1,12 @@
+{
+  "match": false,
+  "comment": "XML namespaces do not match",
+  "expected" : {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a:alligator xmlns:a=\"urn:alligators\"/>"
+  },
+  "actual": {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a:alligator xmlns:a=\"urn:crocodiles\"/>"
+  }
+}

--- a/pact-specification-test/src/main/resources/v3/response/body/unexpected xml namespace.json
+++ b/pact-specification-test/src/main/resources/v3/response/body/unexpected xml namespace.json
@@ -1,0 +1,12 @@
+{
+  "match": false,
+  "comment": "XML namespaces not expected",
+  "expected" : {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator/>"
+  },
+  "actual": {
+    "headers": {"Content-Type": "application/xml"},
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><alligator xmlns=\"urn:alligators\"/>"
+  }
+}


### PR DESCRIPTION
## Problem to solve

XML namespaces are not currently used when comparing nodes between XML documents.  This poses a problem when different services assign different prefixes for the same namespace. For example, if `<a:foo xmlns:a="urn:ns"/>` is expected, then `<foo xmlns="urn:ns"/>` or `<b:foo xmlns:b="urn:ns"/>` will not currently match.

## Proposed changes

XML namespaces will be utilized when comparing nodes between XML documents.

When an XML namespace is defined (e.g., `<prefix:local xmlns:prefix="urn:ns"/>`), 
nodes will be compared by their namespace (e.g., `urn:ns`) and the local part of their name (e.g., `local`). Nodes using different
XML namespace declarations/prefixes (e.g., `<foo xmlns="urn:ns"/>`, `<a:foo xmlns:a="urn:ns"/>`, `<b:foo xmlns:b="urn:ns"/>`) can match.

When XML namespaces are not defined (e.g., `<prefix:local/>`), nodes will be compared by their full node name which includes both the local part
and optional prefix (e.g., `prefix:local`). Un-namespaced nodes with different full node names (e.g., `<foo/>`, `<a:foo/>`, `<b:foo/>`) won't match.

Nodes without an XML namespace (e.g., `<foo/>`) should not match nodes with an XML namespace (e.g., `<foo xmlns="urn:ns"/>`).

Namespace-aware matching can be disabled by setting the optional `pact.matching.xml.namespace-aware` system property to false (it will be considered true by default).

## NOTICE

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.