### PR TITLE
fix: Don't overwrite Pact with multiple interactions

### DIFF
--- a/consumer/junit5/build.gradle
+++ b/consumer/junit5/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   testCompile 'org.apache.commons:commons-io:1.3.2'
   testRuntime "org.junit.vintage:junit-vintage-engine:${project.junit5Version}"
   testRuntime "org.junit.jupiter:junit-jupiter-engine:${project.junit5Version}"
+  testCompile 'org.mockito:mockito-core:2.28.2'
   testCompile project(path: ":consumer:java8", configuration: 'default')
   testCompile 'org.hamcrest:hamcrest:2.1'
   testCompile('org.spockframework:spock-core:2.0-M2-groovy-3.0') {

--- a/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
+++ b/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
@@ -13,9 +13,10 @@ import au.com.dius.pact.consumer.mockServer
 import au.com.dius.pact.consumer.model.MockHttpsProviderConfig
 import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.core.model.BasePact
-import au.com.dius.pact.core.model.DefaultPactWriter
+import au.com.dius.pact.core.model.Consumer
 import au.com.dius.pact.core.model.Interaction
 import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.Provider
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
 import au.com.dius.pact.core.model.annotations.PactFolder
@@ -208,6 +209,7 @@ class PactConsumerTestExt : Extension, BeforeTestExecutionCallback, BeforeAllCal
   override fun beforeAll(context: ExtensionContext) {
     val store = context.getStore(NAMESPACE)
     store.put("executedFragments", mutableListOf<Method>())
+    store.put("pactsToWrite", mutableMapOf<Pair<Consumer, Provider>, Pair<BasePact<*>, PactSpecVersion>>())
   }
 
   override fun beforeTestExecution(context: ExtensionContext) {
@@ -341,32 +343,35 @@ class PactConsumerTestExt : Extension, BeforeTestExecutionCallback, BeforeAllCal
     if (!context.executionException.isPresent) {
       val store = context.getStore(NAMESPACE)
       val providerInfo = store["providerInfo"] as ProviderInfo
-      val pactDirectory = lookupPactDirectory(context)
-      if (providerInfo.providerType != ProviderType.ASYNCH) {
+      if (providerInfo.providerType == ProviderType.ASYNCH) {
+        storePactForWrite(store)
+      } else {
         val mockServer = store["mockServer"] as JUnit5MockServerSupport
-        val pact = store["pact"] as RequestResponsePact
-        val config = store["mockServerConfig"] as MockProviderConfig
         Thread.sleep(100) // give the mock server some time to have consistent state
         mockServer.close()
         val result = mockServer.validateMockServerState(null)
         if (result is PactVerificationResult.Ok) {
-          logger.debug {
-            "Writing pact ${pact.consumer.name} -> ${pact.provider.name} to file " +
-              "${pact.fileForPact(pactDirectory)}"
-          }
-          val pactFile = pact.fileForPact(pactDirectory)
-          DefaultPactWriter.writePact(pactFile, pact, config.pactVersion)
+          storePactForWrite(store)
         } else {
           JUnitTestSupport.validateMockServerResult(result)
         }
-      } else {
-        val pact = store["pact"] as MessagePact
-        logger.debug {
-          "Writing pact ${pact.consumer.name} -> ${pact.provider.name} to file " +
-            "${pact.fileForPact(pactDirectory)}"
-        }
-        pact.write(pactDirectory, PactSpecVersion.V3)
       }
+    }
+  }
+
+  private fun storePactForWrite(store: ExtensionContext.Store) {
+    @Suppress("UNCHECKED_CAST")
+    val pactsToWrite = store["pactsToWrite"] as MutableMap<Pair<Consumer, Provider>, Pair<BasePact<*>, PactSpecVersion>>
+    val pact = store["pact"] as BasePact<*>
+    val providerInfo = store["providerInfo"] as ProviderInfo
+    val version = providerInfo.pactVersion ?: PactSpecVersion.V3
+
+    pactsToWrite.merge(
+      Pair(pact.consumer, pact.provider),
+      Pair(pact, version)
+    ) { (currentPact, currentVersion), _ ->
+      currentPact.mergeInteractions(pact.interactions)
+      Pair(currentPact, maxOf(version, currentVersion))
     }
   }
 
@@ -381,6 +386,20 @@ class PactConsumerTestExt : Extension, BeforeTestExecutionCallback, BeforeAllCal
   override fun afterAll(context: ExtensionContext) {
     if (!context.executionException.isPresent) {
       val store = context.getStore(NAMESPACE)
+      val pactDirectory = lookupPactDirectory(context)
+
+      @Suppress("UNCHECKED_CAST")
+      val pactsToWrite =
+        store["pactsToWrite"] as MutableMap<Pair<Consumer, Provider>, Pair<BasePact<*>, PactSpecVersion>>
+      pactsToWrite.values
+        .forEach { (pact, version) ->
+          logger.debug {
+            "Writing pact ${pact.consumer.name} -> ${pact.provider.name} to file " +
+              "${pact.fileForPact(pactDirectory)}"
+          }
+          pact.write(pactDirectory, version)
+        }
+
       val executedFragments = store["executedFragments"] as MutableList<Method>
       val methods = AnnotationSupport.findAnnotatedMethods(context.requiredTestClass, Pact::class.java,
         HierarchyTraversalMode.TOP_DOWN)

--- a/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/PactConsumerTestExtSpec.groovy
+++ b/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/PactConsumerTestExtSpec.groovy
@@ -1,14 +1,22 @@
 package au.com.dius.pact.consumer.junit5
 
+import au.com.dius.pact.consumer.BaseMockServer
+import au.com.dius.pact.consumer.PactConsumerConfig
+import au.com.dius.pact.consumer.PactVerificationResult
+import au.com.dius.pact.consumer.model.MockProviderConfig
 import au.com.dius.pact.core.model.Consumer
 import au.com.dius.pact.core.model.PactSpecVersion
 import au.com.dius.pact.core.model.Provider
+import au.com.dius.pact.core.model.RequestResponseInteraction
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.messaging.MessagePact
+import groovy.json.JsonSlurper
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
+import org.mockito.Mockito
 import spock.lang.Specification
 import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
 
 @SuppressWarnings(['EmptyMethod', 'UnusedMethodParameter'])
 class PactConsumerTestExtSpec extends Specification {
@@ -44,6 +52,52 @@ class PactConsumerTestExtSpec extends Specification {
     model               | providerType        | testMethod
     RequestResponsePact | ProviderType.SYNCH  | 'testMethodRequestResponsePact'
     MessagePact         | ProviderType.ASYNCH | 'testMethodMessagePact'
+  }
+
+  @RestoreSystemProperties
+  def 'never overwrites Pacts defined within same class'() {
+    given:
+    System.setProperty('pact.writer.overwrite', 'true')
+
+    def mockServer = Mockito.mock(BaseMockServer)
+    Mockito.when(mockServer.validateMockServerState(Mockito.any())).then {
+      new PactVerificationResult.Ok()
+    }
+    def mockStore = [
+      'mockServer': new JUnit5MockServerSupport(mockServer),
+      'mockServerConfig': new MockProviderConfig(),
+      'providerInfo': new ProviderInfo()
+    ]
+    def mockContext = [
+      'getTestClass': { Optional.of(Object) },
+      'getExecutionException': { Optional.empty() },
+      'getStore': {
+        [
+          'get': { mockStore.get(it) },
+          'put': { k, v -> mockStore.put(k, v) }
+        ] as ExtensionContext.Store
+      }
+    ] as ExtensionContext
+
+    def provider = new Provider('provider')
+    def consumer = new Consumer('consumer')
+    def first = new RequestResponsePact(provider, consumer, [new RequestResponseInteraction('first')])
+    def second = new RequestResponsePact(provider, consumer, [new RequestResponseInteraction('second')])
+
+    when:
+    testExt.beforeAll(mockContext)
+    mockStore['pact'] = first  // normally set by testExt.resolveParameter()
+    testExt.afterTestExecution(mockContext)
+    mockStore['pact'] = second  // normally set by testExt.resolveParameter()
+    testExt.afterTestExecution(mockContext)
+    testExt.afterAll(mockContext)
+    def pactFile = new File("${PactConsumerConfig.pactDirectory}/consumer-provider.json")
+    def json = new JsonSlurper().parse(pactFile)
+
+    then:
+    json.metadata.pactSpecification.version == '3.0.0'
+    json.interactions[0].description == 'first'
+    json.interactions[1].description == 'second'
   }
 
 }


### PR DESCRIPTION
## Problem to Fix

Fixes a problem where only the last interaction defined for a Pact is written if `pact.writer.overwrite` is set to `true` when using JUnit 5 support for Pact consumer tests.

_It seems like the problem may also exist for JUnit 4, but it is not addressed here._

### Steps to reproduce

- Set `pact.writer.overwrite` system property to true
- Include two or more `@Pact` annotated methods to define different interactions for the same consumer and provider combination in a JUnit5 Pact consumer test.

### What is the current _bug_ behavior?

Pact will only include the interaction defined in the last `@Pact` method.

### What is the expected _correct_ behavior?

Pact contract should include all interactions defined in a single class, even when `pact.writer.overwrite` is `true`.

## Proposed Solution

Write Pacts at end during `afterAll` instead of after testing each interaction in `afterTestExecution`.  Saved each Pact in `store["pactsToWrite"]` and used `Pact::mergeInteractions` to combine different interactions.

### Unintended Consequences

This broke the `checkPactFile` test in `ProviderStateInjectedPactTest`, because the Pact file is now being written after this occurs.  To work-around, had to remove the `checkPactFile` method and moved each of its assertions elsewhere.  Moved the `generators` assertion to `articles` method within the same file.  Moved the version assertion to the new test in `PactConsumerTestExtSpec`.

## NOTICE

This software was produced for the U. S. Government under Contract No. FA8702-20-C-0001, and is subject to the Rights in Noncommercial Computer Software and Noncommercial Computer Software Documentation Clause DFARS 252.227-7014 (FEB 2014)

Approved for Public Release; Distribution Unlimited. Case Number 19-3203.

(c) 2020 The MITRE Corporation. All Rights Reserved.