### PR TITLE
Improve performance for JSON parsing and related hot paths

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/DocPath.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/DocPath.kt
@@ -8,13 +8,23 @@ private val logger = KotlinLogging.logger {}
 @Suppress("TooManyFunctions")
 data class DocPath(
   val pathTokens: List<PathToken>,
-  val expr: String
+  private var e: String?
 ): Into<DocPath> {
   /** Construct a new document path from the provided string path */
   constructor(expression: String): this(parsePath(expression), expression)
 
   /** Construct a new DocPath from a list of tokens */
-  constructor(tokens: List<PathToken>): this(tokens, buildExpr(tokens))
+  constructor(tokens: List<PathToken>): this(tokens, null)
+
+  val expr: String by lazy {
+    if (this.e == null) {
+      val exp = buildExpr(this.pathTokens)
+      this.e = exp
+      exp
+    } else {
+      this.e!!
+    }
+  }
 
   override fun into() = this.copy()
 

--- a/core/support/build.gradle
+++ b/core/support/build.gradle
@@ -1,9 +1,18 @@
 plugins {
     id 'au.com.dius.pact.kotlin-library-conventions'
+    id 'me.champeau.jmh' version '0.7.3'
 }
 
 description = 'Pact-JVM Support module with common utilities'
 group = 'au.com.dius.pact.core'
+
+def benchmarkLogbackConfig = file('src/jmh/resources/logback-benchmark.xml').absolutePath
+def benchmarkJvmArgs = [
+    '-Dpact_do_not_track=true',
+    '-Xms512m',
+    '-Xmx1g',
+    "-Dlogback.configurationFile=${benchmarkLogbackConfig}"
+]
 
 dependencies {
     api 'io.github.oshai:kotlin-logging-jvm'
@@ -17,4 +26,69 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest'
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'junit:junit'
+}
+
+jmh {
+    warmupIterations = 3
+    iterations = 5
+    fork = 1
+    warmup = '1s'
+    timeOnIteration = '1s'
+    jvmArgsAppend = benchmarkJvmArgs
+}
+
+tasks.register('jmhJfr', Exec) {
+    dependsOn tasks.named('jmhJar')
+    group = 'benchmarking'
+    description = 'Runs the JMH benchmark jar with Java Flight Recorder enabled'
+
+    doFirst {
+        def benchmark = providers.gradleProperty('jmhBenchmark')
+            .orElse('au.com.dius.pact.core.support.json.JsonParserBenchmark.parseString')
+            .get()
+        def payloadType = providers.gradleProperty('jmhPayloadType').orElse('http-pact').get()
+        def itemCount = providers.gradleProperty('jmhItemCount').orElse('50').get()
+        def warmupIterations = providers.gradleProperty('jmhWarmupIterations').orElse('3').get()
+        def measurementIterations = providers.gradleProperty('jmhMeasurementIterations').orElse('5').get()
+        def forks = providers.gradleProperty('jmhForks').orElse('1').get()
+        def iterationTime = providers.gradleProperty('jmhIterationTime').orElse('1s').get()
+        def jfrSettings = providers.gradleProperty('jfrSettings').orElse('profile').get()
+        def safeBenchmark = benchmark.replaceAll('[^A-Za-z0-9._-]', '_')
+        def safePayloadType = payloadType.replaceAll('[^A-Za-z0-9._-]', '_')
+        def defaultJfrFile = layout.buildDirectory.file("jfr/${safeBenchmark}-${safePayloadType}-${itemCount}.jfr")
+            .get()
+            .asFile
+            .absolutePath
+        def configuredJfrFile = providers.gradleProperty('jfrFile').orElse(defaultJfrFile).get()
+        def configuredJfrPath = new File(configuredJfrFile)
+        def jfrFile = configuredJfrPath.isAbsolute()
+            ? configuredJfrPath.absolutePath
+            : new File(rootProject.rootDir, configuredJfrFile).absolutePath
+        def jmhJarFile = tasks.named('jmhJar').get().archiveFile.get().asFile
+        def javaExecutable = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(17)
+        }.get().executablePath.asFile.absolutePath
+        def forkJvmArgs = (benchmarkJvmArgs + [
+            "-XX:StartFlightRecording=filename=${jfrFile},settings=${jfrSettings},dumponexit=true"
+        ]).join(' ')
+
+        file(jfrFile).parentFile.mkdirs()
+
+        commandLine(
+            javaExecutable,
+            '-jar',
+            jmhJarFile.absolutePath,
+            benchmark,
+            '-p', "payloadType=${payloadType}",
+            '-p', "itemCount=${itemCount}",
+            '-wi', warmupIterations,
+            '-i', measurementIterations,
+            '-r', iterationTime,
+            '-w', iterationTime,
+            '-f', forks,
+            '-jvmArgsAppend', forkJvmArgs
+        )
+
+        println "Writing JFR recording to ${jfrFile}"
+    }
 }

--- a/core/support/src/jmh/java/au/com/dius/pact/core/support/json/JsonParserBenchmark.java
+++ b/core/support/src/jmh/java/au/com/dius/pact/core/support/json/JsonParserBenchmark.java
@@ -1,0 +1,262 @@
+package au.com.dius.pact.core.support.json;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class JsonParserBenchmark {
+
+  @State(Scope.Thread)
+  public static class BenchmarkState {
+    @Param({"user-batch", "catalog", "http-pact", "message-pact"})
+    public String payloadType;
+
+    @Param({"10", "50", "100"})
+    public int itemCount;
+
+    public String payload;
+    public byte[] payloadBytes;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      payload = switch (payloadType) {
+        case "user-batch" -> buildUserBatchPayload(itemCount);
+        case "catalog" -> buildCatalogPayload(itemCount);
+        case "http-pact" -> buildHttpPactPayload(itemCount);
+        case "message-pact" -> buildMessagePactPayload(itemCount);
+        default -> throw new IllegalArgumentException("Unknown payload type: " + payloadType);
+      };
+      payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  @Benchmark
+  public JsonValue parseString(BenchmarkState state) {
+    return JsonParser.parseString(state.payload);
+  }
+
+  @Benchmark
+  public JsonValue parseReader(BenchmarkState state) {
+    return JsonParser.parseReader(new StringReader(state.payload));
+  }
+
+  @Benchmark
+  public JsonValue parseStream(BenchmarkState state) {
+    return JsonParser.parseStream(new ByteArrayInputStream(state.payloadBytes));
+  }
+
+  private static String buildUserBatchPayload(int itemCount) {
+    StringBuilder builder = new StringBuilder(256 + (itemCount * 220));
+    builder.append("{\"users\":[");
+
+    for (int index = 0; index < itemCount; index++) {
+      if (index > 0) {
+        builder.append(',');
+      }
+
+      builder
+        .append("{\"id\":\"").append(uuidFor(index, 1)).append("\",")
+        .append("\"username\":\"user-").append(index).append("\",")
+        .append("\"displayName\":\"Benchmark User ").append(index).append("\",")
+        .append("\"active\":").append((index & 1) == 0).append(',')
+        .append("\"score\":").append(1250 + (index * 7)).append(',')
+        .append("\"rating\":").append(decimalFor(index, 11)).append(',')
+        .append("\"email\":\"user-").append(index).append("@example.org\",")
+        .append("\"tags\":[\"").append(tagFor(index)).append("\",\"group-").append(index % 9).append("\"],")
+        .append("\"settings\":{\"theme\":\"").append((index & 1) == 0 ? "dark" : "light")
+        .append("\",\"locale\":\"en-AU\",\"newsletter\":").append(index % 3 == 0).append("},")
+        .append("\"metadata\":null}");
+    }
+
+    builder
+      .append("],\"meta\":{\"page\":1,\"count\":").append(itemCount)
+      .append(",\"traceId\":\"").append(uuidFor(itemCount, 21)).append("\"}}");
+    return builder.toString();
+  }
+
+  private static String buildCatalogPayload(int itemCount) {
+    StringBuilder builder = new StringBuilder(512 + (itemCount * 420));
+    builder.append("{\"catalog\":{\"generatedAt\":\"2026-05-20T00:00:00Z\",\"categories\":[");
+
+    for (int category = 0; category < itemCount; category++) {
+      if (category > 0) {
+        builder.append(',');
+      }
+
+      builder
+        .append("{\"id\":\"cat-").append(category).append("\",")
+        .append("\"name\":\"Category ").append(category).append("\",")
+        .append("\"priority\":").append(category % 5).append(',')
+        .append("\"facets\":{\"featured\":").append(category % 2 == 0)
+        .append(",\"weight\":").append(decimalFor(category, 17)).append("},")
+        .append("\"items\":[");
+
+      for (int item = 0; item < 3; item++) {
+        if (item > 0) {
+          builder.append(',');
+        }
+
+        int sku = (category * 10) + item;
+        builder
+          .append("{\"sku\":\"SKU-").append(sku).append("\",")
+          .append("\"name\":\"Item ").append(category).append('-').append(item).append("\",")
+          .append("\"available\":").append((sku & 1) == 0).append(',')
+          .append("\"price\":").append(decimalFor(sku, 5)).append(',')
+          .append("\"attributes\":{\"colour\":\"").append(colourFor(sku)).append("\",")
+          .append("\"size\":\"").append(sizeFor(sku)).append("\"},")
+          .append("\"history\":[{\"status\":\"created\",\"at\":\"2026-01-01T00:00:00Z\"},")
+          .append("{\"status\":\"updated\",\"at\":\"2026-02-01T00:00:00Z\"}]}");
+      }
+
+      builder.append("]}");
+    }
+
+    builder.append("]}}");
+    return builder.toString();
+  }
+
+  private static String buildHttpPactPayload(int itemCount) {
+    StringBuilder builder = new StringBuilder(2048 + (itemCount * 1800));
+    builder
+      .append("{\"consumer\":{\"name\":\"Json Parser Consumer\"},")
+      .append("\"provider\":{\"name\":\"Json Parser Provider\"},")
+      .append("\"interactions\":[");
+
+    for (int index = 0; index < itemCount; index++) {
+      if (index > 0) {
+        builder.append(',');
+      }
+
+      builder
+        .append("{\"key\":\"interaction-").append(index).append("\",")
+        .append("\"type\":\"Synchronous/HTTP\",")
+        .append("\"description\":\"fetch item ").append(index).append("\",")
+        .append("\"providerStates\":[{\"name\":\"item ").append(index).append(" exists\",")
+        .append("\"params\":{\"id\":").append(index).append(",\"region\":\"ap-southeast-2\"}}],")
+        .append("\"request\":{")
+        .append("\"method\":\"GET\",")
+        .append("\"path\":\"/items/").append(index).append("\",")
+        .append("\"query\":[[\"include\",\"details\"],[\"verbose\",\"true\"]],")
+        .append("\"headers\":{\"Accept\":[\"application/json\"],\"X-Trace-Id\":[\"")
+        .append(uuidFor(index, 31)).append("\"]}},")
+        .append("\"response\":{")
+        .append("\"status\":200,")
+        .append("\"headers\":{\"Content-Type\":[\"application/json;charset=UTF-8\"]},")
+        .append("\"body\":{\"id\":").append(index).append(",")
+        .append("\"name\":\"Item ").append(index).append("\",")
+        .append("\"price\":").append(decimalFor(index, 23)).append(',')
+        .append("\"available\":").append((index & 1) == 0).append(',')
+        .append("\"tags\":[\"").append(tagFor(index)).append("\",\"region-au\"],")
+        .append("\"attributes\":{\"origin\":\"AU\",\"warehouse\":\"WH-").append(index % 7).append("\"}}},")
+        .append("\"matchingRules\":{\"body\":{")
+        .append("\"$.body.id\":{\"matchers\":[{\"match\":\"integer\"}]},")
+        .append("\"$.body.name\":{\"matchers\":[{\"match\":\"type\"}]},")
+        .append("\"$.body.price\":{\"matchers\":[{\"match\":\"decimal\"}]},")
+        .append("\"$.body.tags\":{\"combine\":\"AND\",\"matchers\":[{\"min\":2,\"match\":\"type\"}]}}},")
+        .append("\"generators\":{\"body\":{")
+        .append("\"$.body.id\":{\"type\":\"RandomInt\",\"min\":1,\"max\":999999},")
+        .append("\"$.body.name\":{\"type\":\"RandomString\",\"size\":16}}},")
+        .append("\"comments\":{\"testname\":\"benchmark-generated\"}}");
+    }
+
+    builder
+      .append("],\"metadata\":{\"pactSpecification\":{\"version\":\"4.0\"},")
+      .append("\"pact-jvm\":{\"version\":\"4.7.0\"}}}");
+    return builder.toString();
+  }
+
+  private static String buildMessagePactPayload(int itemCount) {
+    StringBuilder builder = new StringBuilder(1536 + (itemCount * 1200));
+    builder
+      .append("{\"consumer\":{\"name\":\"Json Parser Consumer\"},")
+      .append("\"provider\":{\"name\":\"Json Parser Provider\"},")
+      .append("\"messages\":[");
+
+    for (int index = 0; index < itemCount; index++) {
+      if (index > 0) {
+        builder.append(',');
+      }
+
+      builder
+        .append("{\"description\":\"inventory event ").append(index).append("\",")
+        .append("\"providerStates\":[{\"name\":\"inventory event ").append(index).append(" ready\"}],")
+        .append("\"contents\":{\"eventId\":\"").append(uuidFor(index, 41)).append("\",")
+        .append("\"type\":\"inventory.updated\",")
+        .append("\"sequence\":").append(index).append(',')
+        .append("\"payload\":{\"sku\":\"SKU-").append(index).append("\",")
+        .append("\"quantity\":").append(50 + index).append(',')
+        .append("\"reserved\":").append(index % 4).append(',')
+        .append("\"locations\":[{\"code\":\"MEL\",\"quantity\":").append(10 + index)
+        .append("},{\"code\":\"SYD\",\"quantity\":").append(5 + (index % 10)).append("}]},")
+        .append("\"notes\":[\"restock scheduled\",\"priority-").append(index % 5).append("\"]},")
+        .append("\"metaData\":{\"contentType\":\"application/json\",\"source\":\"benchmark-suite\"},")
+        .append("\"matchingRules\":{\"content\":{")
+        .append("\"$.payload.quantity\":{\"matchers\":[{\"match\":\"integer\"}]},")
+        .append("\"$.payload.locations\":{\"matchers\":[{\"match\":\"type\",\"min\":2}]}}},")
+        .append("\"generators\":{\"content\":{\"$.eventId\":{\"type\":\"Uuid\"}}}}");
+    }
+
+    builder
+      .append("],\"metadata\":{\"pactSpecification\":{\"version\":\"3.0.0\"},")
+      .append("\"pact-jvm\":{\"version\":\"4.7.0\"}}}");
+    return builder.toString();
+  }
+
+  private static String decimalFor(int value, int salt) {
+    return ((value * 17) + salt) + "." + ((value + salt) % 100);
+  }
+
+  private static String uuidFor(int index, int variant) {
+    long suffix = ((long) variant * 10_000L) + index;
+    return String.format("00000000-0000-4000-8000-%012d", suffix);
+  }
+
+  private static String tagFor(int index) {
+    return switch (index % 5) {
+      case 0 -> "beta";
+      case 1 -> "stable";
+      case 2 -> "internal";
+      case 3 -> "priority";
+      default -> "preview";
+    };
+  }
+
+  private static String colourFor(int index) {
+    return switch (index % 6) {
+      case 0 -> "red";
+      case 1 -> "green";
+      case 2 -> "blue";
+      case 3 -> "black";
+      case 4 -> "white";
+      default -> "orange";
+    };
+  }
+
+  private static String sizeFor(int index) {
+    return switch (index % 4) {
+      case 0 -> "S";
+      case 1 -> "M";
+      case 2 -> "L";
+      default -> "XL";
+    };
+  }
+}

--- a/core/support/src/jmh/resources/logback-benchmark.xml
+++ b/core/support/src/jmh/resources/logback-benchmark.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.tika" level="ERROR"/>
+    <logger name="au.com.dius.pact" level="WARN"/>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/BaseJsonLexer.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/BaseJsonLexer.java
@@ -1,9 +1,9 @@
 package au.com.dius.pact.core.support.json;
 
 import au.com.dius.pact.core.support.Result;
-import org.apache.commons.lang3.ArrayUtils;
 
-import java.util.function.Predicate;
+import java.util.Arrays;
+import java.util.function.IntPredicate;
 
 /**
  * Base Lexer for tokenising a JSON document
@@ -16,8 +16,8 @@ public class BaseJsonLexer {
   }
 
   protected void skipWhitespace() {
-    Character next = json.peekNextChar();
-    while (next != null && Character.isWhitespace(next)) {
+    int next = json.peekNextChar();
+    while (next != JsonSource.EOF && Character.isWhitespace(next)) {
       json.advance();
       next = json.peekNextChar();
     }
@@ -26,11 +26,15 @@ public class BaseJsonLexer {
   protected Result<JsonToken.StringValue, JsonException> scanString() {
     char[] buffer = new char[128];
     int index = 0;
-    Character next;
+    int next;
     do {
       next = json.nextChar();
-      if (next != null && next == '\\') {
-        Character escapeCode = json.nextChar();
+      if (next == '\\') {
+        int escapeCode = json.nextChar();
+        if (escapeCode == JsonSource.EOF) {
+          return new Result.Err(new JsonException(String.format(
+            "Invalid JSON (%s), End of document scanning for string terminator", json.documentPointer())));
+        }
         switch (escapeCode) {
           case '"': if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = '"'; break;
           case '\\': if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = '\\'; break;
@@ -41,53 +45,36 @@ public class BaseJsonLexer {
           case 'r': if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = '\r'; break;
           case 't': if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = '\t'; break;
           case 'u': {
-            Character u1 = json.nextChar();
-            if (u1 == null) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
-            } else if (invalidHex(u1)) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), u1)));
+            int hex = 0;
+            for (int i = 0; i < 4; i++) {
+              int codePoint = json.nextChar();
+              if (codePoint == JsonSource.EOF) {
+                return new Result.Err(new JsonException(String.format(
+                  "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
+              }
+
+              int digit = hexValue(codePoint);
+              if (digit == -1) {
+                return new Result.Err(new JsonException(String.format(
+                  "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), (char) codePoint)));
+              }
+
+              hex = (hex << 4) | digit;
             }
-            Character u2 = json.nextChar();
-            if (u2 == null) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
-            } else if (invalidHex(u2)) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), u2)));
-            }
-            Character u3 = json.nextChar();
-            if (u3 == null) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
-            } else if (invalidHex(u3)) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), u3)));
-            }
-            Character u4 = json.nextChar();
-            if (u4 == null) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
-            } else if (invalidHex(u4)) {
-              return new Result.Err(new JsonException(String.format(
-                "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), u4)));
-            }
-            int hex = Integer.parseInt(new String(new char[]{u1, u2, u3, u4}), 16);
             if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) hex;
             break;
           }
           default: return new Result.Err(new JsonException(String.format(
-            "Invalid JSON (%s), '%c' is not a valid escape code", json.documentPointer(), escapeCode)));
+            "Invalid JSON (%s), '%c' is not a valid escape code", json.documentPointer(), (char) escapeCode)));
         }
-      } else if (next == null) {
+      } else if (next == JsonSource.EOF) {
         return new Result.Err(new JsonException(String.format("Invalid JSON (%s), End of document scanning for string terminator",
           json.documentPointer())));
       } else if (next != '"') {
-        if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = next;
+        if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) next;
       }
     } while (next != '"');
-    return new Result.Ok(new JsonToken.StringValue(ArrayUtils.subarray(buffer, 0, index)));
+    return new Result.Ok(new JsonToken.StringValue(Arrays.copyOf(buffer, index)));
   }
 
   private char[] allocate(char[] buffer) {
@@ -100,51 +87,40 @@ public class BaseJsonLexer {
     return newBuffer;
   }
 
-  private boolean invalidHex(Character ch) {
-    if (Character.isDigit(ch)) {
-      return false;
-    } else {
-      switch (ch) {
-        case 'a':
-        case 'b':
-        case 'c':
-        case 'd':
-        case 'e':
-        case 'f':
-        case 'A':
-        case 'B':
-        case 'C':
-        case 'D':
-        case 'E':
-        case 'F':
-          return false;
-        default:
-          return true;
-      }
+  private int hexValue(int ch) {
+    if (ch >= '0' && ch <= '9') {
+      return ch - '0';
     }
+    if (ch >= 'a' && ch <= 'f') {
+      return ch - 'a' + 10;
+    }
+    if (ch >= 'A' && ch <= 'F') {
+      return ch - 'A' + 10;
+    }
+    return -1;
   }
 
-  protected char[] consumeChars(Character first, Predicate<Character> predicate) {
+  protected char[] consumeChars(int first, IntPredicate predicate) {
     char[] buffer = new char[16];
-    buffer[0] = first;
+    buffer[0] = (char) first;
     int index = 1;
-    Character next = json.peekNextChar();
-    while (next != null && predicate.test(next)) {
-      if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = next;
+    int next = json.peekNextChar();
+    while (next != JsonSource.EOF && predicate.test(next)) {
+      if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) next;
       json.advance();
       next = json.peekNextChar();
     }
-    return ArrayUtils.subarray(buffer, 0, index);
+    return Arrays.copyOf(buffer, index);
   }
 
-  protected Result<JsonToken, JsonException> scanNumber(Character next) {
+  protected Result<JsonToken, JsonException> scanNumber(int next) {
     char[] buffer = consumeChars(next, Character::isDigit);
     if (next == '-' && buffer.length == 1) {
       return new Result.Err(new JsonException(String.format(
-        "Invalid JSON (%s), found a '%c' that was not followed by any digits", json.documentPointer(), next)));
+        "Invalid JSON (%s), found a '%c' that was not followed by any digits", json.documentPointer(), (char) next)));
     }
-    Character ch = json.peekNextChar();
-    if (ch != null && (ch == '.' || ch == 'e' || ch == 'E')) {
+    int ch = json.peekNextChar();
+    if (ch != JsonSource.EOF && (ch == '.' || ch == 'e' || ch == 'E')) {
       return scanDecimalNumber(buffer);
     } else {
       return new Result.Ok(new JsonToken.Integer(buffer));
@@ -153,23 +129,23 @@ public class BaseJsonLexer {
 
   protected Result<JsonToken, JsonException> scanDecimalNumber(char[] buffer) {
     int index = buffer.length;
-    Character next = json.peekNextChar();
-    if (next != null && next == '.') {
+    int next = json.peekNextChar();
+    if (next != JsonSource.EOF && next == '.') {
       char[] digits = consumeChars(json.nextChar(), Character::isDigit);
       buffer = allocate(buffer, digits.length);
       System.arraycopy(digits, 0, buffer, index, digits.length);
       index += digits.length;
       if (!Character.isDigit(buffer[index - 1])) {
         return new Result.Err(new JsonException(String.format("Invalid JSON (%s), '%s' is not a valid number",
-          json.documentPointer(), new String(ArrayUtils.subarray(buffer, 0, index)))));
+          json.documentPointer(), new String(Arrays.copyOf(buffer, index)))));
       }
       next = json.peekNextChar();
     }
-    if (next != null && (next == 'e' || next == 'E')) {
-      if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = json.nextChar();
+    if (next != JsonSource.EOF && (next == 'e' || next == 'E')) {
+      if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) json.nextChar();
       next = json.peekNextChar();
-      if (next != null && (next == '+' || next == '-')) {
-        if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = json.nextChar();
+      if (next != JsonSource.EOF && (next == '+' || next == '-')) {
+        if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) json.nextChar();
       }
       char[] digits = consumeChars(json.nextChar(), Character::isDigit);
       buffer = allocate(buffer, digits.length);
@@ -177,9 +153,9 @@ public class BaseJsonLexer {
       index += digits.length;
       if (!Character.isDigit(buffer[index - 1])) {
         return new Result.Err(new JsonException(String.format("Invalid JSON (%s), '%s' is not a valid number",
-          json.documentPointer(), new String(ArrayUtils.subarray(buffer, 0, index)))));
+          json.documentPointer(), new String(Arrays.copyOf(buffer, index)))));
       }
     }
-    return new Result.Ok(new JsonToken.Decimal(ArrayUtils.subarray(buffer, 0, index)));
+    return new Result.Ok(new JsonToken.Decimal(Arrays.copyOf(buffer, index)));
   }
 }

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/BaseJsonLexer.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/BaseJsonLexer.java
@@ -11,6 +11,24 @@ import java.util.function.IntPredicate;
 public class BaseJsonLexer {
   protected JsonSource json;
 
+  private static final class ScannedString {
+    private final char[] buffer;
+    private final int length;
+
+    private ScannedString(char[] buffer, int length) {
+      this.buffer = buffer;
+      this.length = length;
+    }
+
+    private char[] toCharArray() {
+      return length == buffer.length ? buffer : Arrays.copyOf(buffer, length);
+    }
+
+    private String toStringValue() {
+      return new String(buffer, 0, length);
+    }
+  }
+
   public BaseJsonLexer(JsonSource json) {
     this.json = json;
   }
@@ -24,6 +42,22 @@ public class BaseJsonLexer {
   }
 
   protected Result<JsonToken.StringValue, JsonException> scanString() {
+    try {
+      return new Result.Ok(new JsonToken.StringValue(scanStringValue().toCharArray()));
+    } catch (JsonException e) {
+      return new Result.Err(e);
+    }
+  }
+
+  protected Result<String, JsonException> scanKeyString() {
+    try {
+      return new Result.Ok(scanStringValue().toStringValue());
+    } catch (JsonException e) {
+      return new Result.Err(e);
+    }
+  }
+
+  private ScannedString scanStringValue() {
     char[] buffer = new char[128];
     int index = 0;
     int next;
@@ -32,8 +66,8 @@ public class BaseJsonLexer {
       if (next == '\\') {
         int escapeCode = json.nextChar();
         if (escapeCode == JsonSource.EOF) {
-          return new Result.Err(new JsonException(String.format(
-            "Invalid JSON (%s), End of document scanning for string terminator", json.documentPointer())));
+          throw new JsonException(String.format(
+            "Invalid JSON (%s), End of document scanning for string terminator", json.documentPointer()));
         }
         switch (escapeCode) {
           case '"': if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = '"'; break;
@@ -49,14 +83,14 @@ public class BaseJsonLexer {
             for (int i = 0; i < 4; i++) {
               int codePoint = json.nextChar();
               if (codePoint == JsonSource.EOF) {
-                return new Result.Err(new JsonException(String.format(
-                  "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer())));
+                throw new JsonException(String.format(
+                  "Invalid JSON (%s), Unicode characters require 4 hex digits", json.documentPointer()));
               }
 
               int digit = hexValue(codePoint);
               if (digit == -1) {
-                return new Result.Err(new JsonException(String.format(
-                  "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), (char) codePoint)));
+                throw new JsonException(String.format(
+                  "Invalid JSON (%s), '%c' is not a valid hex code character", json.documentPointer(), (char) codePoint));
               }
 
               hex = (hex << 4) | digit;
@@ -64,17 +98,17 @@ public class BaseJsonLexer {
             if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) hex;
             break;
           }
-          default: return new Result.Err(new JsonException(String.format(
-            "Invalid JSON (%s), '%c' is not a valid escape code", json.documentPointer(), (char) escapeCode)));
+          default: throw new JsonException(String.format(
+            "Invalid JSON (%s), '%c' is not a valid escape code", json.documentPointer(), (char) escapeCode));
         }
       } else if (next == JsonSource.EOF) {
-        return new Result.Err(new JsonException(String.format("Invalid JSON (%s), End of document scanning for string terminator",
-          json.documentPointer())));
+        throw new JsonException(String.format("Invalid JSON (%s), End of document scanning for string terminator",
+          json.documentPointer()));
       } else if (next != '"') {
         if (index >= buffer.length) { buffer = allocate(buffer); }; buffer[index++] = (char) next;
       }
     } while (next != '"');
-    return new Result.Ok(new JsonToken.StringValue(Arrays.copyOf(buffer, index)));
+    return new ScannedString(buffer, index);
   }
 
   private char[] allocate(char[] buffer) {

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/JsonSource.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/JsonSource.java
@@ -4,8 +4,10 @@ package au.com.dius.pact.core.support.json;
  * Abstract class that represents the source of a JSON document
  */
 public abstract class JsonSource {
-  public abstract Character nextChar();
-  public abstract Character peekNextChar();
+  public static final int EOF = -1;
+
+  public abstract int nextChar();
+  public abstract int peekNextChar();
   public abstract void advance(int count);
 
   protected long line = 0;
@@ -13,6 +15,15 @@ public abstract class JsonSource {
 
   public void advance() {
     advance(1);
+  }
+
+  protected void updatePosition(int next) {
+    if (next == '\n') {
+      character = 0;
+      line++;
+    } else {
+      character++;
+    }
   }
 
   public String documentPointer() {

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/ReaderSource.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/ReaderSource.java
@@ -7,50 +7,61 @@ import java.io.Reader;
  * JSON source from a Reader
  */
 public class ReaderSource extends JsonSource {
-  private Reader reader;
-  private int buffer = EOF;
-  private boolean hasBuffer = false;
+  private static final int BUFFER_SIZE = 8192;
+
+  private final Reader reader;
+  private final char[] buffer = new char[BUFFER_SIZE];
+  private int bufferIndex = 0;
+  private int bufferLimit = 0;
+  private boolean endOfInput = false;
 
   public ReaderSource(Reader reader) {
     this.reader = reader;
   }
 
   public int nextChar() {
-    int next;
-    if (hasBuffer) {
-      next = buffer;
-      hasBuffer = false;
-      buffer = EOF;
-    } else {
-      next = readNextChar();
+    if (!ensureAvailable()) {
+      return EOF;
     }
 
-    if (next != EOF) {
-      updatePosition(next);
-    }
-
+    int next = buffer[bufferIndex++];
+    updatePosition(next);
     return next;
   }
 
   public int peekNextChar() {
-    if (!hasBuffer) {
-      buffer = readNextChar();
-      hasBuffer = true;
+    if (!ensureAvailable()) {
+      return EOF;
     }
-    return buffer;
+    return buffer[bufferIndex];
   }
 
   public void advance(int count) {
     for (int i = 0; i < count; i++) {
-      if (nextChar() == EOF) {
+      if (!ensureAvailable()) {
         return;
       }
+      updatePosition(buffer[bufferIndex++]);
     }
   }
 
-  private int readNextChar() {
+  private boolean ensureAvailable() {
+    if (bufferIndex < bufferLimit) {
+      return true;
+    }
+    if (endOfInput) {
+      return false;
+    }
+
     try {
-      return reader.read();
+      bufferLimit = reader.read(buffer, 0, buffer.length);
+      bufferIndex = 0;
+      if (bufferLimit == -1) {
+        endOfInput = true;
+        bufferLimit = 0;
+        return false;
+      }
+      return true;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/ReaderSource.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/ReaderSource.java
@@ -8,71 +8,49 @@ import java.io.Reader;
  */
 public class ReaderSource extends JsonSource {
   private Reader reader;
-  private Character buffer = null;
+  private int buffer = EOF;
+  private boolean hasBuffer = false;
 
   public ReaderSource(Reader reader) {
     this.reader = reader;
   }
 
-  public Character nextChar() {
-    if (buffer != null) {
-      Character c = buffer;
-      buffer = null;
-      return c;
+  public int nextChar() {
+    int next;
+    if (hasBuffer) {
+      next = buffer;
+      hasBuffer = false;
+      buffer = EOF;
     } else {
-      int next = 0;
-      try {
-        next = reader.read();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      if (next == -1) {
-        return null;
-      } else {
-        if (next == '\n') {
-          character = 0;
-          line++;
-        } else {
-          character++;
-        }
-        return (char) next;
-      }
+      next = readNextChar();
     }
+
+    if (next != EOF) {
+      updatePosition(next);
+    }
+
+    return next;
   }
 
-  public Character peekNextChar() {
-    if (buffer == null) {
-      int next = 0;
-      try {
-        next = reader.read();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      if (next == -1) {
-        buffer = null;
-      } else {
-        buffer = (char) next;
-      }
+  public int peekNextChar() {
+    if (!hasBuffer) {
+      buffer = readNextChar();
+      hasBuffer = true;
     }
     return buffer;
   }
 
   public void advance(int count) {
-    int charsToSkip = count;
-    if (buffer != null) {
-      buffer = null;
-      charsToSkip = count - 1;
-    }
-    try {
-      for (int i = 0; i < charsToSkip; i++) {
-        int next = reader.read();
-        if (next == '\n') {
-          character = 0;
-          line++;
-        } else {
-          character++;
-        }
+    for (int i = 0; i < count; i++) {
+      if (nextChar() == EOF) {
+        return;
       }
+    }
+  }
+
+  private int readNextChar() {
+    try {
+      return reader.read();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/support/src/main/java/au/com/dius/pact/core/support/json/StringSource.java
+++ b/core/support/src/main/java/au/com/dius/pact/core/support/json/StringSource.java
@@ -11,23 +11,18 @@ public class StringSource extends JsonSource {
     this.json = json;
   }
 
-  public Character nextChar() {
-    Character c = peekNextChar();
-    if (c != null) {
-      if (c == '\n') {
-        character = 0;
-        line++;
-      } else {
-        character++;
-      }
+  public int nextChar() {
+    int c = peekNextChar();
+    if (c != EOF) {
+      updatePosition(c);
       index++;
     }
     return c;
   }
 
-  public Character peekNextChar() {
+  public int peekNextChar() {
     if (index >= json.length) {
-      return null;
+      return EOF;
     } else {
       return json[index];
     }
@@ -35,13 +30,7 @@ public class StringSource extends JsonSource {
 
   public void advance(int count) {
     for (int i = 0; i < count; i++) {
-      char next = json[index++];
-      if (next == '\n') {
-        character = 0;
-        line++;
-      } else {
-        character++;
-      }
+      updatePosition(json[index++]);
     }
   }
 }

--- a/core/support/src/main/kotlin/au/com/dius/pact/core/support/json/JsonParser.kt
+++ b/core/support/src/main/kotlin/au/com/dius/pact/core/support/json/JsonParser.kt
@@ -58,63 +58,63 @@ sealed class JsonToken(val chars: CharArray) {
 class JsonLexer(json: JsonSource) : BaseJsonLexer(json) {
   fun nextToken(): Result<JsonToken?, JsonException> {
     val next = json.nextChar()
-    if (next != null) {
+    if (next != JsonSource.EOF) {
       return when {
-        next.isWhitespace() -> {
+        next.toChar().isWhitespace() -> {
           skipWhitespace()
           Result.Ok(JsonToken.Whitespace)
         }
-        next == '-' || next.isDigit() -> scanNumber(next)
-        next == 't' -> scanTrue()
-        next == 'f' -> scanFalse()
-        next == 'n' -> scanNull()
-        next == '"' -> scanString()
-        next == '[' -> Result.Ok(JsonToken.ArrayStart)
-        next == ']' -> Result.Ok(JsonToken.ArrayEnd)
-        next == '{' -> Result.Ok(JsonToken.ObjectStart)
-        next == '}' -> Result.Ok(JsonToken.ObjectEnd)
-        next == ',' -> Result.Ok(JsonToken.Comma)
-        next == ':' -> Result.Ok(JsonToken.Colon)
+        next == '-'.code || next.toChar().isDigit() -> scanNumber(next)
+        next == 't'.code -> scanTrue()
+        next == 'f'.code -> scanFalse()
+        next == 'n'.code -> scanNull()
+        next == '"'.code -> scanString()
+        next == '['.code -> Result.Ok(JsonToken.ArrayStart)
+        next == ']'.code -> Result.Ok(JsonToken.ArrayEnd)
+        next == '{'.code -> Result.Ok(JsonToken.ObjectStart)
+        next == '}'.code -> Result.Ok(JsonToken.ObjectEnd)
+        next == ','.code -> Result.Ok(JsonToken.Comma)
+        next == ':'.code -> Result.Ok(JsonToken.Colon)
         else -> unexpectedCharacter(next)
       }
     }
     return Result.Ok(null)
   }
 
-  private fun unexpectedCharacter(next: Char?) = if (next == null)
+  private fun unexpectedCharacter(next: Int) = if (next == JsonSource.EOF)
     Result.Err(JsonException("Invalid JSON (${documentPointer()}), unexpected end of the JSON document"))
   else
-    Result.Err(JsonException("Invalid JSON (${documentPointer()}), found unexpected character '$next'"))
+    Result.Err(JsonException("Invalid JSON (${documentPointer()}), found unexpected character '${next.toChar()}'"))
 
   private fun scanNull(): Result<JsonToken?, JsonException> {
     var next = json.nextChar()
-    if (next == null || next != 'u') return unexpectedCharacter(next)
+    if (next != 'u'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'l') return unexpectedCharacter(next)
+    if (next != 'l'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'l') return unexpectedCharacter(next)
+    if (next != 'l'.code) return unexpectedCharacter(next)
     return Result.Ok(JsonToken.Null)
   }
 
   private fun scanFalse(): Result<JsonToken?, JsonException> {
     var next = json.nextChar()
-    if (next == null || next != 'a') return unexpectedCharacter(next)
+    if (next != 'a'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'l') return unexpectedCharacter(next)
+    if (next != 'l'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 's') return unexpectedCharacter(next)
+    if (next != 's'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'e') return unexpectedCharacter(next)
+    if (next != 'e'.code) return unexpectedCharacter(next)
     return Result.Ok(JsonToken.False)
   }
 
   private fun scanTrue(): Result<JsonToken?, JsonException> {
     var next = json.nextChar()
-    if (next == null || next != 'r') return unexpectedCharacter(next)
+    if (next != 'r'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'u') return unexpectedCharacter(next)
+    if (next != 'u'.code) return unexpectedCharacter(next)
     next = json.nextChar()
-    if (next == null || next != 'e') return unexpectedCharacter(next)
+    if (next != 'e'.code) return unexpectedCharacter(next)
     return Result.Ok(JsonToken.True)
   }
 

--- a/core/support/src/main/kotlin/au/com/dius/pact/core/support/json/JsonParser.kt
+++ b/core/support/src/main/kotlin/au/com/dius/pact/core/support/json/JsonParser.kt
@@ -56,6 +56,11 @@ sealed class JsonToken(val chars: CharArray) {
 
 @Suppress("ReturnCount")
 class JsonLexer(json: JsonSource) : BaseJsonLexer(json) {
+  sealed interface ObjectKeyToken {
+    data class Key(val value: String) : ObjectKeyToken
+    data object ObjectEnd : ObjectKeyToken
+  }
+
   fun nextToken(): Result<JsonToken?, JsonException> {
     val next = json.nextChar()
     if (next != JsonSource.EOF) {
@@ -79,6 +84,28 @@ class JsonLexer(json: JsonSource) : BaseJsonLexer(json) {
       }
     }
     return Result.Ok(null)
+  }
+
+  fun nextObjectKey(): Result<ObjectKeyToken?, JsonException> {
+    var next = json.nextChar()
+    while (next != JsonSource.EOF && next.toChar().isWhitespace()) {
+      next = json.nextChar()
+    }
+
+    return when (next) {
+      JsonSource.EOF -> Result.Ok(null)
+      '}'.code -> Result.Ok(ObjectKeyToken.ObjectEnd)
+      '"'.code -> when (val result = scanKeyString()) {
+        is Result.Ok -> Result.Ok(ObjectKeyToken.Key(result.value))
+        is Result.Err -> Result.Err(result.error)
+      }
+      else -> Result.Err(
+        JsonException(
+          "Invalid Json document (${documentPointer()}) - expected a string but found unexpected characters " +
+            "'${next.toChar()}'"
+        )
+      )
+    }
   }
 
   private fun unexpectedCharacter(next: Int) = if (next == JsonSource.EOF)
@@ -180,15 +207,17 @@ object JsonParser {
     var token: JsonToken?
 
     do {
-      token = nextTokenOrThrow(lexer)
-      if (token !is JsonToken.ObjectEnd) {
-        val key = when (token) {
+      val keyToken = when (val result = lexer.nextObjectKey()) {
+        is Result.Ok -> result.value
+        is Result.Err -> throw result.error
+      }
+      if (keyToken != JsonLexer.ObjectKeyToken.ObjectEnd) {
+        val key = when (keyToken) {
           null -> throw JsonException(
             "Invalid Json document (${lexer.documentPointer()}) - found end of document while parsing object")
-          is JsonToken.StringValue -> String(token.chars)
-          else -> throw JsonException(
-            "Invalid Json document (${lexer.documentPointer()}) - expected a string but found unexpected characters " +
-              "'${token.chars}'")
+          is JsonLexer.ObjectKeyToken.Key -> keyToken.value
+          JsonLexer.ObjectKeyToken.ObjectEnd -> throw JsonException(
+            "Invalid Json document (${lexer.documentPointer()}) - found unexpected end of object while parsing key")
         }
 
         token = nextTokenOrThrow(lexer)
@@ -223,6 +252,8 @@ object JsonParser {
             "Invalid Json document (${lexer.documentPointer()}) - Expecting ',' or '}' while parsing object, " +
               "found '${String(token.chars)}'")
         }
+      } else {
+        token = JsonToken.ObjectEnd
       }
     } while (token != null && token != JsonToken.ObjectEnd)
 

--- a/core/support/src/test/groovy/au/com/dius/pact/core/support/json/JsonParserSpec.groovy
+++ b/core/support/src/test/groovy/au/com/dius/pact/core/support/json/JsonParserSpec.groovy
@@ -63,6 +63,7 @@ class JsonParserSpec extends Specification {
     'empty array'                     | '[]'                     | new JsonValue.Array([])
     'empty string'                    | '""'                     | new JsonValue.StringValue(''.chars)
     'keys with special chars'         | '{"ä": "äbc"}'           | new JsonValue.Object(['ä': new JsonValue.StringValue('äbc'.chars)])
+    'keys with escapes'               | '{"a\\tb": "äbc"}'       | new JsonValue.Object(['a\tb': new JsonValue.StringValue('äbc'.chars)])
   }
 
   @SuppressWarnings('TrailingWhitespace')


### PR DESCRIPTION
## Summary
- add JMH benchmarks for the core/support JSON parser with multiple payload types and entrypoints
- optimize JSON object key parsing to avoid creating intermediate string tokens for object keys
- buffer ReaderSource reads so parseStream no longer pays per-character reader.read() overhead
- include the existing DocPath lazy expression optimization already on this branch

## Benchmark notes
- parseString improved across the benchmark suite after the object-key parsing change
- parseStream saw the biggest gain after buffering ReaderSource
- in the latest runs, http-pact with itemCount=100 improved from 2.310 ms/op in the first parseStream benchmark to 0.452 ms/op

## Validation
- ./gradlew --no-daemon :core:support:test :core:support:jmhJar
- focused JMH runs for JsonParserBenchmark.parseString and JsonParserBenchmark.parseStream