### PR TITLE
added valueFromProviderState on LambdaDslObject

### DIFF
--- a/consumer/java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
+++ b/consumer/java8/src/main/java/io/pactfoundation/consumer/dsl/LambdaDslObject.java
@@ -426,6 +426,17 @@ public class LambdaDslObject {
         return this;
     }
 
+    /**
+     * Attribute that will have its value injected from the provider state
+     * @param name Attribute name
+     * @param expression Expression to be evaluated from the provider state
+     * @param example Example value to be used in the consumer test
+     */
+    public LambdaDslObject valueFromProviderState(String name, String expression, Object example) {
+        object.valueFromProviderState(name, expression, example);
+        return this;
+    }
+
     /** Combine all the matchers using AND
     * @param name  Attribute name
     * @param value Attribute example value

--- a/consumer/java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
+++ b/consumer/java8/src/test/java/io/pactfoundation/consumer/dsl/LambdaDslObjectTest.java
@@ -990,4 +990,15 @@ public class LambdaDslObjectTest {
     arrayObjectRule = actualPactDsl.getMatchers().allMatchingRules().get(5).toMap(PactSpecVersion.V3);
     assertThat(arrayObjectRule.get("match"), is("type"));
   }
+
+  @Test
+  public void testValueFromProviderState() {
+    String pactDslJson = new PactDslJsonBody()
+            .valueFromProviderState("id", "id", "A1")
+            .getBody().toString();
+    String lambdaDslJson = LambdaDsl
+            .newJsonBody(body -> body.valueFromProviderState("id", "id", "A1"))
+            .build().toString();
+    assertThat(lambdaDslJson, is(pactDslJson));
+  }
 }


### PR DESCRIPTION
Currently `valueFromProviderState` is not available directly from LambdaDSL API so we would need some workaround like this:
```
LambdaDslJsonBody lambdaDslJsonBody = LambdaDsl.newJsonBody(body -> body.stringType("name"));
PactDslJsonBody pactDslJsonBody = lambdaDslJsonBody.getPactDslObject();
pactDslJsonBody.valueFromProviderState("id", "${id}", "1");
```

I simply added the method on LambdaDslObject to have direct access