### PR TITLE
fix: Omitting consumer version selectors should fall back to tags

### DIFF
--- a/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -720,16 +720,13 @@ class PactBrokerLoaderSpec extends Specification {
       loader.pactReader = mockReader
       loader
     }
-    def selectors = [
-      new ConsumerVersionSelector('latest', true)
-    ]
 
     when:
     def result = pactBrokerLoader().load('test')
 
     then:
     result == []
-    1 * brokerClient.fetchConsumersWithSelectors('test', selectors, [], false, '') >> new Ok([])
+    1 * brokerClient.fetchConsumersWithSelectors('test', [], [], false, '') >> new Ok([])
   }
 
   def 'configured from annotation with https and no port'() {
@@ -748,16 +745,13 @@ class PactBrokerLoaderSpec extends Specification {
       loader.pactReader = mockReader
       loader
     }
-    def selectors = [
-      new ConsumerVersionSelector('latest', true)
-    ]
 
     when:
     def result = pactBrokerLoader().load('test')
 
     then:
     result == []
-    1 * brokerClient.fetchConsumersWithSelectors('test', selectors, [], false, '') >> new Ok([])
+    1 * brokerClient.fetchConsumersWithSelectors('test', [], [], false, '') >> new Ok([])
   }
 
   def 'Auth: Uses no auth if no auth is provided'() {


### PR DESCRIPTION
Fixes #1157 

Tested locally with:
No tags, No consumer version selectors
Only tags, no version selectors
No tags, Only version selectors
Tags and version selectors (Should prefer version selectors)