### PR TITLE
fix: handling stack trace properly of verification failure with excep…

### DIFF
--- a/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/JsonReporter.kt
+++ b/provider/pact-jvm-provider/src/main/kotlin/au/com/dius/pact/provider/reporters/JsonReporter.kt
@@ -263,7 +263,7 @@ class JsonReporter(
       "result" to FAILED,
       "exception" to jsonObject(
         "message" to e.message,
-        "stackTrace" to ExceptionUtils.getStackFrames(e)
+        "stackTrace" to jsonArray(*ExceptionUtils.getStackFrames(e))
     )
     )
   }


### PR DESCRIPTION
Hi,

I found some bug in 4.0.10 when provider wants to report verification failure with exception and its stacktraces:

```
[Ljava.lang.String;@153a925d cannot be converted to JSON
java.lang.IllegalArgumentException: [Ljava.lang.String;@153a925d cannot be converted to JSON
	at com.github.salomonbrys.kotson.BuilderKt.toJsonElement(Builder.kt:24)
	at com.github.salomonbrys.kotson.BuilderKt._jsonObject(Builder.kt:45)
	at com.github.salomonbrys.kotson.BuilderKt.jsonObject(Builder.kt:50)
	at au.com.dius.pact.provider.reporters.JsonReporter.verificationFailed(JsonReporter.kt:233)
	at au.com.dius.pact.provider.ProviderVerifier.verifyResponseByInvokingProviderMethods(ProviderVerifier.kt:311)
	at au.com.dius.pact.provider.junit5.PactVerificationContext.validateTestExecution(PactJUnit5VerificationProvider.kt:120)
	at au.com.dius.pact.provider.junit5.PactVerificationContext.verifyInteraction(PactJUnit5VerificationProvider.kt:83)
```