### PR TITLE
feat(008): Set test run ID before plugin calls for log correlation

### DIFF
--- a/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/au.com.dius.pact.kotlin-common-conventions.gradle
@@ -35,7 +35,7 @@ dependencies {
         api 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
         api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.4.4'
         api 'org.json:json:20250517'
-        api 'io.pact.plugin.driver:core:1.0.0-beta.1' // remember also to update implementation
+        api 'io.pact.plugin.driver:core:1.0.0-beta.4' // remember also to update implementation
         api 'org.apache.tika:tika-core:3.2.3'
         api 'io.github.oshai:kotlin-logging-jvm:7.0.7'
 
@@ -56,7 +56,7 @@ dependencies {
         implementation 'org.apache.groovy:groovy:4.0.29'
         implementation 'org.apache.groovy:groovy-json:4.0.29'
         implementation 'org.apache.groovy:groovy-xml:4.0.29'
-        implementation 'io.pact.plugin.driver:core:1.0.0-beta.1'  //remember to also update under api
+        implementation 'io.pact.plugin.driver:core:1.0.0-beta.4'  //remember to also update under api
         implementation 'io.github.oshai:kotlin-logging-jvm:7.0.7'
 
         testImplementation 'org.apache.groovy:groovy:4.0.29'

--- a/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactBuilder.kt
+++ b/consumer/src/main/kotlin/au/com/dius/pact/consumer/dsl/PactBuilder.kt
@@ -39,6 +39,8 @@ import io.pact.plugins.jvm.core.DefaultPluginManager
 import io.pact.plugins.jvm.core.PactPlugin
 import io.pact.plugins.jvm.core.PactPluginEntryNotFoundException
 import io.pact.plugins.jvm.core.PactPluginNotFoundException
+import io.pact.plugins.jvm.core.TestContext
+import java.util.UUID
 
 interface DslBuilder {
   fun addPluginConfiguration(matcher: ContentMatcher, pactConfiguration: Map<String, JsonValue>)
@@ -372,6 +374,7 @@ open class PactBuilder(
     part: IHttpPart,
     interaction: V4Interaction
   ) {
+    TestContext.setTestRunId(UUID.randomUUID().toString())
     when (val result = matcher.configureContent(contentType, bodyConfig)) {
       is Ok -> {
         if (result.value.size > 1) {
@@ -598,6 +601,7 @@ open class PactBuilder(
             }
           } else {
             logger.debug { "Plugin matcher, will get the plugin to provide the interaction contents" }
+            TestContext.setTestRunId(UUID.randomUUID().toString())
             when (val result = matcher.configureContent(contentType, bodyConfig)) {
               is Ok -> {
                 result.value.map {

--- a/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/PluginContentMatcher.kt
+++ b/core/matchers/src/main/kotlin/au/com/dius/pact/core/matchers/PluginContentMatcher.kt
@@ -4,7 +4,9 @@ import au.com.dius.pact.core.model.ContentType
 import au.com.dius.pact.core.model.OptionalBody
 import au.com.dius.pact.core.support.Result
 import io.pact.plugins.jvm.core.InteractionContents
+import io.pact.plugins.jvm.core.TestContext
 import io.github.oshai.kotlinlogging.KLogging
+import java.util.UUID
 
 /**
  * Content matcher that delegates to a plugin
@@ -15,6 +17,9 @@ class PluginContentMatcher(
 ) : ContentMatcher {
   override fun matchBody(expected: OptionalBody, actual: OptionalBody, context: MatchingContext): BodyMatchResult {
     logger.debug { "matchBody: context=$context" }
+    if (TestContext.currentTestRunId() == null) {
+      TestContext.setTestRunId(UUID.randomUUID().toString())
+    }
     val result = contentMatcher.invokeContentMatcher(expected, actual, context.allowUnexpectedKeys,
       context.matchers.matchingRules, context.pluginConfiguration)
     val bodyResults = result.entries.map { mismatch ->
@@ -28,6 +33,7 @@ class PluginContentMatcher(
   override fun setupBodyFromConfig(
     bodyConfig: Map<String, Any?>
   ): Result<List<InteractionContents>, String> {
+    TestContext.setTestRunId(UUID.randomUUID().toString())
     return contentMatcher.configureContent(contentType.toString(), bodyConfig)
   }
 

--- a/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PluginTestTarget.kt
+++ b/provider/junit5/src/main/kotlin/au/com/dius/pact/provider/junit5/PluginTestTarget.kt
@@ -16,8 +16,10 @@ import io.pact.plugins.jvm.core.CatalogueManager
 import io.pact.plugins.jvm.core.DefaultPluginManager
 import io.pact.plugins.jvm.core.PactPluginNotFoundException
 import io.pact.plugins.jvm.core.PluginManager
+import io.pact.plugins.jvm.core.TestContext
 import java.io.File
 import java.net.URL
+import java.util.UUID
 
 /**
  * Provider data when verifying via a plugin
@@ -96,6 +98,7 @@ class PluginTestTarget(private val config: MutableMap<String, Any?> = mutableMap
         if (context.containsKey("providerState")) {
           testContext["providerState"] = context["providerState"]
         }
+        TestContext.setTestRunId(UUID.randomUUID().toString())
         when (val result = pluginManager.prepareValidationForInteraction(transportEntry, v4pact.value,
           interaction.asV4Interaction(), testContext)) {
           is Ok -> RequestDataToBeVerified(result.value) to transportEntry

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/ProviderVerifier.kt
@@ -52,7 +52,9 @@ import io.pact.plugins.jvm.core.DefaultPluginManager
 import io.pact.plugins.jvm.core.InteractionVerificationDetails
 import io.pact.plugins.jvm.core.PluginConfiguration
 import io.pact.plugins.jvm.core.PluginManager
+import io.pact.plugins.jvm.core.TestContext
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.UUID
 import java.io.File
 import java.lang.reflect.Method
 import java.net.URL
@@ -1026,6 +1028,7 @@ open class ProviderVerifier @JvmOverloads constructor (
               config[k] = v
             }
 
+            TestContext.setTestRunId(UUID.randomUUID().toString())
             val request = when (val result = DefaultPluginManager.prepareValidationForInteraction(transportEntry,
               v4pact, v4Interaction, config)) {
               is Ok -> result.value


### PR DESCRIPTION
## Summary

Part of proposal [008 — Plugin observability and logging](https://github.com/pact-foundation/pact-plugins/blob/main/docs/proposals/008-plugin-observability-and-logging.md).

Sets a UUID in the pact-plugins-jvm `TestContext` before each plugin driver call so the driver injects it as `testContext.testRunId` in outgoing gRPC requests, allowing plugin log entries to be correlated with a specific test interaction.

- **Consumer (`PactBuilder`)**: fresh UUID per `configureContent` call — each HTTP or message interaction setup gets its own ID
- **Core matchers (`PluginContentMatcher`)**: fresh UUID in `setupBodyFromConfig` (consumer setup path via internal matchers); fallback UUID in `matchBody` only if none already set (mirrors `pact_matching` Rust behaviour)
- **Provider (`ProviderVerifier`)**: fresh UUID once per interaction in the `PLUGIN` verification branch, set before `prepareValidationForInteraction` so both the prepare and subsequent verify calls share the same ID
- **Provider JUnit5 (`PluginTestTarget`)**: same pattern for the transport-plugin path
- Bumps `io.pact.plugin.driver:core` version constraint from `1.0.0-beta.1` to `1.0.0-beta.4` (which includes `TestContext`)

## Test plan

- [ ] Build compiles cleanly against `io.pact.plugin.driver:core:1.0.0-beta.4`
- [ ] Existing plugin-based consumer tests still pass
- [ ] Existing plugin-based provider verification tests still pass
- [ ] Plugin log entries emitted during a test include a `testRunId` field matching the UUID set for that interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)