### PR TITLE
Fixing escaping typo that causes table to be misformatted

### DIFF
--- a/provider/maven/README.md
+++ b/provider/maven/README.md
@@ -260,7 +260,7 @@ The following plugin properties can be specified with `-Dproperty=value` on the 
 |`pact.verifier.disableUrlPathDecoding`|Disables decoding of request paths|
 |`pact.pactbroker.httpclient.usePreemptiveAuthentication`|Enables preemptive authentication with the pact broker when set to `true`|
 |`pact.consumer.tags`|Overrides the tags used when publishing pacts [version 4.0.7+]|
-|`pact.content_type.override.<TYPE>.<SUBTYPE>=text|binary`|Overrides the handling of a particular content type [version 4.1.3+]|
+|`pact.content_type.override.<TYPE>.<SUBTYPE>=text\|binary`|Overrides the handling of a particular content type [version 4.1.3+]|
 
 Example in the configuration section:
 


### PR DESCRIPTION
Diff

![image](https://user-images.githubusercontent.com/1585655/86330987-be9f4e80-bc48-11ea-9325-0a149dd8379a.png)
