### PR TITLE
Fixed performing async requests for MockMvcTestTarget

### DIFF
--- a/provider/junit5spring/build.gradle
+++ b/provider/junit5spring/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   implementation 'org.springframework:spring-test:5.2.3.RELEASE'
   implementation 'org.springframework:spring-web:5.2.3.RELEASE'
   implementation 'javax.servlet:javax.servlet-api:3.1.0'
+  implementation 'org.hamcrest:hamcrest:2.1'
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test:2.2.5.RELEASE'
   testImplementation 'org.springframework.boot:spring-boot-starter-web:2.2.5.RELEASE'

--- a/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
+++ b/provider/junit5spring/src/main/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTarget.kt
@@ -11,13 +11,13 @@ import au.com.dius.pact.provider.ProviderResponse
 import au.com.dius.pact.provider.junit5.TestTarget
 import mu.KLogging
 import org.apache.commons.lang3.StringUtils
+import org.hamcrest.core.IsAnything
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.test.web.client.match.MockRestRequestMatchers.anything
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.RequestBuilder
 import org.springframework.test.web.servlet.ResultActions
@@ -153,7 +153,7 @@ class MockMvcTestTarget @JvmOverloads constructor(
         val resultActions = mockMvc.perform(requestBuilder)
         return if (resultActions.andReturn().request.isAsyncStarted) {
             mockMvc.perform(MockMvcRequestBuilders.asyncDispatch(resultActions
-              .andExpect(MockMvcResultMatchers.request().asyncResult(anything()))
+              .andExpect(MockMvcResultMatchers.request().asyncResult<Any>(IsAnything()))
               .andReturn()))
         } else {
             resultActions

--- a/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTestJava.java
+++ b/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTestJava.java
@@ -8,10 +8,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.concurrent.CompletableFuture;
 
 @Provider("myAwesomeService")
 @PactFolder("pacts")
@@ -35,6 +39,15 @@ class MockMvcTestTargetStandaloneMockMvcTestJava {
         @GetMapping("/data")
         @ResponseStatus(HttpStatus.NO_CONTENT)
         void getData(@RequestParam("ticketId") String ticketId) {
+        }
+
+        @GetMapping("/async-data")
+        DeferredResult<ResponseEntity<Void>> getAsyncData(@RequestParam("ticketId") String ticketId)  {
+            DeferredResult<ResponseEntity<Void>> result = new DeferredResult<>();
+            CompletableFuture.runAsync(() -> result.setResult(ResponseEntity
+                    .noContent()
+                    .build()));
+            return result;
         }
     }
 }

--- a/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTestJava.java
+++ b/provider/junit5spring/src/test/java/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTestJava.java
@@ -1,20 +1,24 @@
 package au.com.dius.pact.provider.spring.junit5;
 
-import au.com.dius.pact.provider.junitsupport.Provider;
-import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 import au.com.dius.pact.provider.junit5.PactVerificationContext;
 import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.async.DeferredResult;
+
+import java.util.concurrent.CompletableFuture;
 
 @WebMvcTest
 @Provider("myAwesomeService")
@@ -40,6 +44,15 @@ class MockMvcTestTargetWebMvcTestJava {
         @GetMapping("/data")
         @ResponseStatus(HttpStatus.NO_CONTENT)
         void getData(@RequestParam("ticketId") String ticketId) {
+        }
+
+        @GetMapping("/async-data")
+        DeferredResult<ResponseEntity<Void>> getAsyncData(@RequestParam("ticketId") String ticketId)  {
+            DeferredResult<ResponseEntity<Void>> result = new DeferredResult<>();
+            CompletableFuture.runAsync(() -> result.setResult(ResponseEntity
+                    .noContent()
+                    .build()));
+            return result;
         }
     }
 }

--- a/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetNoCustomMockMvcTest.kt
+++ b/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetNoCustomMockMvcTest.kt
@@ -1,18 +1,21 @@
 package au.com.dius.pact.provider.spring.junit5
 
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
-import au.com.dius.pact.provider.junit5.PactVerificationContext
-import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.request.async.DeferredResult
+import java.util.concurrent.CompletableFuture
 
 @Provider("myAwesomeService")
 @IgnoreNoPactsToVerify
@@ -35,6 +38,17 @@ internal class MockMvcTestTargetNoCustomMockMvcTest {
         @GetMapping("/data")
         @ResponseStatus(HttpStatus.NO_CONTENT)
         fun getData(@RequestParam("ticketId") ticketId: String) {
+        }
+
+        @GetMapping("/async-data")
+        fun getAsyncData(@RequestParam("ticketId") ticketId: String): DeferredResult<ResponseEntity<Any>> {
+            val result = DeferredResult<ResponseEntity<Any>>()
+            CompletableFuture.runAsync {
+                result.setResult(ResponseEntity
+                        .noContent()
+                        .build())
+            }
+            return result
         }
     }
 }

--- a/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTest.kt
+++ b/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetStandaloneMockMvcTest.kt
@@ -1,19 +1,22 @@
 package au.com.dius.pact.provider.spring.junit5
 
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
-import au.com.dius.pact.provider.junit5.PactVerificationContext
-import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.request.async.DeferredResult
+import java.util.concurrent.CompletableFuture
 
 @Provider("myAwesomeService")
 @IgnoreNoPactsToVerify
@@ -38,6 +41,17 @@ internal class MockMvcTestTargetStandaloneMockMvcTest {
         @GetMapping("/data")
         @ResponseStatus(HttpStatus.NO_CONTENT)
         fun getData(@RequestParam("ticketId") ticketId: String) {
+        }
+
+        @GetMapping("/async-data")
+        fun getAsyncData(@RequestParam("ticketId") ticketId: String): DeferredResult<ResponseEntity<Any>> {
+            val result = DeferredResult<ResponseEntity<Any>>()
+            CompletableFuture.runAsync {
+                result.setResult(ResponseEntity
+                        .noContent()
+                        .build())
+            }
+            return result
         }
     }
 }

--- a/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTest.kt
+++ b/provider/junit5spring/src/test/kotlin/au/com/dius/pact/provider/spring/junit5/MockMvcTestTargetWebMvcTest.kt
@@ -1,21 +1,24 @@
 package au.com.dius.pact.provider.spring.junit5
 
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.loader.PactFolder
-import au.com.dius.pact.provider.junit5.PactVerificationContext
-import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.context.request.async.DeferredResult
+import java.util.concurrent.CompletableFuture
 
 @WebMvcTest
 @Provider("myAwesomeService")
@@ -43,5 +46,16 @@ internal class DataResource {
     @GetMapping("/data")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun getData(@RequestParam("ticketId") ticketId: String) {
+    }
+
+    @GetMapping("/async-data")
+    fun getAsyncData(@RequestParam("ticketId") ticketId: String): DeferredResult<ResponseEntity<Any>> {
+        val result = DeferredResult<ResponseEntity<Any>>()
+        CompletableFuture.runAsync {
+            result.setResult(ResponseEntity
+                    .noContent()
+                    .build())
+        }
+        return result
     }
 }

--- a/provider/junit5spring/src/test/resources/pacts/contract.json
+++ b/provider/junit5spring/src/test/resources/pacts/contract.json
@@ -15,7 +15,19 @@
     "response" : {
       "status" : 204
     }
-  } ],
+  },
+  {
+    "description" : "Get async data",
+    "request" : {
+      "method" : "GET",
+      "path" : "/async-data",
+      "query": "ticketId=0000"
+    },
+    "response" : {
+      "status" : 204
+    }
+  }
+  ],
   "metadata" : {
     "pact-specification" : {
       "version" : "2.0.0"


### PR DESCRIPTION
Currently performing async requests is not working because result matcher is not using matcher's logic, but is asserting equality between matcher's object and result - [currently used method docs](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/web/servlet/result/RequestResultMatchers.html#asyncResult-java.lang.Object-).

I made a change for using typed matcher's logic to match anything - [fix method docs](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/web/servlet/result/RequestResultMatchers.html#asyncResult-org.hamcrest.Matcher-)