### PR TITLE
Fixing link to ExampleMessageConsumerTest

### DIFF
--- a/consumer/junit/README.md
+++ b/consumer/junit/README.md
@@ -712,7 +712,7 @@ If you are using the `PactProviderRule`, you can pass the version into the const
 For testing a consumer of messages from a message queue, the `MessagePactProviderRule` rule class works in much the
 same way as the `PactProviderRule` class for Request-Response interactions, but will generate a V3 format message pact file.
 
-For an example, look at [ExampleMessageConsumerTest](src/test/java/au/com/dius/pact/consumer/v3%2FExampleMessageConsumerTest.java)
+For an example, look at [ExampleMessageConsumerTest](src/test/java/au/com/dius/pact/consumer/junit/v3/ExampleMessageConsumerTest.java)
 
 # Having values injected from provider state callbacks (3.6.11+)
 


### PR DESCRIPTION
The [current link for ExampleMessageConsumerTest](https://github.com/DiUS/pact-jvm/blob/7ff6491a0923e4709a8f78ab5451a99989559712/consumer/junit/src/test/java/au/com/dius/pact/consumer/v3%2FExampleMessageConsumerTest.java) leads to a 404 page.

The changed link will lead to the ExampleMessageConsumerTest file on the _master_ branch.

![image](https://user-images.githubusercontent.com/1585655/88037378-142e9300-cb45-11ea-9c7f-76ee55880a96.png)
