### PR TITLE
feat: add arrayContains as a matching rule expression

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/expressions/MatcherDefinition.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/matchingrules/expressions/MatcherDefinition.kt
@@ -2,6 +2,7 @@ package au.com.dius.pact.core.model.matchingrules.expressions
 
 import au.com.dius.pact.core.model.generators.Generator
 import au.com.dius.pact.core.model.generators.ProviderStateGenerator
+import au.com.dius.pact.core.model.matchingrules.ArrayContainsMatcher
 import au.com.dius.pact.core.model.matchingrules.BooleanMatcher
 import au.com.dius.pact.core.model.matchingrules.ContentTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.DateMatcher
@@ -10,6 +11,7 @@ import au.com.dius.pact.core.model.matchingrules.EachValueMatcher
 import au.com.dius.pact.core.model.matchingrules.EqualsMatcher
 import au.com.dius.pact.core.model.matchingrules.IncludeMatcher
 import au.com.dius.pact.core.model.matchingrules.MatchingRule
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory
 import au.com.dius.pact.core.model.matchingrules.MaxTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.MinTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.NotEmptyMatcher
@@ -54,7 +56,7 @@ data class MatchingRuleResult(
   val reference: MatchingReference? = null
 )
 
-@Suppress("MaxLineLength")
+@Suppress("MaxLineLength", "LargeClass")
 class MatcherDefinitionParser(private val lexer: MatcherDefinitionLexer) {
   /**
    * Parse a matcher expression into a MatchingRuleDefinition containing the example value, matching rules and any generator.
@@ -113,6 +115,7 @@ class MatcherDefinitionParser(private val lexer: MatcherDefinitionLexer) {
   //        | 'eachValue' LEFT_BRACKET e=matchingDefinitionExp RIGHT_BRACKET
   //        | 'atLeast' LEFT_BRACKET DIGIT+ RIGHT_BRACKET
   //        | 'atMost' LEFT_BRACKET DIGIT+ RIGHT_BRACKET
+  //        | 'arrayContains' LEFT_BRACKET e=matchingDefinitionExp (',' e=matchingDefinitionExp)* RIGHT_BRACKET
   //      )
   //      ;
   @Suppress("ReturnCount", "LongMethod")
@@ -243,9 +246,65 @@ class MatcherDefinitionParser(private val lexer: MatcherDefinitionLexer) {
             Result.Err(parseError("Was expecting a '(' at index ${lexer.index}"))
           }
         }
+        lexer.matchString("arrayContains") -> {
+          if (matchChar('(')) {
+            val variants = mutableListOf<Triple<Int, MatchingRuleCategory, Map<String, Generator>>>()
+            var index = 0
+            lexer.skipWhitespace()
+            when (val firstVariant = matchingDefinitionExp()) {
+              is Result.Err -> return@mark firstVariant
+              is Result.Ok -> when (val v = buildVariant(index++, firstVariant.value)) {
+                is Result.Err -> return@mark v
+                is Result.Ok -> variants.add(v.value)
+              }
+            }
+            lexer.skipWhitespace()
+            while (lexer.peekNextChar() == ',') {
+              lexer.advance()
+              lexer.skipWhitespace()
+              when (val variantResult = matchingDefinitionExp()) {
+                is Result.Err -> return@mark variantResult
+                is Result.Ok -> when (val v = buildVariant(index++, variantResult.value)) {
+                  is Result.Err -> return@mark v
+                  is Result.Ok -> variants.add(v.value)
+                }
+              }
+              lexer.skipWhitespace()
+            }
+            if (matchChar(')')) {
+              Result.Ok(MatchingRuleDefinition(null, ValueType.Unknown,
+                listOf(Either.A(ArrayContainsMatcher(variants))), null, lexer.fromMark()))
+            } else {
+              Result.Err(parseError("Was expecting a ')' at index ${lexer.index}"))
+            }
+          } else {
+            Result.Err(parseError("Was expecting a '(' at index ${lexer.index}"))
+          }
+        }
         else -> Result.Err(parseError("Was expecting a matching rule definition type at index ${lexer.index}"))
       }
     }
+  }
+
+  private fun buildVariant(
+    index: Int,
+    definition: MatchingRuleDefinition
+  ): Result<Triple<Int, MatchingRuleCategory, Map<String, Generator>>, String> {
+    val category = MatchingRuleCategory("body")
+    for (rule in definition.rules) {
+      when (rule) {
+        is Either.A -> category.addRule("", rule.value)
+        is Either.B -> return Result.Err(
+          parseError("References are not supported inside arrayContains at index ${lexer.index}")
+        )
+      }
+    }
+    val generators: Map<String, Generator> = if (definition.generator != null) {
+      mapOf("" to definition.generator)
+    } else {
+      emptyMap()
+    }
+    return Result.Ok(Triple(index, category, generators))
   }
 
   private fun matchChar(c: Char): Boolean {

--- a/core/model/src/test/groovy/au/com/dius/pact/core/model/matchingrules/expressions/MatchingDefinitionParserSpec.groovy
+++ b/core/model/src/test/groovy/au/com/dius/pact/core/model/matchingrules/expressions/MatchingDefinitionParserSpec.groovy
@@ -1,12 +1,15 @@
 package au.com.dius.pact.core.model.matchingrules.expressions
 
 import au.com.dius.pact.core.model.generators.ProviderStateGenerator
+import au.com.dius.pact.core.model.matchingrules.ArrayContainsMatcher
+import kotlin.Triple
 import au.com.dius.pact.core.model.matchingrules.BooleanMatcher
 import au.com.dius.pact.core.model.matchingrules.DateMatcher
 import au.com.dius.pact.core.model.matchingrules.EachKeyMatcher
 import au.com.dius.pact.core.model.matchingrules.EachValueMatcher
 import au.com.dius.pact.core.model.matchingrules.EqualsMatcher
 import au.com.dius.pact.core.model.matchingrules.IncludeMatcher
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory
 import au.com.dius.pact.core.model.matchingrules.MaxTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.MinTypeMatcher
 import au.com.dius.pact.core.model.matchingrules.NotEmptyMatcher
@@ -338,5 +341,98 @@ class MatchingDefinitionParserSpec extends Specification {
     'atMost(100'  | 'Error parsing expression: Was expecting a \')\' at index 10\n        atMost(100\n                  ^'
     'atMost(-10)' | 'Error parsing expression: Was expecting an unsigned number at index 7'
     'atMost(0.1)' | 'Error parsing expression: Was expecting a \')\' at index 8\n        atMost(0.1)\n                ^'
+  }
+
+  def 'parse arrayContains with single variant'() {
+    given:
+    def expression = "arrayContains(matching(type, 'Name'))"
+    def category = new MatchingRuleCategory('body')
+    category.addRule('', TypeMatcher.INSTANCE)
+    def expected = new MatchingRuleDefinition(null, ValueType.Unknown,
+      [Either.a(new ArrayContainsMatcher([new Triple(0, category, [:])]))] , null, expression)
+
+    when:
+    def result = MatchingRuleDefinition.parseMatchingRuleDefinition(expression).value
+
+    then:
+    result == expected
+  }
+
+  def 'parse arrayContains with multiple variants'() {
+    given:
+    def expression = "arrayContains(matching(type, 'Name'), matching(number, 100))"
+    def cat1 = new MatchingRuleCategory('body')
+    cat1.addRule('', TypeMatcher.INSTANCE)
+    def cat2 = new MatchingRuleCategory('body')
+    cat2.addRule('', new NumberTypeMatcher(NumberTypeMatcher.NumberType.NUMBER))
+    def expected = new MatchingRuleDefinition(null, ValueType.Unknown,
+      [Either.a(new ArrayContainsMatcher([new Triple(0, cat1, [:]), new Triple(1, cat2, [:])]))] , null, expression)
+
+    when:
+    def result = MatchingRuleDefinition.parseMatchingRuleDefinition(expression).value
+
+    then:
+    result == expected
+  }
+
+  def 'parse arrayContains with regex variant'() {
+    given:
+    def expression = "arrayContains(matching(regex, '\\\\w+', 'Fred'))"
+    def category = new MatchingRuleCategory('body')
+    category.addRule('', new RegexMatcher('\\w+'))
+    def expected = new MatchingRuleDefinition(null, ValueType.Unknown,
+      [Either.a(new ArrayContainsMatcher([new Triple(0, category, [:])]))] , null, expression)
+
+    when:
+    def result = MatchingRuleDefinition.parseMatchingRuleDefinition(expression).value
+
+    then:
+    result == expected
+  }
+
+  def 'parse arrayContains combined with atLeast'() {
+    given:
+    def expression = "arrayContains(matching(type, 'Name')), atLeast(1)"
+    def cat = new MatchingRuleCategory('body')
+    cat.addRule('', TypeMatcher.INSTANCE)
+    def expected = new MatchingRuleDefinition('', ValueType.Unknown,
+      [Either.a(new ArrayContainsMatcher([new Triple(0, cat, [:])])), Either.a(new MinTypeMatcher(1))],
+      null, expression)
+
+    when:
+    def result = MatchingRuleDefinition.parseMatchingRuleDefinition(expression).value
+
+    then:
+    result == expected
+  }
+
+  def 'parse arrayContains combined with eachValue'() {
+    given:
+    def expression = "eachValue(matching(type, 'X')), arrayContains(matching(equalTo, 'PUBLIC'))"
+    def innerDef = new MatchingRuleDefinition('X', TypeMatcher.INSTANCE, null, "matching(type, 'X')")
+    def cat = new MatchingRuleCategory('body')
+    cat.addRule('', EqualsMatcher.INSTANCE)
+    def expected = new MatchingRuleDefinition(null, ValueType.Unknown,
+      [Either.a(new EachValueMatcher(innerDef)), Either.a(new ArrayContainsMatcher([new Triple(0, cat, [:])]))] ,
+      null, expression)
+
+    when:
+    def result = MatchingRuleDefinition.parseMatchingRuleDefinition(expression).value
+
+    then:
+    result == expected
+  }
+
+  def 'invalid arrayContains'() {
+    expect:
+    MatchingRuleDefinition.parseMatchingRuleDefinition(expression).errorValue() == error
+
+    where:
+
+    expression                               | error
+    'arrayContains'                          | 'Error parsing expression: Was expecting a \'(\' at index 13\n        arrayContains\n                     ^'
+    'arrayContains('                         | "Error parsing expression: Was expecting a matching rule definition type at index 14\n        arrayContains(\n                      ^"
+    'arrayContains()'                        | "Error parsing expression: Was expecting a matching rule definition type at index 14\n        arrayContains()\n                      ^"
+    "arrayContains(matching(type, 'Name')"   | "Error parsing expression: Was expecting a ')' at index 36\n        arrayContains(matching(type, 'Name')\n                                            ^"
   }
 }


### PR DESCRIPTION
## Summary

- Adds parsing support for `arrayContains(EXPR [, EXPR, ...])` as a matching rule expression in `MatcherDefinitionParser`
- Each inner expression becomes an indexed variant in an `ArrayContainsMatcher`
- Whitespace is correctly handled between variants and around the outer parentheses
- Added `@Suppress("LargeClass")` to `MatcherDefinitionParser` as the new code pushed it just over detekt's 600-LOC threshold

## Related

Mirrors the equivalent change in the Rust reference implementation: pact-foundation/pact-reference#523

## Test coverage

Tests added to `MatchingDefinitionParserSpec` covering:
- Single inline variant: `arrayContains(matching(type, 'Name'))`
- Multiple inline variants: `arrayContains(matching(type, 'Name'), matching(number, 100))`
- Regex variant: `arrayContains(matching(regex, '\\w+', 'Fred'))`
- Combined with `atLeast`: `arrayContains(matching(type, 'Name')), atLeast(1)`
- Combined with `eachValue`: `eachValue(matching(type, 'X')), arrayContains(matching(equalTo, 'PUBLIC'))`
- Error cases: missing `(`, empty `arrayContains()`, unclosed `(`

**Not yet supported**: references inside `arrayContains` (e.g. `matching($'name')`). Supporting these requires extending `ArrayContainsMatcher`'s variant structure to hold unresolved references, which is a separate, more substantial change.

## Test plan

- [ ] `./gradlew :core:model:check` passes
- [ ] `./gradlew :core:matchers:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)