### PR TITLE
maven-plugin: adds support to configure pact-publish via command line…

### DIFF
--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBaseMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBaseMojo.kt
@@ -8,22 +8,22 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest
 import org.apache.maven.settings.crypto.SettingsDecrypter
 
 abstract class PactBaseMojo : AbstractMojo() {
-  @Parameter
+  @Parameter(property = "pact.broker.url")
   protected var pactBrokerUrl: String? = null
 
-  @Parameter
+  @Parameter(property = "pact.broker.serverId")
   protected var pactBrokerServerId: String? = null
 
-  @Parameter
+  @Parameter(property = "pact.broker.token")
   protected var pactBrokerToken: String? = null
 
-  @Parameter
+  @Parameter(property = "pact.broker.username")
   protected var pactBrokerUsername: String? = null
 
-  @Parameter
+  @Parameter(property = "pact.broker.password")
   protected var pactBrokerPassword: String? = null
 
-  @Parameter(defaultValue = "basic")
+  @Parameter(defaultValue = "basic", property = "pact.broker.authenticationScheme")
   protected var pactBrokerAuthenticationScheme: String? = null
 
   @Parameter(defaultValue = "\${settings}", readonly = true)

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactPublishMojo.kt
@@ -18,13 +18,13 @@ open class PactPublishMojo : PactBaseMojo() {
     @Parameter(defaultValue = "false", expression = "\${skipPactPublish}")
     private var skipPactPublish: Boolean = false
 
-    @Parameter(required = true, defaultValue = "\${project.version}")
+    @Parameter(required = true, defaultValue = "\${project.version}", property = "pact.projectVersion")
     private lateinit var projectVersion: String
 
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "false", property = "pact.trimSnapshot")
     private var trimSnapshot: Boolean = false
 
-    @Parameter(defaultValue = "\${project.build.directory}/pacts")
+    @Parameter(defaultValue = "\${project.build.directory}/pacts", property = "pact.pactDirectory")
     private lateinit var pactDirectory: String
 
     private var brokerClient: PactBrokerClient? = null


### PR DESCRIPTION
we would like to use maven plugin to publish pacts to pact broker without adding the plugin to the pom..