### PR TITLE
Feature/webflux support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
     return
   }
 
-  version = '4.1.8-SNAPSHOT'
+  version = '4.1.7'
   
   buildscript {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
     return
   }
 
-  version = '4.1.7'
+  version = '4.1.8-SNAPSHOT'
   
   buildscript {
     repositories {

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
   api project(path: ":provider:junit", configuration: 'default')
 
-  compile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.16.RELEASE'
-  compile group: 'org.springframework', name: 'spring-webmvc', version: '5.2.7.RELEASE'
-  compile group: 'org.springframework', name: 'spring-webflux', version: '5.2.7.RELEASE'
-  compile group: 'org.springframework', name: 'spring-test', version: '5.2.7.RELEASE'
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.2.5.RELEASE'
+  compile group: 'org.springframework', name: 'spring-webmvc', version: '5.2.3.RELEASE'
+  compile group: 'org.springframework', name: 'spring-webflux', version: '5.2.3.RELEASE'
+  compile group: 'org.springframework', name: 'spring-test', version: '5.2.3.RELEASE'
   compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.11.0'
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.10.2'
 
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.16.RELEASE'
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.2.5.RELEASE'
   testRuntime "org.junit.vintage:junit-vintage-engine:${project.junit5Version}"
   testCompile "org.codehaus.groovy:groovy:${project.groovyVersion}"
   testCompile('org.spockframework:spock-core:2.0-M2-groovy-3.0') {

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compile group: 'org.springframework', name: 'spring-test', version: '5.2.3.RELEASE'
   compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.10.2'
+  runtime group: 'org.synchronoss.cloud', name: 'nio-multipart-parser', version: '1.1.0'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.2.5.RELEASE'
   testRuntime "org.junit.vintage:junit-vintage-engine:${project.junit5Version}"

--- a/provider/spring/build.gradle
+++ b/provider/spring/build.gradle
@@ -2,9 +2,11 @@ dependencies {
   api project(path: ":provider:junit", configuration: 'default')
 
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.16.RELEASE'
-  compile group: 'org.springframework', name: 'spring-webmvc', version: '4.3.19.RELEASE'
+  compile group: 'org.springframework', name: 'spring-webmvc', version: '5.2.7.RELEASE'
+  compile group: 'org.springframework', name: 'spring-webflux', version: '5.2.7.RELEASE'
+  compile group: 'org.springframework', name: 'spring-test', version: '5.2.7.RELEASE'
   compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.6.4'
+  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.11.0'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.5.16.RELEASE'
   testRuntime "org.junit.vintage:junit-vintage-engine:${project.junit5Version}"

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/MvcProviderVerifier.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/MvcProviderVerifier.kt
@@ -50,7 +50,6 @@ open class MvcProviderVerifier(private val debugRequestResponse: Boolean = false
     interactionMessage: String,
     failures: MutableMap<String, Any>,
     mockMvc: MockMvc,
-    context: Map<String, Any>,
     pending: Boolean
   ): VerificationResult {
     return try {

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
@@ -1,0 +1,203 @@
+package au.com.dius.pact.provider.spring
+
+import au.com.dius.pact.core.model.ContentType
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.provider.ProviderClient
+import au.com.dius.pact.provider.ProviderInfo
+import au.com.dius.pact.provider.ProviderResponse
+import au.com.dius.pact.provider.ProviderVerifier
+import au.com.dius.pact.provider.VerificationFailureType
+import au.com.dius.pact.provider.VerificationResult
+import groovy.lang.Binding
+import groovy.lang.Closure
+import groovy.lang.GroovyShell
+import org.apache.commons.lang3.StringUtils
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
+import org.springframework.test.web.reactive.server.EntityExchangeResult
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.util.UriComponentsBuilder
+import scala.Function1
+import java.util.concurrent.Callable
+import java.util.function.Consumer
+import java.util.function.Function
+import javax.mail.internet.ContentDisposition
+import javax.mail.internet.MimeMultipart
+import javax.mail.util.ByteArrayDataSource
+
+class WebFluxProviderVerifier : ProviderVerifier() {
+
+    fun verifyResponseFromProvider(
+            provider: ProviderInfo,
+            interaction: RequestResponseInteraction,
+            interactionMessage: String,
+            failures: MutableMap<String, Any>,
+            webClient: WebTestClient,
+            pending: Boolean
+    ): VerificationResult {
+        return try {
+            val request = interaction.request
+
+            val clientResponse = executeWebFluxRequest(webClient, request, provider)
+
+            val expectedResponse = interaction.response
+            val actualResponse = handleResponse(clientResponse)
+
+            verifyRequestResponsePact(expectedResponse, actualResponse, interactionMessage, failures,
+                    interaction.interactionId.orEmpty(), false)
+        } catch (e: Exception) {
+            logger.error(e) { "Request to provider method failed" }
+
+            failures[interactionMessage] = e
+            reporters.forEach {
+                it.requestFailed(
+                        provider, interaction, interactionMessage,
+                        e, projectHasProperty.apply(PACT_SHOW_STACKTRACE)
+                )
+            }
+            return VerificationResult.Failed(
+                    listOf(mapOf("message" to "Request to provider method failed with an exception", "exception" to e)),
+                    "Request to provider method failed with an exception", interactionMessage,
+                    listOf(VerificationFailureType.ExceptionFailure(e)), pending, interaction.interactionId)
+        }
+    }
+
+    fun executeWebFluxRequest(
+            webTestClient: WebTestClient, request: Request, provider: ProviderInfo
+    ): EntityExchangeResult<ByteArray> {
+        val body = request.body
+
+        val builder = if (body.isPresent()) {
+            if (request.isMultipartFileUpload()) {
+                val multipart = MimeMultipart(ByteArrayDataSource(body.unwrap(), request.contentTypeHeader()))
+
+                val bodyBuilder = MultipartBodyBuilder()
+                var i = 0
+                while (i < multipart.count) {
+                    val bodyPart = multipart.getBodyPart(i)
+                    val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
+                    val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
+                    val filename = contentDisposition.getParameter("filename").orEmpty()
+
+                    bodyBuilder
+                            .part(name, bodyPart.content)
+                            .header("Content-Disposition", "form-data; name=$name; filename=$filename")
+
+                    i++
+                }
+
+                webTestClient
+                        .method(HttpMethod.POST)
+                        .uri(requestUriString(request))
+                        .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
+                        .headers { request.headers.forEach { k, v -> it.addAll(k, v) } }
+            } else {
+                webTestClient
+                        .method(HttpMethod.valueOf(request.method))
+                        .uri(requestUriString(request))
+                        .bodyValue(body.value!!)
+                        .headers {
+                            request.headers.forEach { k, v -> it.addAll(k, v) }
+                            if (!request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                                it.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                            }
+                        }
+
+            }
+        } else {
+            webTestClient
+                    .method(HttpMethod.valueOf(request.method))
+                    .uri(requestUriString(request))
+                    .headers {
+                        request.headers.forEach { k, v -> it.addAll(k, v) }
+                    }
+        }
+
+        executeRequestFilter(builder, provider)
+
+        val clientResponse = builder.exchange()
+
+        return clientResponse.expectBody().returnResult()
+    }
+
+    private fun executeRequestFilter(requestBuilder: WebTestClient.RequestHeadersSpec<*>, provider: ProviderInfo) {
+        val requestFilter = provider.requestFilter
+        if (requestFilter != null) {
+            when (requestFilter) {
+                is Closure<*> -> requestFilter.call(requestBuilder)
+                is Function1<*, *> ->
+                    (requestFilter as Function1<WebTestClient.RequestHeadersSpec<*>, *>).apply(requestBuilder)
+                is org.apache.commons.collections4.Closure<*> ->
+                    (requestFilter as org.apache.commons.collections4.Closure<Any>).execute(requestBuilder)
+                else -> {
+                    if (ProviderClient.isFunctionalInterface(requestFilter)) {
+                        invokeJavaFunctionalInterface(requestFilter, requestBuilder)
+                    } else {
+                        val binding = Binding()
+                        binding.setVariable(ProviderClient.REQUEST, requestBuilder)
+                        val shell = GroovyShell(binding)
+                        shell.evaluate(requestFilter as String)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun invokeJavaFunctionalInterface(
+            functionalInterface: Any, requestBuilder: WebTestClient.RequestHeadersSpec<*>
+    ) {
+        when (functionalInterface) {
+            is Consumer<*> ->
+                (functionalInterface as Consumer<WebTestClient.RequestHeadersSpec<*>>).accept(requestBuilder)
+            is Function<*, *> ->
+                (functionalInterface as Function<WebTestClient.RequestHeadersSpec<*>, Any?>).apply(requestBuilder)
+            is Callable<*> ->
+                (functionalInterface as Callable<WebTestClient.RequestHeadersSpec<*>>).call()
+            else -> throw IllegalArgumentException(
+                    "Java request filters must be either a Consumer or Function that " +
+                    "takes at least one WebTestClient.RequestHeadersSpec<*> parameter")
+        }
+    }
+
+    fun requestUriString(request: Request): String {
+        val uriBuilder = UriComponentsBuilder.fromPath(request.path)
+
+        request.query.forEach { (key, value) ->
+            uriBuilder.queryParam(key, value)
+        }
+
+        return uriBuilder.toUriString()
+    }
+
+    fun handleResponse(exchangeResult: EntityExchangeResult<ByteArray>): ProviderResponse {
+        logger.debug { "Received response: ${exchangeResult.status}" }
+
+        val headers = mutableMapOf<String, List<String>>()
+        exchangeResult.responseHeaders.forEach { header ->
+            headers[header.key] = header.value
+        }
+
+        val contentTypeHeader = exchangeResult.responseHeaders.contentType
+        val contentType = if (contentTypeHeader == null) {
+            ContentType.JSON
+        } else {
+            ContentType.fromString(contentTypeHeader.toString())
+        }
+
+        val response = ProviderResponse(
+                exchangeResult.status.value(),
+                headers,
+                contentType,
+                exchangeResult.responseBody?.let { String(it) }
+        )
+
+        logger.debug { "Response: $response" }
+
+        return response
+    }
+
+}

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
@@ -87,6 +87,8 @@ class WebFluxProviderVerifier : ProviderVerifier() {
 
           bodyBuilder
             .part(name, bodyPart.content)
+            .filename(filename)
+            .contentType(MediaType.valueOf(bodyPart.contentType))
             .header("Content-Disposition", "form-data; name=$name; filename=$filename")
 
           i++
@@ -120,9 +122,9 @@ class WebFluxProviderVerifier : ProviderVerifier() {
 
     executeRequestFilter(builder, provider)
 
-    val clientResponse = builder.exchange()
+    val exchangeResult = builder.exchange()
 
-    return clientResponse.expectBody().returnResult()
+    return exchangeResult.expectBody().returnResult()
   }
 
   private fun executeRequestFilter(requestBuilder: WebTestClient.RequestHeadersSpec<*>, provider: ProviderInfo) {

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
@@ -31,173 +31,174 @@ import javax.mail.util.ByteArrayDataSource
 
 class WebFluxProviderVerifier : ProviderVerifier() {
 
-    fun verifyResponseFromProvider(
-            provider: ProviderInfo,
-            interaction: RequestResponseInteraction,
-            interactionMessage: String,
-            failures: MutableMap<String, Any>,
-            webClient: WebTestClient,
-            pending: Boolean
-    ): VerificationResult {
-        return try {
-            val request = interaction.request
+  fun verifyResponseFromProvider(
+    provider: ProviderInfo,
+    interaction: RequestResponseInteraction,
+    interactionMessage: String,
+    failures: MutableMap<String, Any>,
+    webClient: WebTestClient,
+    pending: Boolean
+  ): VerificationResult {
+    return try {
+      val request = interaction.request
 
-            val clientResponse = executeWebFluxRequest(webClient, request, provider)
+      val clientResponse = executeWebFluxRequest(webClient, request, provider)
 
-            val expectedResponse = interaction.response
-            val actualResponse = handleResponse(clientResponse)
+      val expectedResponse = interaction.response
+      val actualResponse = handleResponse(clientResponse)
 
-            verifyRequestResponsePact(expectedResponse, actualResponse, interactionMessage, failures,
-                    interaction.interactionId.orEmpty(), false)
-        } catch (e: Exception) {
-            logger.error(e) { "Request to provider method failed" }
+      verifyRequestResponsePact(expectedResponse, actualResponse, interactionMessage, failures,
+        interaction.interactionId.orEmpty(), false)
+    } catch (e: Exception) {
+      logger.error(e) { "Request to provider method failed" }
 
-            failures[interactionMessage] = e
-            reporters.forEach {
-                it.requestFailed(
-                        provider, interaction, interactionMessage,
-                        e, projectHasProperty.apply(PACT_SHOW_STACKTRACE)
-                )
-            }
-            return VerificationResult.Failed(
-                    listOf(mapOf("message" to "Request to provider method failed with an exception", "exception" to e)),
-                    "Request to provider method failed with an exception", interactionMessage,
-                    listOf(VerificationFailureType.ExceptionFailure(e)), pending, interaction.interactionId)
-        }
-    }
-
-    fun executeWebFluxRequest(
-            webTestClient: WebTestClient, request: Request, provider: ProviderInfo
-    ): EntityExchangeResult<ByteArray> {
-        val body = request.body
-
-        val builder = if (body.isPresent()) {
-            if (request.isMultipartFileUpload()) {
-                val multipart = MimeMultipart(ByteArrayDataSource(body.unwrap(), request.contentTypeHeader()))
-
-                val bodyBuilder = MultipartBodyBuilder()
-                var i = 0
-                while (i < multipart.count) {
-                    val bodyPart = multipart.getBodyPart(i)
-                    val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
-                    val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
-                    val filename = contentDisposition.getParameter("filename").orEmpty()
-
-                    bodyBuilder
-                            .part(name, bodyPart.content)
-                            .header("Content-Disposition", "form-data; name=$name; filename=$filename")
-
-                    i++
-                }
-
-                webTestClient
-                        .method(HttpMethod.POST)
-                        .uri(requestUriString(request))
-                        .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
-                        .headers { request.headers.forEach { k, v -> it.addAll(k, v) } }
-            } else {
-                webTestClient
-                        .method(HttpMethod.valueOf(request.method))
-                        .uri(requestUriString(request))
-                        .bodyValue(body.value!!)
-                        .headers {
-                            request.headers.forEach { k, v -> it.addAll(k, v) }
-                            if (!request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
-                                it.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                            }
-                        }
-
-            }
-        } else {
-            webTestClient
-                    .method(HttpMethod.valueOf(request.method))
-                    .uri(requestUriString(request))
-                    .headers {
-                        request.headers.forEach { k, v -> it.addAll(k, v) }
-                    }
-        }
-
-        executeRequestFilter(builder, provider)
-
-        val clientResponse = builder.exchange()
-
-        return clientResponse.expectBody().returnResult()
-    }
-
-    private fun executeRequestFilter(requestBuilder: WebTestClient.RequestHeadersSpec<*>, provider: ProviderInfo) {
-        val requestFilter = provider.requestFilter
-        if (requestFilter != null) {
-            when (requestFilter) {
-                is Closure<*> -> requestFilter.call(requestBuilder)
-                is Function1<*, *> ->
-                    (requestFilter as Function1<WebTestClient.RequestHeadersSpec<*>, *>).apply(requestBuilder)
-                is org.apache.commons.collections4.Closure<*> ->
-                    (requestFilter as org.apache.commons.collections4.Closure<Any>).execute(requestBuilder)
-                else -> {
-                    if (ProviderClient.isFunctionalInterface(requestFilter)) {
-                        invokeJavaFunctionalInterface(requestFilter, requestBuilder)
-                    } else {
-                        val binding = Binding()
-                        binding.setVariable(ProviderClient.REQUEST, requestBuilder)
-                        val shell = GroovyShell(binding)
-                        shell.evaluate(requestFilter as String)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun invokeJavaFunctionalInterface(
-            functionalInterface: Any, requestBuilder: WebTestClient.RequestHeadersSpec<*>
-    ) {
-        when (functionalInterface) {
-            is Consumer<*> ->
-                (functionalInterface as Consumer<WebTestClient.RequestHeadersSpec<*>>).accept(requestBuilder)
-            is Function<*, *> ->
-                (functionalInterface as Function<WebTestClient.RequestHeadersSpec<*>, Any?>).apply(requestBuilder)
-            is Callable<*> ->
-                (functionalInterface as Callable<WebTestClient.RequestHeadersSpec<*>>).call()
-            else -> throw IllegalArgumentException(
-                    "Java request filters must be either a Consumer or Function that " +
-                    "takes at least one WebTestClient.RequestHeadersSpec<*> parameter")
-        }
-    }
-
-    fun requestUriString(request: Request): String {
-        val uriBuilder = UriComponentsBuilder.fromPath(request.path)
-
-        request.query.forEach { (key, value) ->
-            uriBuilder.queryParam(key, value)
-        }
-
-        return uriBuilder.toUriString()
-    }
-
-    fun handleResponse(exchangeResult: EntityExchangeResult<ByteArray>): ProviderResponse {
-        logger.debug { "Received response: ${exchangeResult.status}" }
-
-        val headers = mutableMapOf<String, List<String>>()
-        exchangeResult.responseHeaders.forEach { header ->
-            headers[header.key] = header.value
-        }
-
-        val contentTypeHeader = exchangeResult.responseHeaders.contentType
-        val contentType = if (contentTypeHeader == null) {
-            ContentType.JSON
-        } else {
-            ContentType.fromString(contentTypeHeader.toString())
-        }
-
-        val response = ProviderResponse(
-                exchangeResult.status.value(),
-                headers,
-                contentType,
-                exchangeResult.responseBody?.let { String(it) }
+      failures[interactionMessage] = e
+      reporters.forEach {
+        it.requestFailed(
+          provider, interaction, interactionMessage,
+          e, projectHasProperty.apply(PACT_SHOW_STACKTRACE)
         )
+      }
+      return VerificationResult.Failed(
+        listOf(mapOf("message" to "Request to provider method failed with an exception", "exception" to e)),
+        "Request to provider method failed with an exception", interactionMessage,
+        listOf(VerificationFailureType.ExceptionFailure(e)), pending, interaction.interactionId)
+    }
+  }
 
-        logger.debug { "Response: $response" }
+  fun executeWebFluxRequest(
+    webTestClient: WebTestClient,
+    request: Request,
+    provider: ProviderInfo
+  ): EntityExchangeResult<ByteArray> {
+    val body = request.body
 
-        return response
+    val builder = if (body.isPresent()) {
+      if (request.isMultipartFileUpload()) {
+        val multipart = MimeMultipart(ByteArrayDataSource(body.unwrap(), request.contentTypeHeader()))
+
+        val bodyBuilder = MultipartBodyBuilder()
+        var i = 0
+        while (i < multipart.count) {
+          val bodyPart = multipart.getBodyPart(i)
+          val contentDisposition = ContentDisposition(bodyPart.getHeader("Content-Disposition").first())
+          val name = StringUtils.defaultString(contentDisposition.getParameter("name"), "file")
+          val filename = contentDisposition.getParameter("filename").orEmpty()
+
+          bodyBuilder
+            .part(name, bodyPart.content)
+            .header("Content-Disposition", "form-data; name=$name; filename=$filename")
+
+          i++
+        }
+
+        webTestClient
+          .method(HttpMethod.POST)
+          .uri(requestUriString(request))
+          .body(BodyInserters.fromMultipartData(bodyBuilder.build()))
+          .headers { request.headers.forEach { k, v -> it.addAll(k, v) } }
+      } else {
+        webTestClient
+          .method(HttpMethod.valueOf(request.method))
+          .uri(requestUriString(request))
+          .bodyValue(body.value!!)
+          .headers {
+            request.headers.forEach { k, v -> it.addAll(k, v) }
+            if (!request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+              it.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            }
+          }
+      }
+    } else {
+      webTestClient
+        .method(HttpMethod.valueOf(request.method))
+        .uri(requestUriString(request))
+        .headers {
+          request.headers.forEach { k, v -> it.addAll(k, v) }
+        }
     }
 
+    executeRequestFilter(builder, provider)
+
+    val clientResponse = builder.exchange()
+
+    return clientResponse.expectBody().returnResult()
+  }
+
+  private fun executeRequestFilter(requestBuilder: WebTestClient.RequestHeadersSpec<*>, provider: ProviderInfo) {
+    val requestFilter = provider.requestFilter
+    if (requestFilter != null) {
+      when (requestFilter) {
+        is Closure<*> -> requestFilter.call(requestBuilder)
+        is Function1<*, *> ->
+          (requestFilter as Function1<WebTestClient.RequestHeadersSpec<*>, *>).apply(requestBuilder)
+        is org.apache.commons.collections4.Closure<*> ->
+          (requestFilter as org.apache.commons.collections4.Closure<Any>).execute(requestBuilder)
+        else -> {
+          if (ProviderClient.isFunctionalInterface(requestFilter)) {
+            invokeJavaFunctionalInterface(requestFilter, requestBuilder)
+          } else {
+            val binding = Binding()
+            binding.setVariable(ProviderClient.REQUEST, requestBuilder)
+            val shell = GroovyShell(binding)
+            shell.evaluate(requestFilter as String)
+          }
+        }
+      }
+    }
+  }
+
+  private fun invokeJavaFunctionalInterface(
+    functionalInterface: Any,
+    requestBuilder: WebTestClient.RequestHeadersSpec<*>
+  ) {
+    when (functionalInterface) {
+      is Consumer<*> ->
+        (functionalInterface as Consumer<WebTestClient.RequestHeadersSpec<*>>).accept(requestBuilder)
+      is Function<*, *> ->
+        (functionalInterface as Function<WebTestClient.RequestHeadersSpec<*>, Any?>).apply(requestBuilder)
+      is Callable<*> ->
+        (functionalInterface as Callable<WebTestClient.RequestHeadersSpec<*>>).call()
+      else -> throw IllegalArgumentException(
+        "Java request filters must be either a Consumer or Function that " +
+          "takes at least one WebTestClient.RequestHeadersSpec<*> parameter")
+    }
+  }
+
+  fun requestUriString(request: Request): String {
+    val uriBuilder = UriComponentsBuilder.fromPath(request.path)
+
+    request.query.forEach { (key, value) ->
+      uriBuilder.queryParam(key, value)
+    }
+
+    return uriBuilder.toUriString()
+  }
+
+  fun handleResponse(exchangeResult: EntityExchangeResult<ByteArray>): ProviderResponse {
+    logger.debug { "Received response: ${exchangeResult.status}" }
+
+    val headers = mutableMapOf<String, List<String>>()
+    exchangeResult.responseHeaders.forEach { header ->
+      headers[header.key] = header.value
+    }
+
+    val contentTypeHeader = exchangeResult.responseHeaders.contentType
+    val contentType = if (contentTypeHeader == null) {
+      ContentType.JSON
+    } else {
+      ContentType.fromString(contentTypeHeader.toString())
+    }
+
+    val response = ProviderResponse(
+      exchangeResult.status.value(),
+      headers,
+      contentType,
+      exchangeResult.responseBody?.let { String(it) }
+    )
+
+    logger.debug { "Response: $response" }
+
+    return response
+  }
 }

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/WebFluxProviderVerifier.kt
@@ -150,13 +150,13 @@ class WebFluxProviderVerifier : ProviderVerifier() {
 
   private fun invokeJavaFunctionalInterface(
     functionalInterface: Any,
-    requestBuilder: WebTestClient.RequestHeadersSpec<*>
+    headersSpec: WebTestClient.RequestHeadersSpec<*>
   ) {
     when (functionalInterface) {
       is Consumer<*> ->
-        (functionalInterface as Consumer<WebTestClient.RequestHeadersSpec<*>>).accept(requestBuilder)
+        (functionalInterface as Consumer<WebTestClient.RequestHeadersSpec<*>>).accept(headersSpec)
       is Function<*, *> ->
-        (functionalInterface as Function<WebTestClient.RequestHeadersSpec<*>, Any?>).apply(requestBuilder)
+        (functionalInterface as Function<WebTestClient.RequestHeadersSpec<*>, Any?>).apply(headersSpec)
       is Callable<*> ->
         (functionalInterface as Callable<WebTestClient.RequestHeadersSpec<*>>).call()
       else -> throw IllegalArgumentException(

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/MockTestingTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/MockTestingTarget.kt
@@ -1,0 +1,109 @@
+package au.com.dius.pact.provider.spring.target
+
+import au.com.dius.pact.core.model.Interaction
+import au.com.dius.pact.core.model.PactSource
+import au.com.dius.pact.provider.IConsumerInfo
+import au.com.dius.pact.provider.IProviderInfo
+import au.com.dius.pact.provider.IProviderVerifier
+import au.com.dius.pact.provider.ProviderInfo
+import au.com.dius.pact.provider.ProviderVerifier
+import au.com.dius.pact.provider.PactVerification
+import au.com.dius.pact.provider.VerificationResult
+import au.com.dius.pact.provider.junit.target.BaseTarget
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.TargetRequestFilter
+import java.net.URLClassLoader
+import java.util.function.Consumer
+import java.util.function.Supplier
+
+abstract class MockTestingTarget(
+  var runTimes: Int
+) : BaseTarget() {
+
+  override fun getProviderInfo(source: PactSource): ProviderInfo {
+    val provider = testClass.getAnnotation(Provider::class.java)
+    val providerInfo = ProviderInfo(provider.value)
+
+    val methods = testClass.getAnnotatedMethods(TargetRequestFilter::class.java)
+    if (methods.isNotEmpty()) {
+      validateTargetRequestFilters(methods)
+      providerInfo.requestFilter = Consumer<Any> { httpRequest ->
+        methods.forEach { method ->
+          try {
+            method.invokeExplosively(testTarget, httpRequest)
+          } catch (t: Throwable) {
+            throw AssertionError("Request filter method ${method.name} failed with an exception", t)
+          }
+        }
+      }
+    }
+
+    return providerInfo
+  }
+
+  override fun setupVerifier(
+    interaction: Interaction,
+    provider: IProviderInfo,
+    consumer: IConsumerInfo,
+    pactSource: PactSource?
+  ): IProviderVerifier {
+    var verifier = createProviderVerifier()
+
+    setupReporters(verifier)
+
+    verifier.projectClasspath = Supplier { (ClassLoader.getSystemClassLoader() as URLClassLoader).urLs.toList() }
+
+    verifier.initialiseReporters(provider)
+    verifier.reportVerificationForConsumer(consumer, provider, pactSource)
+
+    if (interaction.providerStates.isNotEmpty()) {
+      for ((name) in interaction.providerStates) {
+        verifier.reportStateForInteraction(name.toString(), provider, consumer, true)
+      }
+    }
+
+    verifier.reportInteractionDescription(interaction)
+
+    return verifier
+  }
+
+  protected fun doTestInteraction(
+    consumerName: String,
+    interaction: Interaction,
+    source: PactSource,
+    callVerifierFn: (
+      provider: ProviderInfo,
+      consumer: IConsumerInfo,
+      verifier: IProviderVerifier,
+      failures: HashMap<String, Any>
+    ) -> VerificationResult
+  ) {
+    val provider = getProviderInfo(source)
+    val consumer = consumerInfo(consumerName, source)
+    provider.verificationType = PactVerification.ANNOTATED_METHOD
+
+    val verifier = setupVerifier(interaction, provider, consumer, source)
+
+    val failures = HashMap<String, Any>()
+
+    val results = 1.rangeTo(runTimes).map {
+      callVerifierFn(provider, consumer, verifier, failures)
+    }
+
+    val result = results.fold(VerificationResult.Ok) { acc: VerificationResult, r -> acc.merge(r) }
+
+    reportTestResult(result, verifier)
+
+    try {
+      if (result is VerificationResult.Failed) {
+        val errors = results.filterIsInstance<VerificationResult.Failed>()
+        verifier.displayFailures(errors)
+        throw AssertionError(verifier.generateErrorStringFromVerificationResult(errors))
+      }
+    } finally {
+      verifier.finaliseReports()
+    }
+  }
+
+  abstract fun createProviderVerifier(): ProviderVerifier
+}

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
@@ -88,11 +88,11 @@ class WebFluxTarget(
     val failures = HashMap<String, Any>()
 
     val results = 1.rangeTo(runTimes).map {
-      val webTestClientBuilder = WebTestClient.bindToRouterFunction(routerFunction).build()
+      val webClient = WebTestClient.bindToRouterFunction(routerFunction).build()
 
       verifier.verifyResponseFromProvider(
         provider, interaction as RequestResponseInteraction, interaction.description,
-        failures, webTestClientBuilder, consumer.pending
+        failures, webClient, consumer.pending
       )
     }
     val result = results.fold(VerificationResult.Ok) { acc: VerificationResult, r -> acc.merge(r) }

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
@@ -3,75 +3,16 @@ package au.com.dius.pact.provider.spring.target
 import au.com.dius.pact.core.model.Interaction
 import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.model.RequestResponseInteraction
-import au.com.dius.pact.provider.IConsumerInfo
-import au.com.dius.pact.provider.IProviderInfo
-import au.com.dius.pact.provider.IProviderVerifier
-import au.com.dius.pact.provider.PactVerification
-import au.com.dius.pact.provider.ProviderInfo
-import au.com.dius.pact.provider.VerificationResult
-import au.com.dius.pact.provider.junit.target.BaseTarget
-import au.com.dius.pact.provider.junitsupport.Provider
-import au.com.dius.pact.provider.junitsupport.TargetRequestFilter
 import au.com.dius.pact.provider.spring.WebFluxProviderVerifier
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import java.net.URLClassLoader
-import java.util.function.Consumer
-import java.util.function.Supplier
 
 class WebFluxTarget(
-  var runTimes: Int = 1
-) : BaseTarget() {
+  runTimes: Int = 1
+) : MockTestingTarget(runTimes) {
 
   lateinit var routerFunction: RouterFunction<out ServerResponse>
-
-  override fun getProviderInfo(source: PactSource): ProviderInfo {
-    val provider = testClass.getAnnotation(Provider::class.java)
-    val providerInfo = ProviderInfo(provider.value)
-
-    val methods = testClass.getAnnotatedMethods(TargetRequestFilter::class.java)
-    if (methods.isNotEmpty()) {
-      validateTargetRequestFilters(methods)
-      providerInfo.requestFilter = Consumer<Any> { httpRequest ->
-        methods.forEach { method ->
-          try {
-            method.invokeExplosively(testTarget, httpRequest)
-          } catch (t: Throwable) {
-            throw AssertionError("Request filter method ${method.name} failed with an exception", t)
-          }
-        }
-      }
-    }
-
-    return providerInfo
-  }
-
-  override fun setupVerifier(
-    interaction: Interaction,
-    provider: IProviderInfo,
-    consumer: IConsumerInfo,
-    pactSource: PactSource?
-  ): IProviderVerifier {
-    var verifier = WebFluxProviderVerifier()
-
-    setupReporters(verifier)
-
-    verifier.projectClasspath = Supplier { (ClassLoader.getSystemClassLoader() as URLClassLoader).urLs.toList() }
-
-    verifier.initialiseReporters(provider)
-    verifier.reportVerificationForConsumer(consumer, provider, pactSource)
-
-    if (interaction.providerStates.isNotEmpty()) {
-      for ((name) in interaction.providerStates) {
-        verifier.reportStateForInteraction(name.toString(), provider, consumer, true)
-      }
-    }
-
-    verifier.reportInteractionDescription(interaction)
-
-    return verifier
-  }
 
   override fun testInteraction(
     consumerName: String,
@@ -79,36 +20,17 @@ class WebFluxTarget(
     source: PactSource,
     context: Map<String, Any>
   ) {
-    val provider = getProviderInfo(source)
-    val consumer = consumerInfo(consumerName, source)
-    provider.verificationType = PactVerification.ANNOTATED_METHOD
-
-    val verifier = setupVerifier(interaction, provider, consumer, source) as WebFluxProviderVerifier
-
-    val failures = HashMap<String, Any>()
-
-    val results = 1.rangeTo(runTimes).map {
+    doTestInteraction(consumerName, interaction, source) { provider, consumer, verifier, failures ->
       val webClient = WebTestClient.bindToRouterFunction(routerFunction).build()
-
-      verifier.verifyResponseFromProvider(
+      val webFluxProviderVerifier = verifier as WebFluxProviderVerifier
+      webFluxProviderVerifier.verifyResponseFromProvider(
         provider, interaction as RequestResponseInteraction, interaction.description,
         failures, webClient, consumer.pending
       )
     }
-    val result = results.fold(VerificationResult.Ok) { acc: VerificationResult, r -> acc.merge(r) }
-
-    reportTestResult(result, verifier)
-
-    try {
-      if (result is VerificationResult.Failed) {
-        val errors = results.filterIsInstance<VerificationResult.Failed>()
-        verifier.displayFailures(errors)
-        throw AssertionError(verifier.generateErrorStringFromVerificationResult(errors))
-      }
-    } finally {
-      verifier.finaliseReports()
-    }
   }
 
   override fun getRequestClass(): Class<*> = WebTestClient.RequestHeadersSpec::class.java
+
+  override fun createProviderVerifier() = WebFluxProviderVerifier()
 }

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
@@ -109,4 +109,6 @@ class WebFluxTarget(
       verifier.finaliseReports()
     }
   }
+
+  override fun getRequestClass(): Class<*> = WebTestClient.RequestHeadersSpec::class.java
 }

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
@@ -6,13 +6,13 @@ import au.com.dius.pact.core.model.RequestResponseInteraction
 import au.com.dius.pact.provider.spring.WebFluxProviderVerifier
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.function.server.RouterFunction
-import org.springframework.web.reactive.function.server.ServerResponse
 
 class WebFluxTarget(
   runTimes: Int = 1
 ) : MockTestingTarget(runTimes) {
 
-  lateinit var routerFunction: RouterFunction<out ServerResponse>
+  var controllers = listOf<Any>()
+  var routerFunction: RouterFunction<*>? = null
 
   override fun testInteraction(
     consumerName: String,
@@ -21,7 +21,9 @@ class WebFluxTarget(
     context: Map<String, Any>
   ) {
     doTestInteraction(consumerName, interaction, source) { provider, consumer, verifier, failures ->
-      val webClient = WebTestClient.bindToRouterFunction(routerFunction).build()
+      val webClient = routerFunction?.let {
+        WebTestClient.bindToRouterFunction(routerFunction).build()
+      } ?: WebTestClient.bindToController(*controllers.toTypedArray()).build()
       val webFluxProviderVerifier = verifier as WebFluxProviderVerifier
       webFluxProviderVerifier.verifyResponseFromProvider(
         provider, interaction as RequestResponseInteraction, interaction.description,

--- a/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
+++ b/provider/spring/src/main/kotlin/au/com/dius/pact/provider/spring/target/WebFluxTarget.kt
@@ -1,0 +1,113 @@
+package au.com.dius.pact.provider.spring.target;
+
+import au.com.dius.pact.core.model.Interaction
+import au.com.dius.pact.core.model.PactSource
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.provider.IConsumerInfo
+import au.com.dius.pact.provider.IProviderInfo
+import au.com.dius.pact.provider.IProviderVerifier
+import au.com.dius.pact.provider.PactVerification
+import au.com.dius.pact.provider.ProviderInfo
+import au.com.dius.pact.provider.VerificationResult
+import au.com.dius.pact.provider.junit.target.BaseTarget
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.TargetRequestFilter
+import au.com.dius.pact.provider.spring.WebFluxProviderVerifier
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import java.net.URLClassLoader
+import java.util.function.Consumer
+import java.util.function.Supplier
+
+class WebFluxTarget(
+        var runTimes: Int = 1
+) : BaseTarget() {
+
+    lateinit var routerFunction: RouterFunction<out ServerResponse>
+
+    override fun getProviderInfo(source: PactSource): ProviderInfo {
+        val provider = testClass.getAnnotation(Provider::class.java)
+        val providerInfo = ProviderInfo(provider.value)
+
+        val methods = testClass.getAnnotatedMethods(TargetRequestFilter::class.java)
+        if (methods.isNotEmpty()) {
+            validateTargetRequestFilters(methods)
+            providerInfo.requestFilter = Consumer<Any> { httpRequest ->
+                methods.forEach { method ->
+                    try {
+                        method.invokeExplosively(testTarget, httpRequest)
+                    } catch (t: Throwable) {
+                        throw AssertionError("Request filter method ${method.name} failed with an exception", t)
+                    }
+                }
+            }
+        }
+
+        return providerInfo
+    }
+
+    override fun setupVerifier(
+            interaction: Interaction,
+            provider: IProviderInfo,
+            consumer: IConsumerInfo,
+            pactSource: PactSource?
+    ): IProviderVerifier {
+        var verifier = WebFluxProviderVerifier()
+
+        setupReporters(verifier)
+
+        verifier.projectClasspath = Supplier { (ClassLoader.getSystemClassLoader() as URLClassLoader).urLs.toList() }
+
+        verifier.initialiseReporters(provider)
+        verifier.reportVerificationForConsumer(consumer, provider, pactSource)
+
+        if (interaction.providerStates.isNotEmpty()) {
+            for ((name) in interaction.providerStates) {
+                verifier.reportStateForInteraction(name.toString(), provider, consumer, true)
+            }
+        }
+
+        verifier.reportInteractionDescription(interaction)
+
+        return verifier
+    }
+
+    override fun testInteraction(
+            consumerName: String,
+            interaction: Interaction,
+            source: PactSource,
+            context: Map<String, Any>
+    ) {
+        val provider = getProviderInfo(source)
+        val consumer = consumerInfo(consumerName, source)
+        provider.verificationType = PactVerification.ANNOTATED_METHOD
+
+        val verifier = setupVerifier(interaction, provider, consumer, source) as WebFluxProviderVerifier
+
+        val failures = HashMap<String, Any>()
+
+        val results = 1.rangeTo(runTimes).map {
+            val webTestClientBuilder = WebTestClient.bindToRouterFunction(routerFunction).build()
+
+            verifier.verifyResponseFromProvider(
+                    provider, interaction as RequestResponseInteraction, interaction.description,
+                    failures, webTestClientBuilder, consumer.pending
+            )
+        }
+        val result = results.fold(VerificationResult.Ok) { acc: VerificationResult, r -> acc.merge(r) }
+
+        reportTestResult(result, verifier)
+
+        try {
+            if (result is VerificationResult.Failed) {
+                val errors = results.filterIsInstance<VerificationResult.Failed>()
+                verifier.displayFailures(errors)
+                throw AssertionError(verifier.generateErrorStringFromVerificationResult(errors))
+            }
+        } finally {
+            verifier.finaliseReports()
+        }
+    }
+
+}

--- a/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/WebFluxProviderVerifierSpec.groovy
+++ b/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/WebFluxProviderVerifierSpec.groovy
@@ -1,0 +1,99 @@
+package au.com.dius.pact.provider.spring
+
+import au.com.dius.pact.core.model.OptionalBody
+import au.com.dius.pact.core.model.Request
+import au.com.dius.pact.provider.ProviderInfo
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DataBufferUtils
+import org.springframework.http.codec.multipart.FilePart
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST
+
+class WebFluxProviderVerifierSpec extends Specification {
+
+  def verifier = new WebFluxProviderVerifier()
+
+  class TestHandler {
+    Mono<ServerResponse> testNoBody(ServerRequest ignore) {
+      ServerResponse.ok().build()
+    }
+
+    Mono<ServerResponse> testBody(ServerRequest serverRequest) {
+      ServerResponse.ok().body(serverRequest.bodyToMono(String), String)
+    }
+
+    Mono<ServerResponse> testMultiBody(ServerRequest serverRequest) {
+      ServerResponse.ok().body(serverRequest.multipartData()
+        .map { it.getFirst('file') }
+        .cast(FilePart)
+        .zipWhen { it.content().next() }
+        .map {
+          def part = it.first()
+          def buffer = it.last()
+
+          [part.name(), part.filename(), part.headers()['Content-Type'].first(), toString(buffer)].join('|')
+        }, String)
+    }
+  }
+
+  def 'executing a request against web test client with a body'() {
+    given:
+    def body = '"This is a body"'
+    def request = new Request(method: 'POST', body: OptionalBody.body(body.bytes))
+    def handler = new TestHandler()
+    def routerFunction = RouterFunctions.route(POST('/'), handler.&testBody)
+    def webTestClient = WebTestClient.bindToRouterFunction(routerFunction).build()
+
+    when:
+    def exchangeResult = verifier.executeWebFluxRequest(webTestClient, request, new ProviderInfo())
+
+    then:
+    exchangeResult.responseHeaders['Content-Type'].first() == 'text/plain;charset=UTF-8'
+    new String(exchangeResult.responseBody) == body
+  }
+
+  def 'executing a request against web test client with no body'() {
+    given:
+    def request = new Request()
+    def handler = new TestHandler()
+    def routerFunction = RouterFunctions.route(GET('/'), handler.&testNoBody)
+    def webTestClient = WebTestClient.bindToRouterFunction(routerFunction).build()
+
+    when:
+    def exchangeResult = verifier.executeWebFluxRequest(webTestClient, request, new ProviderInfo())
+
+    then:
+    exchangeResult.responseHeaders['Content-Type'] == null
+    exchangeResult.responseBody == null
+  }
+
+  def 'executing a request against web test client with a multipart file upload'() {
+    given:
+    def request = new Request(method: 'POST').withMultipartFileUpload('file', 'filename', 'text/plain', 'file,contents')
+    def handler = new TestHandler()
+    def routerFunction = RouterFunctions.route(POST('/'), handler.&testMultiBody)
+    def webTestClient = WebTestClient.bindToRouterFunction(routerFunction).build()
+
+    when:
+    def exchangeResult = verifier.executeWebFluxRequest(webTestClient, request, new ProviderInfo())
+
+    then:
+    exchangeResult.responseHeaders['Content-Type'].first() == 'text/plain;charset=UTF-8'
+    new String(exchangeResult.responseBody) == 'file|filename|text/plain|file,contents'
+  }
+
+  private toString(DataBuffer buffer) {
+    byte[] bytes = new byte[buffer.readableByteCount()]
+    buffer.read(bytes)
+    DataBufferUtils.release(buffer)
+    new String(bytes)
+  }
+
+}

--- a/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/target/WebFluxTargetSpec.groovy
+++ b/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/target/WebFluxTargetSpec.groovy
@@ -1,0 +1,78 @@
+package au.com.dius.pact.provider.spring.target
+
+import au.com.dius.pact.core.model.RequestResponseInteraction
+import au.com.dius.pact.core.model.UnknownPactSource
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.TargetRequestFilter
+import org.junit.runners.model.TestClass
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.function.server.RouterFunctions
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+import spock.lang.Specification
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET
+
+@Provider('testProvider')
+class WebFluxTargetSpec extends Specification {
+
+  static final TEST_HEADER_NAME = 'X-Content-Type'
+  static final TEST_MEDIA_TYPE = MediaType.APPLICATION_ATOM_XML.toString()
+
+  class TestHandler {
+    Mono<ServerResponse> test(ServerRequest ignore) {
+      ServerResponse.ok().build()
+    }
+
+    Mono<ServerResponse> testXContentType(ServerRequest serverRequest) {
+      def xContentTypeValues = serverRequest.headers().header(WebFluxTargetSpec.TEST_HEADER_NAME)
+
+      assert !xContentTypeValues.empty
+      assert WebFluxTargetSpec.TEST_MEDIA_TYPE == xContentTypeValues.first()
+
+      ServerResponse.ok().build()
+    }
+  }
+
+  @Provider('testProvider')
+  class TestClassWithFilter {
+    @TargetRequestFilter
+    void requestFilter(WebTestClient.RequestHeadersSpec<?> request) {
+      request.header(WebFluxTargetSpec.TEST_HEADER_NAME, WebFluxTargetSpec.TEST_MEDIA_TYPE)
+    }
+  }
+
+  def 'only execute the test the configured number of times'() {
+    given:
+    def target = new WebFluxTarget(1)
+    target.setTestClass(new TestClass(WebFluxTargetSpec), this)
+    def interaction = new RequestResponseInteraction('Test Interaction')
+    def handler = Spy(TestHandler)
+    target.routerFunction = RouterFunctions.route(GET('/'), handler.&test)
+
+    when:
+    target.testInteraction('testConsumer', interaction, UnknownPactSource.INSTANCE, [:])
+
+    then:
+    1 * handler.test(_)
+  }
+
+  def 'invokes any request filter'() {
+    given:
+    def target = new WebFluxTarget(1)
+    def testInstance = Spy(TestClassWithFilter)
+    target.setTestClass(new TestClass(TestClassWithFilter), testInstance)
+    def interaction = new RequestResponseInteraction('Test Interaction')
+    def handler = Spy(TestHandler)
+    target.routerFunction = RouterFunctions.route(GET('/'), handler.&testXContentType)
+
+    when:
+    target.testInteraction('testConsumer', interaction, UnknownPactSource.INSTANCE, [:])
+
+    then:
+    1 * testInstance.requestFilter(_)
+  }
+
+}

--- a/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/target/WebFluxTargetSpec.groovy
+++ b/provider/spring/src/test/groovy/au/com/dius/pact/provider/spring/target/WebFluxTargetSpec.groovy
@@ -46,7 +46,7 @@ class WebFluxTargetSpec extends Specification {
 
   def 'only execute the test the configured number of times'() {
     given:
-    def target = new WebFluxTarget(1)
+    def target = new WebFluxTarget()
     target.setTestClass(new TestClass(WebFluxTargetSpec), this)
     def interaction = new RequestResponseInteraction('Test Interaction')
     def handler = Spy(TestHandler)
@@ -61,7 +61,7 @@ class WebFluxTargetSpec extends Specification {
 
   def 'invokes any request filter'() {
     given:
-    def target = new WebFluxTarget(1)
+    def target = new WebFluxTarget()
     def testInstance = Spy(TestClassWithFilter)
     target.setTestClass(new TestClass(TestClassWithFilter), testInstance)
     def interaction = new RequestResponseInteraction('Test Interaction')

--- a/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BookController.java
+++ b/provider/spring/src/test/java/au/com/dius/pact/provider/spring/BookController.java
@@ -3,11 +3,13 @@ package au.com.dius.pact.provider.spring;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
+@Controller
 public class BookController {
     @Autowired
     BookLogic bookLogic;

--- a/provider/spring/src/test/java/au/com/dius/pact/provider/spring/NovelController.java
+++ b/provider/spring/src/test/java/au/com/dius/pact/provider/spring/NovelController.java
@@ -3,11 +3,13 @@ package au.com.dius.pact.provider.spring;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
+@Controller
 public class NovelController {
     @Autowired
     BookLogic bookLogic;


### PR DESCRIPTION
Adds support for testing reactive spring components (webflux) on server side. 
Uses `WebTestClient` for testing routers and controllers.
Counterpart of MockMvc testing support.