### PR TITLE
fix: fix ClassCastException for multipart requests in Spring7MockMvcTestTarget

### DIFF
--- a/provider/spring7/src/main/kotlin/au/com/dius/pact/provider/spring/spring7/Spring7MockMvcTestTarget.kt
+++ b/provider/spring7/src/main/kotlin/au/com/dius/pact/provider/spring/spring7/Spring7MockMvcTestTarget.kt
@@ -175,7 +175,7 @@ class Spring7MockMvcTestTarget @JvmOverloads constructor(
 
     override fun executeInteraction(client: Any?, request: Any?): ProviderResponse {
         val mockMvcClient = client as MockMvc
-        val requestBuilder = request as MockHttpServletRequestBuilder
+        val requestBuilder = request as RequestBuilder
         val mvcResult = performRequest(mockMvcClient, requestBuilder).andDo {
             if (printRequestResponse) {
                 MockMvcResultHandlers.print().handle(it)


### PR DESCRIPTION
This fixes #1895.

## Fix

Change the cast in `executeInteraction` from `MockHttpServletRequestBuilder` to `RequestBuilder`, which is the common interface implemented by both builder types:

```kotlin
// Before
val requestBuilder = request as MockHttpServletRequestBuilder

// After
val requestBuilder = request as RequestBuilder
```

This is safe because:
1. `toMockRequestBuilder` already declares its return type as `RequestBuilder`.
2. `MockMvc.perform()` accepts `RequestBuilder`, so no downstream code requires the more specific type.
3. Both `MockHttpServletRequestBuilder` and `MockMultipartHttpServletRequestBuilder` implement `RequestBuilder`.

## New Tests

Two tests were added to `MockMvcTestTargetSpec` to cover multipart file uploads:

- **`should prepare multipart file upload request`** — verifies that `prepareRequest` correctly builds a multipart request with the expected URI, method, and content type.
- **`should execute interaction with multipart file upload`** — verifies end-to-end execution of a multipart upload interaction against a test controller, asserting the file name, content type, original filename, and body are received correctly.
