### PR TITLE
JUnit extension improve thread safety

### DIFF
--- a/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
+++ b/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactConsumerTestExt.kt
@@ -220,7 +220,7 @@ class PactConsumerTestExt : Extension, BeforeTestExecutionCallback, BeforeAllCal
   override fun beforeAll(context: ExtensionContext) {
     val store = context.getStore(NAMESPACE)
     store.put("executedFragments", ConcurrentHashMap.newKeySet<Method>())
-    store.put("pactsToWrite", mutableMapOf<Pair<Consumer, Provider>, Pair<BasePact<*>, PactSpecVersion>>())
+    store.put("pactsToWrite", ConcurrentHashMap<Pair<Consumer, Provider>, Pair<BasePact<*>, PactSpecVersion>>())
   }
 
   override fun beforeTestExecution(context: ExtensionContext) {

--- a/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/PactConsumerTestExtTest.groovy
+++ b/consumer/junit5/src/test/groovy/au/com/dius/pact/consumer/junit5/PactConsumerTestExtTest.groovy
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
-
+import java.lang.reflect.Method
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertThrows
 
@@ -28,7 +28,7 @@ class PactConsumerTestExtTest {
     mockStore = [
       'get': { param ->
         switch (param) {
-          case 'executedFragments': []; break
+          case 'executedFragments': [] as Set<Method>; break
           default: null
         }
       },


### PR DESCRIPTION
Improves the thread-safety of `PactConsumerTestExt` by using data structures designed for concurrent modification/access for objects that store state can be accessed and modified across threads, namely the `executedFragments` and `pactsToWrite` as they are most likely to be modified and then read in an inconsistent order when running a test suite in parallel. This issue is described in more detail. 

I think there are some other improvements that could be made as well, like using atomic operators (e.g. `getOrComputeIfAbsent`) when interacting with the `ExtensionContext.Store`, but as far as I can tell they don't seem to be causing any issues today. 

Solves #1223