### PR TITLE
chore: add pact-jvm user agent

### DIFF
--- a/core/support/src/main/kotlin/au/com/dius/pact/core/support/HttpClient.kt
+++ b/core/support/src/main/kotlin/au/com/dius/pact/core/support/HttpClient.kt
@@ -158,6 +158,11 @@ object HttpClient {
       else -> SystemDefaultCredentialsProvider()
     }
 
+    val pactVersion = Utils.lookupVersion(HttpClient::class.java).ifEmpty { "unknown" }
+    val httpClientVersion = CloseableHttpClient::class.java.`package`?.implementationVersion ?: "unknown"
+    val javaVersion = System.getProperty("java.version") ?: "unknown"
+    defaultHeaders["User-Agent"] = "pact-jvm/$pactVersion Apache-HttpClient/$httpClientVersion Java/$javaVersion"
+
     defaultHeaders.putAll(customHeaders)
     builder.setDefaultHeaders(defaultHeaders.map { BasicHeader(it.key, it.value) })
 


### PR DESCRIPTION
To help identify traffic from Pact JVM specifically, customise the user agent header so that it includes the Pact JVM version.