### PR TITLE
Fix: Keep existing path on baseUrl

### DIFF
--- a/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/util/HttpClientUtils.kt
+++ b/core/pactbroker/src/main/kotlin/au/com/dius/pact/core/pactbroker/util/HttpClientUtils.kt
@@ -29,10 +29,19 @@ object HttpClientUtils {
       }
     } else {
       if (encodePath) {
-        URIBuilder(baseUrl).setPath(url).build()
+        val builder = URIBuilder(baseUrl)
+        pathCombiner(builder, url)
       } else {
         URI(baseUrl + url)
       }
+    }
+  }
+
+  fun pathCombiner(builder: URIBuilder, url: String): URI {
+    return if (builder.getPath() != null) {
+      builder.setPath(builder.getPath() + url).build()
+    } else {
+      builder.setPath(url).build()
     }
   }
 

--- a/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/util/HttpClientUtilsSpec.groovy
+++ b/core/pactbroker/src/test/groovy/au/com/dius/pact/core/pactbroker/util/HttpClientUtilsSpec.groovy
@@ -22,6 +22,7 @@ class HttpClientUtilsSpec extends Specification {
     'path with spaces'        | ''                      | '/path/with spaces'                      | '/path/with%20spaces'
     'Full URL with spaces'    | ''                      | 'http://localhost:1234/path/with spaces' | 'http://localhost:1234/path/with%20spaces'
     'no port'                 | 'http://localhost'      | '/path/with spaces'                      | 'http://localhost/path/with%20spaces'
+    'Extra path'              | 'http://localhost/sub'  | '/extraPath/with spaces'                 | 'http://localhost/sub/extraPath/with%20spaces'
   }
 
 }


### PR DESCRIPTION
Keep path on baseUrl when combining baseUrl and url instead of throwing it away.
Solves issue #1130