### PR TITLE
fixes an issue where all date and time based generators will crash provider tests

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/generators/Generator.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/generators/Generator.kt
@@ -253,7 +253,7 @@ data class DateGenerator @JvmOverloads constructor(
 
   companion object {
     fun fromJson(json: JsonObject): DateGenerator {
-      return DateGenerator(Json.toString(json["format"]), Json.toString(json["expression"]))
+      return DateGenerator(Json.toNullableString(json["format"]), Json.toNullableString(json["expression"]))
     }
   }
 }
@@ -286,7 +286,7 @@ data class TimeGenerator @JvmOverloads constructor(val format: String? = null, v
 
   companion object {
     fun fromJson(json: JsonObject): TimeGenerator {
-      return TimeGenerator(Json.toString(json["format"]), Json.toString(json["expression"]))
+      return TimeGenerator(Json.toNullableString(json["format"]), Json.toNullableString(json["expression"]))
     }
   }
 }
@@ -323,7 +323,7 @@ data class DateTimeGenerator @JvmOverloads constructor(
 
   companion object {
     fun fromJson(json: JsonObject): DateTimeGenerator {
-      return DateTimeGenerator(Json.toString(json["format"]), Json.toString(json["expression"]))
+      return DateTimeGenerator(Json.toNullableString(json["format"]), Json.toNullableString(json["expression"]))
     }
   }
 }

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/DateGeneratorSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/DateGeneratorSpec.groovy
@@ -1,8 +1,11 @@
 package au.com.dius.pact.core.model.generators
 
+import au.com.dius.pact.core.support.Json
+import com.google.gson.JsonObject
 import spock.lang.Specification
 
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 class DateGeneratorSpec extends Specification {
 
@@ -18,6 +21,16 @@ class DateGeneratorSpec extends Specification {
     where:
 
     date << [ LocalDate.now().plusDays(1).format('yyyy-MM-dd') ]
+  }
+
+  def 'Uses json deserialization to work correctly with optional format fields'() {
+    given:
+    def map = [:]
+    def json = Json.INSTANCE.toJson(map)
+    def baseDate = OffsetDateTime.now()
+
+    expect:
+    DateGenerator.@Companion.fromJson((JsonObject)json).generate([baseDate: baseDate]) == baseDate.toString()
   }
 
 }

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/DateTimeGeneratorSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/DateTimeGeneratorSpec.groovy
@@ -1,5 +1,7 @@
 package au.com.dius.pact.core.model.generators
 
+import au.com.dius.pact.core.support.Json
+import com.google.gson.JsonObject
 import spock.lang.Specification
 
 import java.time.OffsetDateTime
@@ -23,4 +25,13 @@ class DateTimeGeneratorSpec extends Specification {
     datetime = base.plusDays(1).plusHours(1).format('yyyy-MM-dd\'T\'HH:mm:ssZ')
   }
 
+  def 'Uses json deserialization to work correctly with optional format fields'() {
+    given:
+    def map = [:]
+    def json = Json.INSTANCE.toJson(map)
+    def baseDateTime = OffsetDateTime.now()
+
+    expect:
+    DateTimeGenerator.@Companion.fromJson((JsonObject)json).generate([baseDateTime: baseDateTime]) == baseDateTime.toString()
+  }
 }

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/TimeGeneratorSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/generators/TimeGeneratorSpec.groovy
@@ -1,5 +1,7 @@
 package au.com.dius.pact.core.model.generators
 
+import au.com.dius.pact.core.support.Json
+import com.google.gson.JsonObject
 import spock.lang.Specification
 
 import java.time.OffsetDateTime
@@ -20,4 +22,12 @@ class TimeGeneratorSpec extends Specification {
     time = base.plusHours(1).format('HH:mm:ss')
   }
 
+  def 'Uses json deserialization to work correctly with optional format fields'() {
+    given:
+    def json = Json.INSTANCE.toJson([:])
+    def baseTime = OffsetDateTime.now()
+
+    expect:
+    TimeGenerator.@Companion.fromJson((JsonObject) json).generate([baseTime: baseTime]) == baseTime.toString()
+  }
 }

--- a/core/support/src/main/kotlin/au/com/dius/pact/core/support/Json.kt
+++ b/core/support/src/main/kotlin/au/com/dius/pact/core/support/Json.kt
@@ -53,8 +53,14 @@ object Json {
   /**
    * Converts a JSON object to a raw string if it is a string value, else just calls toString()
    */
-  fun toString(jsonElement: JsonElement?) = when {
-    jsonElement == null -> jsonNull.toString()
+  fun toString(jsonElement: JsonElement?): String = toNullableString(jsonElement) ?: jsonNull.toString()
+
+  /**
+   * Checks whether a JSON element is available and return null if jsonElement is null. Otherwise it would
+   * convert a JSON element to String
+   */
+  fun toNullableString(jsonElement: JsonElement?): String? = when {
+    jsonElement == null -> null
     jsonElement.isJsonPrimitive -> {
       val value = jsonElement.asJsonPrimitive
       when {


### PR DESCRIPTION
This bugfix will introduce a new function in `Json` object  called `toNullableString`that will return null when `JsonElement` is null.

This function will be used in `DateGenerator`, `TimeGenerator` and `DateTimeGenerator`.

Tests are included to show the behavior of parsing json without optional "format" arguments.