### PR TITLE
#1193: fix consumer inclusion logic

### DIFF
--- a/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/junit/src/test/groovy/au/com/dius/pact/provider/junit/loader/PactBrokerLoaderSpec.groovy
@@ -538,6 +538,27 @@ class PactBrokerLoaderSpec extends Specification {
     result.size() == 3
   }
 
+  def 'Loads pacts for provided consumers with the specified tags despite on long pact name from the broker'() {
+    given:
+        consumers = ['foo-consumer']
+        tags = ['demo']
+        def expected = [
+                new PactBrokerResult('Pact between foo-consumer and baz-provider', '', '', [], [], false, 'demo', false),
+                new PactBrokerResult('Pact between unknown-consumer and baz-provider', '', '', [], [], false, 'demo', false),
+                new PactBrokerResult('Pact between foo-consumer and unknown-provider', '', '', [], [], false, 'demo', false)
+        ]
+        def selectors = [ new ConsumerVersionSelector('demo', true) ]
+
+    when:
+        def result = pactBrokerLoader().load('baz-provider')
+
+    then:
+        brokerClient.getOptions() >> [:]
+        1 * brokerClient.fetchConsumersWithSelectors('baz-provider', selectors, [], false, '') >> new Ok(expected)
+        0 * brokerClient._
+        result.size() == 2
+  }
+
   def 'Loads pacts only for provided consumers with the specified consumer version selectors'() {
     given:
     consumers = ['a', 'b', 'c']

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
@@ -11,6 +11,7 @@ import au.com.dius.pact.core.model.PactSource
 import au.com.dius.pact.core.pactbroker.ConsumerVersionSelector
 import au.com.dius.pact.core.pactbroker.IPactBrokerClient
 import au.com.dius.pact.core.pactbroker.PactBrokerClient
+import au.com.dius.pact.core.support.contains
 import au.com.dius.pact.core.support.expressions.DataType
 import au.com.dius.pact.core.support.expressions.ExpressionParser.parseExpression
 import au.com.dius.pact.core.support.expressions.ExpressionParser.parseListExpression
@@ -200,7 +201,9 @@ open class PactBrokerLoader(
 
       if (pactBrokerConsumers.isNotEmpty()) {
         val consumerInclusions = pactBrokerConsumers.flatMap { parseListExpression(it, resolver) }
-        consumers = consumers.filter { consumerInclusions.isEmpty() || consumerInclusions.contains(it.name) }
+        if (consumerInclusions.isNotEmpty()) {
+          consumers = consumers.filter { consumer -> consumerInclusions.any { inclusion -> consumer.name.contains(inclusion) } }
+        }
       }
 
       return consumers.map { pactReader.loadPact(it, pactBrokerClient.options) }


### PR DESCRIPTION
Currently, consumer inclusions have the wrong logic regarding pact broker providing pacts with names like `Pact between %s (%version) and %provider`, it is fixed and unit-test sample is supplied