### PR TITLE
chore: fixed link in README

### DIFF
--- a/provider/junit/README.md
+++ b/provider/junit/README.md
@@ -168,7 +168,7 @@ for an example.
 #### Specify the additional classes on the test target
 
 You can provide the additional classes to the test target with the `withStateHandler` or `setStateHandlers` methods. See
-[BooksPactProviderTest](spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java) for an example. 
+[BooksPactProviderTest](../spring/src/test/java/au/com/dius/pact/provider/spring/BooksPactProviderTest.java) for an example. 
 
 ## Pact source
 


### PR DESCRIPTION
Fixed link to to BooksPactProviderTest in README.md for provider/junit