### PR TITLE
fix: synchronize access to new pact file

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
@@ -88,7 +88,7 @@ object DefaultPactWriter : PactWriter, KLogging() {
       val raf = RandomAccessFile(pactFile, "rw")
       val lock = raf.channel.lock()
       try {
-        if(pactFile.length() > 0) {
+        val pactToWrite = if (pactFile.length() > 0) {
           val source = FileSource(pactFile)
           val json: JsonValue.Object = JsonParser.parseString(readFileUtf8(raf)).downcast()
           val existingPact = DefaultPactReader.pactFromJson(json, source)
@@ -96,22 +96,18 @@ object DefaultPactWriter : PactWriter, KLogging() {
           if (!result.ok) {
             throw InvalidPactException(result.message)
           }
-          raf.seek(0)
-          val swriter = StringWriter()
-          val writer = PrintWriter(swriter)
-          writePact(result.result!!, writer, pactSpecVersion)
-          val bytes = swriter.toString().toByteArray()
-          raf.setLength(bytes.size.toLong())
-          raf.write(bytes)
-          Result.Ok(bytes.size)
+          result.result!!
         } else {
-          val swriter = StringWriter()
-          val writer = PrintWriter(swriter)
-          writePact(pact, writer, pactSpecVersion)
-          val bytes = swriter.toString().toByteArray()
-          raf.write(bytes)
-          Result.Ok(bytes.size)
+          pact
         }
+        raf.seek(0)
+        val swriter = StringWriter()
+        val writer = PrintWriter(swriter)
+        writePact(pactToWrite, writer, pactSpecVersion)
+        val bytes = swriter.toString().toByteArray()
+        raf.write(bytes)
+        raf.setLength(bytes.size.toLong())
+        Result.Ok(bytes.size)
       } finally {
         lock.release()
         raf.close()

--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
@@ -83,31 +83,35 @@ object DefaultPactWriter : PactWriter, KLogging() {
    */
   @Synchronized
   override fun writePact(pactFile: File, pact: Pact, pactSpecVersion: PactSpecVersion) : Result<Int, Throwable> {
-    return if (pactWriteMode() == PactWriteMode.MERGE && pactFile.exists() && pactFile.length() > 0) {
+    pactFile.parentFile.mkdirs()
+    return if (pactWriteMode() == PactWriteMode.MERGE) {
       val raf = RandomAccessFile(pactFile, "rw")
       val lock = raf.channel.lock()
       try {
-        val source = FileSource(pactFile)
-        val json: JsonValue.Object = JsonParser.parseString(readFileUtf8(raf)).downcast()
-        val existingPact = DefaultPactReader.pactFromJson(json, source)
-        val result = PactMerge.merge(pact, existingPact)
-        if (!result.ok) {
-          throw InvalidPactException(result.message)
+        if(pactFile.length() > 0) {
+          val source = FileSource(pactFile)
+          val json: JsonValue.Object = JsonParser.parseString(readFileUtf8(raf)).downcast()
+          val existingPact = DefaultPactReader.pactFromJson(json, source)
+          val result = PactMerge.merge(pact, existingPact)
+          if (!result.ok) {
+            throw InvalidPactException(result.message)
+          }
+          raf.seek(0)
+          val swriter = StringWriter()
+          val writer = PrintWriter(swriter)
+          writePact(result.result!!, writer, pactSpecVersion)
+          val bytes = swriter.toString().toByteArray()
+          raf.setLength(bytes.size.toLong())
+          raf.write(bytes)
+          Result.Ok(bytes.size)
+        } else {
+          pactFile.printWriter().use { writePact(pact, it, pactSpecVersion) }
         }
-        raf.seek(0)
-        val swriter = StringWriter()
-        val writer = PrintWriter(swriter)
-        writePact(result.result!!, writer, pactSpecVersion)
-        val bytes = swriter.toString().toByteArray()
-        raf.setLength(bytes.size.toLong())
-        raf.write(bytes)
-        Result.Ok(bytes.size)
       } finally {
         lock.release()
         raf.close()
       }
     } else {
-      pactFile.parentFile.mkdirs()
       pactFile.printWriter().use { writePact(pact, it, pactSpecVersion) }
     }
   }

--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactWriter.kt
@@ -105,7 +105,12 @@ object DefaultPactWriter : PactWriter, KLogging() {
           raf.write(bytes)
           Result.Ok(bytes.size)
         } else {
-          pactFile.printWriter().use { writePact(pact, it, pactSpecVersion) }
+          val swriter = StringWriter()
+          val writer = PrintWriter(swriter)
+          writePact(pact, writer, pactSpecVersion)
+          val bytes = swriter.toString().toByteArray()
+          raf.write(bytes)
+          Result.Ok(bytes.size)
         }
       } finally {
         lock.release()


### PR DESCRIPTION
Always get a lock before writing to the pact file when `PactWriteMode.MERGE` is set

Might fix https://github.com/pact-foundation/pact-jvm/issues/1528