### PR TITLE
chore: fix typo breaking internal build

### DIFF
--- a/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactTestFor.kt
+++ b/consumer/junit5/src/main/kotlin/au/com/dius/pact/consumer/junit5/PactTestFor.kt
@@ -57,7 +57,7 @@ annotation class PactTestFor(
         val pactMethods: Array<String> = [],
 
         /**
-         * If an external keystore should be provided to the mockServer. This allos to provide a path to
+         * If an external keystore should be provided to the mockServer. This allows to provide a path to
          * keystore file
          */
         @Deprecated("This has been replaced with the @MockServerConfig annotation")


### PR DESCRIPTION
fixing a minor typo that was appearing in the auto generated dsl files of pactflow-agent-skills