### PR TITLE
fix: support HttpRequest in no-pacts dummy template

### DIFF
--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/DummyTestTemplate.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/DummyTestTemplate.kt
@@ -4,6 +4,7 @@ import au.com.dius.pact.core.model.Interaction
 import au.com.dius.pact.core.model.Pact
 import au.com.dius.pact.provider.ProviderVerifier
 import org.apache.hc.core5.http.ClassicHttpRequest
+import org.apache.hc.core5.http.HttpRequest
 import org.junit.jupiter.api.extension.Extension
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
@@ -23,6 +24,7 @@ object DummyTestTemplate : TestTemplateInvocationContext, ParameterResolver {
       Pact::class.java -> true
       Interaction::class.java -> true
       ClassicHttpRequest::class.java -> true
+      HttpRequest::class.java -> true
       PactVerificationContext::class.java -> true
       ProviderVerifier::class.java -> true
       else -> false

--- a/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/NoPactsToVerifyParameterResolverTest.java
+++ b/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/NoPactsToVerifyParameterResolverTest.java
@@ -1,0 +1,41 @@
+package au.com.dius.pact.provider.junit5;
+
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
+import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors;
+import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@Provider("Animal Profile Service")
+@PactBroker(url = "http://broker.host")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class NoPactsToVerifyParameterResolverTest {
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void pactVerificationTestTemplateWithClassicHttpRequest(ClassicHttpRequest request, PactVerificationContext context) {
+    assertThat(request, is(nullValue()));
+    if (context != null) {
+      context.verifyInteraction();
+    }
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void pactVerificationTestTemplateWithHttpRequest(HttpRequest request, PactVerificationContext context) {
+    assertThat(request, is(nullValue()));
+    if (context != null) {
+      context.verifyInteraction();
+    }
+  }
+
+}

--- a/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/NoPactsToVerifyParameterResolverTest.java
+++ b/provider/junit5/src/test/java/au/com/dius/pact/provider/junit5/NoPactsToVerifyParameterResolverTest.java
@@ -3,11 +3,8 @@ package au.com.dius.pact.provider.junit5;
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junitsupport.Provider;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
-import au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors;
-import au.com.dius.pact.provider.junitsupport.loader.SelectorBuilder;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpRequest;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 


### PR DESCRIPTION
## Summary
- add a test for the no-pacts `@IgnoreNoPactsToVerify` path with HTTP request parameters
- support `HttpRequest` in `DummyTestTemplate` so the dummy no-pacts invocation matches JUnit 5 request parameter handling documented in https://docs.pact.io/implementation_guides/jvm/provider/junit5#objects-that-can-be-injected-into-the-test-methods