### PR TITLE
fix: JsonPrimitive comparison should accept "0" as decimal

### DIFF
--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/MatcherExecutor.kt
@@ -28,7 +28,7 @@ import java.text.ParseException
 
 private val logger = KotlinLogging.logger {}
 private val integerRegex = Regex("^\\d+$")
-private val decimalRegex = Regex("^\\d+\\.\\d*$")
+private val decimalRegex = Regex("^0|\\d+\\.\\d*$")
 
 fun valueOf(value: Any?): String {
   return when (value) {

--- a/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
+++ b/core/matchers/src/test/groovy/au/com/dius/pact/core/matchers/MatcherExecutorSpec.groovy
@@ -12,6 +12,7 @@ import au.com.dius.pact.core.model.matchingrules.TimeMatcher
 import au.com.dius.pact.core.model.matchingrules.TimestampMatcher
 import au.com.dius.pact.core.model.matchingrules.TypeMatcher
 import com.google.gson.JsonNull
+import com.google.gson.JsonPrimitive
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -246,17 +247,18 @@ class MatcherExecutorSpec extends Specification {
 
     where:
 
-    value             | result
-    '100'             | false
-    100               | false
-    100.0             | true
-    100.0 as float    | true
-    100.0 as double   | true
-    100 as int        | false
-    100 as long       | false
-    100 as BigInteger | false
-    BigInteger.ZERO   | false
-    BigDecimal.ZERO   | true
+    value                | result
+    new JsonPrimitive(0) | true
+    '100'                | false
+    100                  | false
+    100.0                | true
+    100.0 as float       | true
+    100.0 as double      | true
+    100 as int           | false
+    100 as long          | false
+    100 as BigInteger    | false
+    BigInteger.ZERO      | false
+    BigDecimal.ZERO      | true
   }
 
   @Unroll


### PR DESCRIPTION
This change makes decimal matching consistent for all types having zero as a value, similarly to the change for BigDecimal: https://github.com/DiUS/pact-jvm/commit/afba8a6a9b23e3cb0feed2738377ca63e16983dd