### PR TITLE
chore: Update scala-java8-compat to 1.0.0

### DIFF
--- a/provider/scalasupport/build.gradle
+++ b/provider/scalasupport/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   compile("com.typesafe.scala-logging:scala-logging_2.13:3.9.2") {
     exclude group: 'org.scala-lang'
   }
-  compile 'org.scala-lang.modules:scala-java8-compat_2.13:0.9.1'
+  compile 'org.scala-lang.modules:scala-java8-compat_2.13:1.0.0'
   compile 'org.asynchttpclient:async-http-client:2.1.0-alpha24'
   compile("ws.unfiltered:unfiltered-netty-server_2.13:0.10.0-M8") {
     exclude group: 'org.scala-lang'


### PR DESCRIPTION
It's a major version change but non-breaking.
sbt complains about this version conflict, so it would be nice to get this merged for the next minor release